### PR TITLE
feat(web): stop/cancel buttons for orchestrator and agent tasks

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -5,7 +5,9 @@ import express, { type Request, type Response } from "express";
 import { config } from "../config.js";
 import { listSkills } from "../copilot/skills.js";
 import { listSquads, createSquad, listSquadAgents } from "../store/squads.js";
-import { getAgentInfo } from "../copilot/agents.js";
+import { getAgentInfo, cancelAgentTask } from "../copilot/agents.js";
+import { abortOrchestrator } from "../copilot/orchestrator.js";
+import { getActiveTasks } from "../store/tasks.js";
 import { IO_VERSION } from "../paths.js";
 import { requireAuth } from "./auth.js";
 
@@ -116,7 +118,21 @@ export async function startApiServer(): Promise<void> {
     try {
       const slug = Array.isArray(req.params.slug) ? req.params.slug[0] : req.params.slug;
       const agents = listSquadAgents(slug);
-      res.json({ agents });
+      const activeTasks = getActiveTasks();
+      const taskByKey = new Map<string, { task_id: string; description: string }>();
+      for (const t of activeTasks) {
+        taskByKey.set(t.agent_slug, { task_id: t.task_id, description: t.description });
+      }
+      const enriched = agents.map((a) => {
+        const key = `${slug}:${a.character_name}`;
+        const task = taskByKey.get(key) ?? taskByKey.get(slug);
+        return {
+          ...a,
+          currentTaskId: task?.task_id ?? null,
+          currentTask: task?.description ?? null,
+        };
+      });
+      res.json({ agents: enriched });
     } catch (e) {
       console.error("Error listing squad agents:", e);
       res.status(500).json({ error: "Failed to list squad agents" });
@@ -131,6 +147,32 @@ export async function startApiServer(): Promise<void> {
     } catch (e) {
       console.error("Error listing agents:", e);
       res.status(500).json({ error: "Failed to list agents" });
+    }
+  });
+
+  // Stop / cancel endpoints
+  api.post("/orchestrator/abort", async (_req: Request, res: Response) => {
+    try {
+      const aborted = await abortOrchestrator();
+      res.json({ aborted });
+    } catch (e) {
+      console.error("Error aborting orchestrator:", e);
+      res.status(500).json({ error: "Failed to abort orchestrator" });
+    }
+  });
+
+  api.post("/tasks/:taskId/cancel", async (req: Request, res: Response) => {
+    try {
+      const taskId = Array.isArray(req.params.taskId) ? req.params.taskId[0] : req.params.taskId;
+      const cancelled = await cancelAgentTask(taskId);
+      if (!cancelled) {
+        res.status(404).json({ error: "Task not found or not running" });
+        return;
+      }
+      res.json({ cancelled: true });
+    } catch (e) {
+      console.error("Error cancelling task:", e);
+      res.status(500).json({ error: "Failed to cancel task" });
     }
   });
 

--- a/src/copilot/agents.ts
+++ b/src/copilot/agents.ts
@@ -35,6 +35,7 @@ import {
   failTask,
   getActiveTasks,
   getTask,
+  cancelTask,
 } from "../store/tasks.js";
 import { SESSIONS_DIR } from "../paths.js";
 import { getUniverse } from "./universes.js";
@@ -47,6 +48,7 @@ export interface AgentInfo {
   universe?: string;
   status: "idle" | "working" | "error";
   currentTask?: string;
+  currentTaskId?: string;
 }
 
 // Key format: "squadSlug:characterName" for per-agent sessions, "squadSlug" for legacy
