### PR TITLE
fix(api): SPA refresh routing for /chat, /skills, /squads, /activity

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -188,15 +188,24 @@ export async function startApiServer(): Promise<void> {
     console.log("[io] Web frontend enabled");
   }
 
-  // Backward-compat: mount API at / (after static files so HTML/CSS/JS are served first)
-  app.use("/", api);
-
-  // SPA fallback — serve index.html for any unmatched route
+  // SPA fallback for browser navigation: when the web frontend is built,
+  // serve index.html for any GET request that accepts HTML and isn't an API
+  // call. This lets vue-router handle client-side routes like /chat, /skills,
+  // /squads, etc. on direct URL access and page refresh. Programmatic clients
+  // (curl, fetch without Accept: text/html) fall through to the backward-compat
+  // API mount below.
   if (existsSync(WEB_DIST)) {
-    app.get("/{*splat}", (_req: Request, res: Response) => {
+    app.get(/.*/, (req: Request, res: Response, next) => {
+      if (req.path.startsWith("/api/")) return next();
+      const accept = req.headers.accept ?? "";
+      if (!accept.includes("text/html")) return next();
       res.sendFile(path.join(WEB_DIST, "index.html"));
     });
   }
+
+  // Backward-compat: mount API at / for non-browser clients (after static files
+  // and SPA fallback so frontend routes are not intercepted).
+  app.use("/", api);
 
   return new Promise<void>((resolve) => {
     app.listen(config.port, () => {


### PR DESCRIPTION
Fixes #24

## Problem

Refreshing the web app on routes like `/chat`, `/skills`, `/squads`, or `/activity` was broken. The user would either get a JSON API response or a 401 instead of the SPA loading and vue-router rendering the correct view.

## Root cause

`src/api/server.ts` mounted the API router at both `/api` (for the frontend) and `/` (legacy backward-compat) — and the legacy mount sat **before** the SPA fallback. Several frontend routes share names with API endpoints (`/skills`, `/squads`), so a browser refresh on `/skills` was intercepted by the legacy API mount and never reached the `index.html` fallback.

## Fix

Reorder middleware so that, when the web frontend is built, browser GET requests (those that send `Accept: text/html`) fall back to `index.html` **before** the backward-compat API mount. This lets vue-router handle client-side routes on direct URL access and refresh.

- `/api/*` is matched first (unchanged)
- Static assets are served from `web-dist` (unchanged)
- New: HTML-accepting GET requests for any unmatched path serve `index.html`
- Programmatic clients (curl, fetch with no `Accept: text/html`) still hit the legacy API at `/` unchanged
- The `/api/*` prefix is explicitly excluded from the fallback so a missing API route still 404s as JSON

## Verification

- `npm run build` ✅ no TypeScript errors
- Refreshing `/chat`, `/skills`, `/squads`, `/activity` now serves the SPA and vue-router renders the correct view
- `curl /health`, `curl /squads` etc. still return JSON via the legacy mount