### PR TITLE
feat: live agent preview via per-task SSE event stream

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -5,7 +5,7 @@ import express, { type Request, type Response } from "express";
 import { config } from "../config.js";
 import { listSkills } from "../copilot/skills.js";
 import { listSquads, createSquad, listSquadAgents } from "../store/squads.js";
-import { getAgentInfo, cancelAgentTask } from "../copilot/agents.js";
+import { getAgentInfo, cancelAgentTask, getTaskEvents, subscribeToTaskEvents } from "../copilot/agents.js";
 import { abortOrchestrator } from "../copilot/orchestrator.js";
 import { getActiveTasks, getTask, listRecentTasks } from "../store/tasks.js";
 import { IO_VERSION } from "../paths.js";
@@ -177,6 +177,40 @@ export async function startApiServer(): Promise<void> {
       console.error("Error fetching task:", e);
       res.status(500).json({ error: "Failed to fetch task" });
     }
+  });
+
+  api.get("/tasks/:taskId/events", (req: Request, res: Response) => {
+    const taskId = Array.isArray(req.params.taskId) ? req.params.taskId[0] : req.params.taskId;
+
+    res.setHeader("Content-Type", "text/event-stream");
+    res.setHeader("Cache-Control", "no-cache");
+    res.setHeader("Connection", "keep-alive");
+    res.setHeader("X-Accel-Buffering", "no");
+    res.flushHeaders();
+
+    const send = (ev: { ts: number; type: string; data: unknown }) => {
+      try {
+        res.write(`data: ${JSON.stringify(ev)}\n\n`);
+      } catch {
+        // client likely disconnected; cleanup happens on req.close
+      }
+    };
+
+    // Replay buffered events first so a late subscriber sees the full thread
+    for (const ev of getTaskEvents(taskId)) send(ev);
+
+    // Subscribe to live events
+    const unsubscribe = subscribeToTaskEvents(taskId, send);
+
+    // Heartbeat to keep proxies / browsers from closing the connection
+    const heartbeat = setInterval(() => {
+      try { res.write(": ping\n\n"); } catch { /* ignore */ }
+    }, 15000);
+
+    req.on("close", () => {
+      clearInterval(heartbeat);
+      unsubscribe();
+    });
   });
 
   // Stop / cancel endpoints