@@ -60,8 +62,10 @@ function agentSessionKey(squadSlug: string, characterName?: string): string {
 export function getAgentInfo(): AgentInfo[] {
   const activeTasks = getActiveTasks();
   const tasksByAgent = new Map<string, string>();
+  const taskIdsByAgent = new Map<string, string>();
   for (const task of activeTasks) {
     tasksByAgent.set(task.agent_slug, task.description);
+    taskIdsByAgent.set(task.agent_slug, task.task_id);
   }
 
   const agents: AgentInfo[] = [];
@@ -79,6 +83,7 @@ export function getAgentInfo(): AgentInfo[] {
     if (characterName) {
       const agent = getSquadAgent(squadSlug, characterName);
       const currentTask = tasksByAgent.get(key) ?? tasksByAgent.get(squadSlug);
+      const currentTaskId = taskIdsByAgent.get(key) ?? taskIdsByAgent.get(squadSlug);
       agents.push({
         slug: squadSlug,
         name: agent ? `${agent.character_name} (${agent.role_title})` : characterName,
@@ -87,15 +92,18 @@ export function getAgentInfo(): AgentInfo[] {
         universe: squad?.universe ?? undefined,
         status: agent?.status === "working" ? "working" : currentTask ? "working" : "idle",
         currentTask,
+        currentTaskId,
       });
     } else {
       // Legacy generic agent
       const currentTask = tasksByAgent.get(squadSlug);
+      const currentTaskId = taskIdsByAgent.get(squadSlug);
       agents.push({
         slug: squadSlug,
         name: squad?.name ?? squadSlug,
         status: currentTask ? "working" : squad?.status === "error" ? "error" : "idle",
         currentTask,
+        currentTaskId,
       });
     }
   }
@@ -505,4 +513,37 @@ function walkDirectory(dir: string, maxDepth = 3, depth = 0): string[] {
     }
   }
   return results;
+}
+
+
+/**
+ * Cancel a running agent task by aborting its session and marking the task
+ * cancelled. Returns true if the task existed and was running.
+ */
+export async function cancelAgentTask(taskId: string): Promise<boolean> {
+  const task = getTask(taskId);
+  if (!task || task.status !== "running") return false;
+
+  const sessionKey = task.agent_slug;
+  const session = agentSessions.get(sessionKey);
+  if (session) {
+    try {
+      await session.abort();
+    } catch (err) {
+      console.error("[io] Error aborting agent session:", err instanceof Error ? err.message : err);
+    }
+  }
+
+  cancelTask(taskId);
+
+  // sessionKey is "squadSlug" or "squadSlug:characterName"
+  const [squadSlug, characterName] = sessionKey.split(":");
+  if (squadSlug) {
+    try { updateSquadStatus(squadSlug, "idle"); } catch { /* ignore */ }
+  }
+  if (squadSlug && characterName) {
+    try { updateAgentStatus(squadSlug, characterName, "idle"); } catch { /* ignore */ }
+  }
+
+  return true;
 }

--- a/src/copilot/orchestrator.ts
+++ b/src/copilot/orchestrator.ts
@@ -490,3 +490,19 @@ export async function shutdownOrchestrator(): Promise<void> {
   clientResetPromise = undefined;
   client = undefined;
 }
+
+/**
+ * Abort the orchestrator's current in-flight request. The session remains valid
+ * for subsequent prompts. Returns true if a session existed and abort was
+ * attempted, false otherwise.
+ */
+export async function abortOrchestrator(): Promise<boolean> {
+  if (!orchestratorSession) return false;
+  try {
+    await orchestratorSession.abort();
+    return true;
+  } catch (err) {
+    console.error("[io] Error aborting orchestrator session:", err instanceof Error ? err.message : err);
+    return false;
+  }
+}

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -59,3 +59,11 @@ export function clearStaleTasks(): void {
     )
     .run();
 }
+
+export function cancelTask(taskId: string, reason = "Cancelled by user"): void {
+  getDb()
+    .prepare(
+      "UPDATE agent_tasks SET status = 'cancelled', result = ?, completed_at = CURRENT_TIMESTAMP WHERE task_id = ? AND status = 'running'",
+    )
+    .run(reason, taskId);
+}

--- a/web/src/views/AgentActivityView.vue
+++ b/web/src/views/AgentActivityView.vue
@@ -61,8 +61,21 @@
             <p class="text-sm text-gray-100 break-words">{{ agent.currentTask }}</p>
           </div>
 
-          <div class="text-xs text-gray-500">
-            Last updated: {{ formatTime(new Date()) }}
+          <div class="flex justify-between items-center">
+            <div class="text-xs text-gray-500">
+              Last updated: {{ formatTime(new Date()) }}
+            </div>
+            <button
+              v-if="agent.status === 'working' && agent.currentTaskId"
+              type="button"
+              @click="stopTask(agent.currentTaskId)"
+              :disabled="stoppingTaskIds.has(agent.currentTaskId)"
+              class="bg-red-600 hover:bg-red-700 disabled:opacity-50 text-white text-xs px-3 py-1 rounded transition-colors flex items-center gap-1"
+              title="Stop this agent's current task"
+            >
+              <span class="inline-block w-2 h-2 bg-white rounded-sm"></span>
+              {{ stoppingTaskIds.has(agent.currentTaskId) ? 'Stopping...' : 'Stop' }}
+            </button>
           </div>
         </div>
       </div>
@@ -82,12 +95,30 @@ interface Agent {
   universe?: string
   status: 'idle' | 'working' | 'error'
   currentTask?: string
+  currentTaskId?: string
 }
 
 const agents = ref<Agent[]>([])
 const loading = ref(true)
 const error = ref<string | null>(null)
+const stoppingTaskIds = ref<Set<string>>(new Set())
 let refreshInterval: NodeJS.Timer | null = null