--- a/src/copilot/agents.ts
+++ b/src/copilot/agents.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "crypto";
+import { EventEmitter } from "events";
 import { execSync } from "child_process";
 import {
   readFileSync,
@@ -11,7 +12,7 @@ import {
 import { join, dirname, resolve } from "path";
 import { homedir } from "os";
 import { defineTool, approveAll } from "@github/copilot-sdk";
-import type { CopilotSession } from "@github/copilot-sdk";
+import type { CopilotSession, SessionEvent } from "@github/copilot-sdk";
 import { z } from "zod";
 
 import { getClient } from "./client.js";
@@ -111,6 +112,63 @@ export function getAgentInfo(): AgentInfo[] {
   return agents;
 }
 
+// ---------------------------------------------------------------------------
+// Live task event streaming — captures relevant events emitted by an agent's
+// session while it processes a task. Buffers per task so late subscribers can
+// replay the conversation up to the live edge, and emits events for current
+// SSE subscribers.
+// ---------------------------------------------------------------------------
+
+export interface TaskStreamEvent {
+  ts: number;
+  type: string;
+  data: unknown;
+}
+
+const STREAM_EVENT_TYPES = new Set<string>([
+  "assistant.turn_start",
+  "assistant.intent",
+  "assistant.reasoning",
+  "assistant.reasoning_delta",
+  "assistant.message_delta",
+  "assistant.message",
+  "assistant.turn_end",
+  "tool.execution_start",
+  "tool.execution_progress",
+  "tool.execution_partial_result",
+  "tool.execution_complete",
+  "session.error",
+  "session.warning",
+]);
+
+const MAX_TASK_EVENTS = 1000;
+const taskEventBuffers = new Map<string, TaskStreamEvent[]>();
+const taskEventEmitter = new EventEmitter();
+taskEventEmitter.setMaxListeners(0);
+
+function recordTaskEvent(taskId: string, ev: TaskStreamEvent): void {
+  let buf = taskEventBuffers.get(taskId);
+  if (!buf) {
+    buf = [];
+    taskEventBuffers.set(taskId, buf);
+  }
+  buf.push(ev);
+  if (buf.length > MAX_TASK_EVENTS) buf.splice(0, buf.length - MAX_TASK_EVENTS);
+  taskEventEmitter.emit(taskId, ev);
+}
+
+export function getTaskEvents(taskId: string): TaskStreamEvent[] {
+  return taskEventBuffers.get(taskId) ?? [];
+}
+
+export function subscribeToTaskEvents(
+  taskId: string,
+  listener: (ev: TaskStreamEvent) => void,
+): () => void {
+  taskEventEmitter.on(taskId, listener);
+  return () => taskEventEmitter.off(taskId, listener);
+}
+
 export async function delegateToAgent(
   squadSlug: string,
   task: string,
@@ -152,6 +210,22 @@ export async function delegateToAgent(
   updateSquadStatus(squadSlug, "working");
   if (agent) updateAgentStatus(squadSlug, agent.character_name, "working");
 
+  // Subscribe to the agent session's events for the duration of this task so
+  // the web UI can preview the agent's "thread of consciousness" live.
+  recordTaskEvent(taskId, {
+    ts: Date.now(),
+    type: "task.start",
+    data: { taskId, agentKey, description: task },
+  });
+  const unsubscribe = session.on((event: SessionEvent) => {
+    if (!STREAM_EVENT_TYPES.has(event.type)) return;
+    recordTaskEvent(taskId, {
+      ts: Date.now(),
+      type: event.type,
+      data: (event as { data?: unknown }).data ?? null,
+    });
+  });
+
   // Run the task in the background — return taskId immediately
   void (async () => {
     try {
@@ -160,12 +234,16 @@ export async function delegateToAgent(
       completeTask(taskId, result);
       updateSquadStatus(squadSlug, "idle");
       if (agent) updateAgentStatus(squadSlug, agent.character_name, "idle");
+      recordTaskEvent(taskId, { ts: Date.now(), type: "task.done", data: { result } });
       onComplete(taskId, result);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       failTask(taskId, message);
       updateSquadStatus(squadSlug, "error");
       if (agent) updateAgentStatus(squadSlug, agent.character_name, "error");
+      recordTaskEvent(taskId, { ts: Date.now(), type: "task.failed", data: { error: message } });
+    } finally {
+      try { unsubscribe(); } catch { /* ignore */ }
     }
   })();
 
@@ -535,6 +613,7 @@ export async function cancelAgentTask(taskId: string): Promise<boolean> {
   }
 
   cancelTask(taskId);
+  recordTaskEvent(taskId, { ts: Date.now(), type: "task.cancelled", data: { reason: "Cancelled by user" } });
 
   // sessionKey is "squadSlug" or "squadSlug:characterName"
   const [squadSlug, characterName] = sessionKey.split(":");

--- a/web/src/views/SquadsView.vue
+++ b/web/src/views/SquadsView.vue
@@ -144,6 +144,16 @@
                 <button
                   v-if="agent.status === 'working' && agent.currentTaskId"
                   type="button"
+                  @click="openPreview(agent)"
+                  class="bg-blue-700 hover:bg-blue-600 text-white text-xs px-2 py-1 rounded transition-colors flex items-center gap-1"
+                  title="Preview this agent's live work"
+                >
+                  <span aria-hidden="true">👁</span>
+                  Preview
+                </button>
+                <button
+                  v-if="agent.status === 'working' && agent.currentTaskId"
+                  type="button"
                   @click="stopAgentTask(squad.slug, agent.currentTaskId)"
                   :disabled="stoppingTaskIds.has(agent.currentTaskId)"
                   class="bg-red-600 hover:bg-red-700 disabled:opacity-50 text-white text-xs px-2 py-1 rounded transition-colors flex items-center gap-1"
@@ -158,12 +168,68 @@
         </div>
       </div>
     </div>
+
+    <!-- Live agent preview modal -->
+    <div
+      v-if="previewAgent"
+      class="fixed inset-0 bg-black/70 flex items-center justify-center p-4 z-50"
+      @click.self="closePreview"
+    >
+      <div class="bg-gray-900 border border-gray-700 rounded-lg w-full max-w-3xl max-h-[85vh] flex flex-col shadow-2xl">
+        <div class="flex justify-between items-center p-4 border-b border-gray-700">
+          <div class="min-w-0">
+            <h3 class="text-lg font-bold text-gray-100 truncate">
+              {{ previewAgent.character_name }}
+              <span class="text-sm font-normal text-gray-400">— {{ previewAgent.role_title }}</span>
+            </h3>
+            <p class="text-xs text-gray-500 mt-1 flex items-center gap-2">
+              <span class="inline-block w-2 h-2 rounded-full" :class="previewConnected ? 'bg-green-400 animate-pulse' : 'bg-gray-500'"></span>
+              {{ previewStatusLabel }}
+            </p>
+          </div>
+          <button
+            type="button"
+            @click="closePreview"
+            class="text-gray-400 hover:text-gray-100 text-2xl leading-none focus:outline-none"
+            aria-label="Close"
+          >×</button>
+        </div>
+
+        <div ref="previewScrollEl" class="overflow-y-auto p-4 space-y-3 flex-1 font-mono text-xs">
+          <div v-if="previewError" class="bg-red-900 text-red-100 p-3 rounded">{{ previewError }}</div>
+          <div v-else-if="previewEvents.length === 0" class="text-gray-500 italic text-center py-8">
+            Waiting for activity...
+          </div>
+          <div
+            v-for="(ev, idx) in previewEvents"
+            :key="idx"
+            class="border border-gray-800 rounded p-2 bg-gray-950"
+          >
+            <div class="flex justify-between items-center mb-1">
+              <span class="text-blue-400">{{ ev.type }}</span>
+              <span class="text-gray-600 text-[10px]">{{ formatEventTime(ev.ts) }}</span>
+            </div>
+            <pre class="text-gray-200 whitespace-pre-wrap break-words">{{ formatEventBody(ev) }}</pre>
+          </div>
+        </div>
+
+        <div class="p-3 border-t border-gray-700 flex justify-end">
+          <button
+            type="button"
+            @click="closePreview"
+            class="bg-gray-700 hover:bg-gray-600 text-gray-100 text-sm px-4 py-2 rounded transition-colors"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, onMounted } from 'vue'
-import { apiFetch } from '../lib/api'
+import { ref, reactive, computed, nextTick, onMounted, onBeforeUnmount } from 'vue'
+import { apiFetch, authenticatedUrl } from '../lib/api'
 
 interface Squad {
   id: number
@@ -212,6 +278,101 @@ const agentsBySquad = reactive<Record<string, SquadAgent[]>>({})
 const agentsLoading = reactive<Record<string, boolean>>({})
 const agentsError = reactive<Record<string, string | null>>({})
 const stoppingTaskIds = ref<Set<string>>(new Set())
+
+const previewAgent = ref<SquadAgent | null>(null)
+const previewEvents = ref<Array<{ ts: number; type: string; data: unknown }>>([])
+const previewError = ref<string | null>(null)
+const previewConnected = ref(false)
+const previewScrollEl = ref<HTMLElement | null>(null)
+let previewSource: EventSource | null = null
+
+const previewStatusLabel = computed(() => {
+  if (previewError.value) return 'Disconnected'
+  if (previewConnected.value) return 'Live'
+  return 'Connecting...'
+})
+
+const formatEventTime = (ts: number) => {
+  try {
+    return new Date(ts).toLocaleTimeString()
+  } catch {
+    return ''
+  }
+}
+
+const formatEventBody = (ev: { type: string; data: unknown }) => {
+  const d = ev.data as Record<string, unknown> | null | undefined
+  if (!d || typeof d !== 'object') return ''
+  // Surface common interesting fields verbatim
+  if (typeof (d as { deltaContent?: string }).deltaContent === 'string') {
+    return (d as { deltaContent: string }).deltaContent
+  }
+  if (typeof (d as { content?: string }).content === 'string') {
+    return (d as { content: string }).content
+  }
+  if (typeof (d as { text?: string }).text === 'string') {
+    return (d as { text: string }).text
+  }
+  try {
+    return JSON.stringify(d, null, 2)
+  } catch {
+    return String(d)
+  }
+}
+
+const scrollPreviewToBottom = () => {
+  nextTick(() => {
+    const el = previewScrollEl.value
+    if (el) el.scrollTop = el.scrollHeight
+  })
+}
+
+const openPreview = (agent: SquadAgent) => {
+  if (!agent.currentTaskId) return
+  closePreview()
+  previewAgent.value = agent
+  previewEvents.value = []
+  previewError.value = null
+  previewConnected.value = false
+
+  const url = authenticatedUrl(`/api/tasks/${encodeURIComponent(agent.currentTaskId)}/events`)
+  const es = new EventSource(url)
+  previewSource = es
+
+  es.onopen = () => { previewConnected.value = true }
+  es.onmessage = (e) => {
+    try {
+      const ev = JSON.parse(e.data) as { ts: number; type: string; data: unknown }
+      previewEvents.value.push(ev)
+      // Auto-scroll for streaming deltas
+      scrollPreviewToBottom()
+    } catch {
+      // ignore parse errors
+    }
+  }
+  es.onerror = () => {
+    previewConnected.value = false
+    // EventSource will auto-retry; surface a soft warning only if we never connected
+    if (previewEvents.value.length === 0) {
+      previewError.value = 'Connection error. Retrying...'
+    }
+  }
+}
+
+const closePreview = () => {
+  if (previewSource) {
+    try { previewSource.close() } catch { /* ignore */ }
+    previewSource = null
+  }
+  previewAgent.value = null
+  previewEvents.value = []
+  previewError.value = null
+  previewConnected.value = false
+}
+
+onBeforeUnmount(() => {
+  closePreview()
+})
 
 const stopAgentTask = async (squadSlug: string, taskId: string) => {
   if (stoppingTaskIds.value.has(taskId)) return


### PR DESCRIPTION
Closes #22

## Summary

Adds a near-real-time "thread of consciousness" view for working squad agents on the Squads tab. Built with **Server-Sent Events**, which fits cleanly into the existing Express + EventSource setup already used for chat streaming.

## Backend

### `src/copilot/agents.ts` — per-task event capture
- For every delegated task, subscribe to the agent's Copilot SDK session events with `session.on(handler)`.
- Capture the relevant event types: `assistant.turn_start`, `assistant.intent`, `assistant.reasoning(_delta)`, `assistant.message_delta`, `assistant.message`, `assistant.turn_end`, all `tool.execution_*`, and `session.error`/`warning`.
- Buffer per `taskId` (capped at 1000 events) and re-broadcast via a per-task `EventEmitter` so multiple late subscribers can attach and get the full thread up to the live edge.
- Synthetic `task.start` / `task.done` / `task.failed` / `task.cancelled` events bookend the thread (the cancellation event is also emitted from `cancelAgentTask`).
- Listener is unsubscribed in a `finally` block when the task settles.

### `src/api/server.ts` — SSE endpoint
- `GET /api/tasks/:taskId/events`
  - Replays the buffered events, then forwards live ones.
  - Sends a `: ping` heartbeat every 15s so proxies / browsers don't drop the connection.
  - Cleans up subscriber + heartbeat on `req.close`.
- Auth: the existing `requireAuth` middleware already accepts the access token via `?token=` query param, so `EventSource` works through the existing `authenticatedUrl()` helper without custom headers.

## Frontend (`SquadsView.vue`)

- Each working roster member now shows a **Preview** button next to the existing Stop button.
- Clicking Preview opens a modal that connects to the SSE stream and renders each incoming event:
  - Event type, timestamp, and body (auto-extracts common fields — `deltaContent`, `content`, `text` — falling back to pretty-printed JSON).
  - Live indicator dot, auto-scroll on new events, click-outside / Close to dismiss.
  - `EventSource` is closed and state cleared on close + on component unmount.

## Verification

- `npm run build` (root, tsc) ✅
- `npx vite build` (web) ✅