+
+const stopTask = async (taskId: string) => {
+  if (stoppingTaskIds.value.has(taskId)) return
+  stoppingTaskIds.value.add(taskId)
+  // Force reactivity for Set
+  stoppingTaskIds.value = new Set(stoppingTaskIds.value)
+  try {
+    await apiFetch(`/api/tasks/${encodeURIComponent(taskId)}/cancel`, { method: 'POST' })
+    await refreshAgents()
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to stop task'
+  } finally {
+    stoppingTaskIds.value.delete(taskId)
+    stoppingTaskIds.value = new Set(stoppingTaskIds.value)
+  }
+}
 
 const formatTime = (date: Date) => {
   return date.toLocaleTimeString('en-US', {

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -46,8 +46,20 @@
           class="flex-1 bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:border-blue-500 disabled:opacity-50"
         />
         <button
+          v-if="store.isLoading"
+          type="button"
+          @click="stopOrchestrator"
+          :disabled="stopping"
+          class="bg-red-600 hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed text-white px-4 py-2 rounded-lg text-sm transition-colors flex items-center gap-2"
+          title="Stop the orchestrator"
+        >
+          <span class="inline-block w-3 h-3 bg-white rounded-sm"></span>
+          {{ stopping ? 'Stopping...' : 'Stop' }}
+        </button>
+        <button
+          v-else
           type="submit"
-          :disabled="store.isLoading || !input.trim()"
+          :disabled="!input.trim()"
           class="bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white px-4 py-2 rounded-lg text-sm transition-colors"
         >
           Send
@@ -64,7 +76,20 @@ import { apiFetch, authenticatedUrl } from '../lib/api'
 
 const store = useChatStore()
 const input = ref('')
+const stopping = ref(false)
 const messagesEl = ref<HTMLElement | null>(null)
+
+async function stopOrchestrator() {
+  if (stopping.value) return
+  stopping.value = true
+  try {
+    await apiFetch('/api/orchestrator/abort', { method: 'POST' })
+  } catch {
+    // best-effort — UI will recover when SSE delivers done/error
+  } finally {
+    stopping.value = false
+  }
+}
 
 const isStreaming = computed(() =>
   store.messages.some((m) => m.streaming)

--- a/web/src/views/SquadsView.vue
+++ b/web/src/views/SquadsView.vue
@@ -141,6 +141,17 @@
                 ]">
                   {{ agent.status }}
                 </span>
+                <button
+                  v-if="agent.status === 'working' && agent.currentTaskId"
+                  type="button"
+                  @click="stopAgentTask(squad.slug, agent.currentTaskId)"
+                  :disabled="stoppingTaskIds.has(agent.currentTaskId)"
+                  class="bg-red-600 hover:bg-red-700 disabled:opacity-50 text-white text-xs px-2 py-1 rounded transition-colors flex items-center gap-1"
+                  title="Stop this agent's current task"
+                >
+                  <span class="inline-block w-2 h-2 bg-white rounded-sm"></span>
+                  {{ stoppingTaskIds.has(agent.currentTaskId) ? 'Stopping...' : 'Stop' }}
+                </button>
               </li>
             </ul>
           </div>
@@ -176,6 +187,8 @@ interface SquadAgent {
   model_tier?: string
   personality?: string | null
   status: string
+  currentTaskId?: string | null
+  currentTask?: string | null
 }
 
 const UNIVERSE_NAMES: Record<string, string> = {
@@ -198,6 +211,22 @@ const expanded = reactive<Record<string, boolean>>({})
 const agentsBySquad = reactive<Record<string, SquadAgent[]>>({})
 const agentsLoading = reactive<Record<string, boolean>>({})
 const agentsError = reactive<Record<string, string | null>>({})
+const stoppingTaskIds = ref<Set<string>>(new Set())
+
+const stopAgentTask = async (squadSlug: string, taskId: string) => {
+  if (stoppingTaskIds.value.has(taskId)) return
+  stoppingTaskIds.value = new Set(stoppingTaskIds.value).add(taskId)
+  try {
+    await apiFetch(`/api/tasks/${encodeURIComponent(taskId)}/cancel`, { method: 'POST' })
+    await loadAgents(squadSlug, true)
+  } catch (e) {
+    agentsError[squadSlug] = e instanceof Error ? e.message : 'Failed to stop task'
+  } finally {
+    const next = new Set(stoppingTaskIds.value)
+    next.delete(taskId)
+    stoppingTaskIds.value = next
+  }
+}
 
 const form = ref({
   slug: '',
@@ -228,7 +257,8 @@ const toggleSquad = async (slug: string) => {
   }
 }
 
-const loadAgents = async (slug: string) => {
+const loadAgents = async (slug: string, force = false) => {
+  if (!force && agentsLoading[slug]) return
   agentsLoading[slug] = true
   agentsError[slug] = null
   try {


### PR DESCRIPTION
Closes #25

## Summary

Adds the ability to interrupt in-flight work from the web UI in two places:

1. **Chat tab** — While the orchestrator is thinking/responding, the Send button is replaced by a red Stop button. Clicking it aborts the orchestrator's current request so the user can give more context or feedback. The session itself remains valid for the next prompt.
2. **Agent activity & squad members** — Working agents now show a Stop button next to their status. Clicking it aborts the agent's session and marks its task cancelled.

## Backend

- `src/copilot/orchestrator.ts`: new `abortOrchestrator()` that calls `session.abort()` on the active orchestrator session
- `src/copilot/agents.ts`: new `cancelAgentTask(taskId)` that looks up the task's session, aborts it, marks the task cancelled, and resets the related squad/agent statuses to `idle`
- `src/copilot/agents.ts`: `AgentInfo` now includes `currentTaskId` so the UI can target the right task
- `src/store/tasks.ts`: new `cancelTask()` helper (sets `status='cancelled'`)
- `src/api/server.ts`:
  - `POST /api/orchestrator/abort` — abort the orchestrator's current request
  - `POST /api/tasks/:taskId/cancel` — cancel a running agent task
  - `GET /api/squads/:slug/agents` now enriches each agent with `currentTaskId` / `currentTask` so squad rosters can show a per-member Stop button

## Frontend

- `ChatView.vue`: conditional Send/Stop button. Stop POSTs `/api/orchestrator/abort`.
- `AgentActivityView.vue`: per-agent Stop button shown when status is `working` and there's a `currentTaskId`.
- `SquadsView.vue`: per-roster-member Stop button alongside the status badge for working agents. The roster auto-refreshes after a successful cancel.

## Verification

- `npm run build` (root, tsc) ✅
- `npx vite build` (web) ✅