### PR TITLE
feat: every squad has a team lead

### DIFF
--- a/src/copilot/agents.ts
+++ b/src/copilot/agents.ts
@@ -26,6 +26,7 @@ import {
   logDecision,
   listSquadAgents,
   getSquadAgent,
+  getSquadLead,
   updateAgentSession,
   updateAgentStatus,
 } from "../store/squads.js";
@@ -190,10 +191,16 @@ export async function delegateToAgent(
       );
     }
   } else {
-    // If squad has named agents, pick the best match (first idle, or first one)
-    const agents = listSquadAgents(squadSlug);
-    if (agents.length > 0) {
-      agent = agents.find((a) => a.status === "idle") ?? agents[0];
+    // Prefer the designated team lead if one exists; otherwise fall back to
+    // the first idle agent (or just the first agent on the roster).
+    const lead = getSquadLead(squadSlug);
+    if (lead) {
+      agent = lead;
+    } else {
+      const agents = listSquadAgents(squadSlug);
+      if (agents.length > 0) {
+        agent = agents.find((a) => a.status === "idle") ?? agents[0];
+      }
     }
   }
 
@@ -327,7 +334,38 @@ async function getOrCreateAgentSession(
     ? getUniverse(squad.universe)?.name ?? squad.universe
     : "Unknown";
 
-  const agentTools = buildAgentTools(squadSlug);
+  const isLead = agent.is_lead === 1;
+  const agentTools = buildAgentTools(squadSlug, isLead);
+
+  let leadSection = "";
+  if (isLead) {
+    const teammates = listSquadAgents(squadSlug).filter(
+      (a) => a.character_name !== agent.character_name,
+    );
+    const roster = teammates.length > 0
+      ? teammates
+          .map((t) => {
+            const charter = t.charter
+              ? t.charter.length > 200
+                ? t.charter.slice(0, 200) + "…"
+                : t.charter
+              : "(no charter)";
+            return `- **${t.character_name}** — ${t.role_title}: ${charter}`;
+          })
+          .join("\n")
+      : "_(no other agents on this squad yet — ask IO to add some)_";
+
+    leadSection = `
+
+## Team Lead Role
+You are the team lead for this squad. When you receive a task, your job is to:
+1. Break it down into concrete subtasks
+2. Assign each subtask to the most appropriate teammate using the \`delegate_to_teammate\` tool
+3. Collect results and synthesize a final summary
+
+## Your Team
+${roster}`;
+  }
 
   const systemMessage = `You are ${agent.character_name}, a specialist agent on the "${squad.name}" project team (${universeName} universe).
 
@@ -343,7 +381,7 @@ ${agent.charter ?? "General-purpose agent. Handle tasks as they come."}
 - **Path**: ${squad.project_path}
 
 ## Past Decisions
-${decisions}
+${decisions}${leadSection}
 
 ## Instructions
 You are a coding agent. Use the shell tool to run commands and file_ops to read/write files.
@@ -441,7 +479,7 @@ Log important decisions with squad_log_decision so they persist.`,
   return session;
 }
 
-function buildAgentTools(squadSlug: string) {
+function buildAgentTools(squadSlug: string, isLead = false) {
   const shell = defineTool("shell", {
     description:
       "Run a shell command. Use for git, build tools, file operations, etc.",
@@ -570,7 +608,57 @@ function buildAgentTools(squadSlug: string) {
     },
   });
 
-  return [shell, fileOps, squadLogDecision];
+  const tools: any[] = [shell, fileOps, squadLogDecision];
+
+  if (isLead) {
+    const delegateToTeammate = defineTool("delegate_to_teammate", {
+      description:
+        "Delegate a subtask to a teammate on this squad. The teammate runs the task synchronously and returns its result. Use this to divvy work as the team lead.",
+      skipPermission: true,
+      parameters: z.object({
+        teammate: z
+          .string()
+          .describe("The teammate's character_name (e.g., 'Optimus Prime')"),
+        task: z
+          .string()
+          .describe("The concrete task or subtask the teammate should perform"),
+      }),
+      handler: async ({ teammate, task }) => {
+        try {
+          const teammateAgent = getSquadAgent(squadSlug, teammate);
+          if (!teammateAgent) {
+            return `Error: teammate "${teammate}" not found in squad "${squadSlug}". Use squad_agents to list the roster.`;
+          }
+          if (teammateAgent.is_lead === 1) {
+            return `Error: "${teammate}" is the team lead. Delegate to a non-lead teammate.`;
+          }
+
+          updateAgentStatus(squadSlug, teammateAgent.character_name, "working");
+          try {
+            const session = await getOrCreateAgentSession(
+              squadSlug,
+              teammateAgent,
+              task,
+            );
+            const response = await session.sendAndWait({ prompt: task }, 300_000);
+            const result =
+              response?.data?.content ?? "(teammate returned no output)";
+            updateAgentStatus(squadSlug, teammateAgent.character_name, "idle");
+            return result;
+          } catch (err) {
+            updateAgentStatus(squadSlug, teammateAgent.character_name, "error");
+            const message = err instanceof Error ? err.message : String(err);
+            return `Error from teammate "${teammate}": ${message}`;
+          }
+        } catch (err) {
+          return `Error: ${err instanceof Error ? err.message : String(err)}`;
+        }
+      },
+    });
+    tools.push(delegateToTeammate);
+  }
+
+  return tools;
 }
 
 function walkDirectory(dir: string, maxDepth = 3, depth = 0): string[] {

--- a/src/copilot/orchestrator.ts
+++ b/src/copilot/orchestrator.ts
@@ -20,6 +20,8 @@ import {
   addSquadAgent,
   listSquadAgents,
   removeSquadAgent,
+  setSquadLead,
+  getSquadLead,
 } from "../store/squads.js";
 import { readPage, writePage, assertPagePath, deletePage, listPages } from "../wiki/fs.js";
 import { resolveModelTiers } from "./model-router.js";
@@ -117,8 +119,16 @@ function getToolDeps() {
         model_tier: a.model_tier,
         personality: a.personality,
         status: a.status,
+        is_lead: a.is_lead,
       })),
     removeSquadAgent,
+    setSquadLead,
+    getSquadLead: (slug: string) => {
+      const lead = getSquadLead(slug);
+      return lead
+        ? { character_name: lead.character_name, role_title: lead.role_title }
+        : undefined;
+    },
     listSkills,
     installSkill,
     removeSkill,

--- a/src/copilot/system-message.ts
+++ b/src/copilot/system-message.ts
@@ -83,12 +83,15 @@ Squads are persistent project teams with **named specialist agents**. Each squad
 ### Delegating Work
 After planning tasks with the user, **use \`squad_delegate\` to send each task to the right agent**:
 1. Plan the work with the user (break into concrete tasks).
-2. Call \`squad_delegate\` with the squad slug and task. Optionally specify an \`agent\` (character name) to target a specific specialist. If omitted, the system picks the best available agent.
+2. Call \`squad_delegate\` with the squad slug and task. Optionally specify an \`agent\` (character name) to target a specific specialist. **If omitted, the task routes to the squad's team lead** (if one is designated); the lead will then orchestrate the work, divvying subtasks to teammates via their \`delegate_to_teammate\` tool and synthesizing the results. If no lead is set, the system falls back to the first idle agent.
 3. The agent works autonomously in the background with their specialized system prompt.
 4. Use \`squad_task_status\` to check progress and retrieve results.
 5. Report results back to the user, mentioning the character name.
 
 You can delegate multiple tasks to different agents in parallel.
+
+### Team Leads
+Every squad should have a **team lead**. After building the team with \`squad_add_agent\`, designate one agent as the lead using \`squad_set_lead\`. The lead receives delegated tasks (when no specific agent is targeted), breaks them into subtasks, and assigns work to teammates via the lead-only \`delegate_to_teammate\` tool. This keeps coordination inside the squad rather than forcing IO to micro-manage assignments.
 
 ### Agent Roles Are Dynamic
 **Do NOT use generic roles** like "developer" or "tester". Analyze the project first and create roles that match its actual technology stack. Examples:

--- a/src/copilot/tools.ts
+++ b/src/copilot/tools.ts
@@ -31,8 +31,10 @@ export interface ToolDeps {
   getTask: (taskId: string) => { task_id: string; agent_slug: string; description: string; status: string; result: string | null } | undefined;
   getActiveAgentTasks: () => Array<{ taskId: string; agentSlug: string; description: string; status: string }>;
   addSquadAgent: (squadSlug: string, roleTitle: string, charter: string, modelTier?: string) => { character_name: string; role_title: string; personality: string | null; model_tier: string };
-  listSquadAgents: (squadSlug: string) => Array<{ character_name: string; role_title: string; charter: string | null; model_tier: string; personality: string | null; status: string }>;
+  listSquadAgents: (squadSlug: string) => Array<{ character_name: string; role_title: string; charter: string | null; model_tier: string; personality: string | null; status: string; is_lead?: number }>;
   removeSquadAgent: (squadSlug: string, characterName: string) => boolean;
+  setSquadLead: (squadSlug: string, characterName: string) => void;
+  getSquadLead: (squadSlug: string) => { character_name: string; role_title: string } | undefined;
   listSkills: () => Array<{ name: string; slug: string; description: string; path: string }>;
   installSkill: (repoUrl: string) => Promise<{ name: string; slug: string; description: string; path: string }>;
   removeSkill: (slug: string) => boolean;
@@ -139,10 +141,14 @@ export function createTools(deps: ToolDeps) {
             ? UNIVERSES.find((u) => u.id === s.universe)?.name ?? s.universe
             : "none";
           const agents = deps.listSquadAgents(s.slug);
+          const lead = deps.getSquadLead(s.slug);
+          const leadLine = lead
+            ? `\n  ⭐ Team Lead: ${lead.character_name} (${lead.role_title})`
+            : "";
           const agentList = agents.length > 0
             ? "\n  Agents: " + agents.map((a) => `${a.character_name} (${a.role_title})`).join(", ")
             : "\n  Agents: none — use squad_add_agent to build the team";
-          return `- **${s.name}** (\`${s.slug}\`) — ${s.status} — 🎬 ${universeName}${agentList}\n  📁 ${s.projectPath}`;
+          return `- **${s.name}** (\`${s.slug}\`) — ${s.status} — 🎬 ${universeName}${leadLine}${agentList}\n  📁 ${s.projectPath}`;
         })
         .join("\n");
     },
@@ -416,9 +422,10 @@ export function createTools(deps: ToolDeps) {
         ? UNIVERSES.find((u) => u.id === squad.universe)?.name ?? squad.universe
         : "none";
 
-      const lines = agents.map((a) =>
-        `- **${a.character_name}** — ${a.role_title} (${a.model_tier}) — ${a.status}${a.personality ? `\n  _${a.personality}_` : ""}`,
-      );
+      const lines = agents.map((a) => {
+        const leadBadge = a.is_lead === 1 ? " ⭐ [LEAD]" : "";
+        return `- **${a.character_name}**${leadBadge} — ${a.role_title} (${a.model_tier}) — ${a.status}${a.personality ? `\n  _${a.personality}_` : ""}`;
+      });
 
       return `**${squad.name}** — 🎬 ${universeName}\n\n${lines.join("\n")}`;
     },
@@ -996,7 +1003,34 @@ export function createTools(deps: ToolDeps) {
     },
   });
 
-  return [wikiRead, wikiWrite, wikiSearch, wikiDelete, wikiList, squadCreate, squadRecall, squadStatus, squadLogDecision, squadDelegate, squadTaskStatus, squadDelete, squadAnalyze, squadAddAgent, squadAgents, squadRemoveAgent, skillList, skillInstall, skillRemove, skillSearch, configUpdate, checkUpdate, shell, fileOps, bash, readFile, viewTool, grepTool, strReplaceEditor, github];
+  const squadSetLead = defineTool("squad_set_lead", {
+    description:
+      "Designate an agent as the team lead for their squad. The lead receives delegated tasks (when no specific agent is targeted) and orchestrates the team by divvying subtasks to teammates.",
+    skipPermission: true,
+    parameters: z.object({
+      slug: z.string().describe("Squad slug"),
+      character_name: z
+        .string()
+        .describe("Character name of the agent to make team lead"),
+    }),
+    handler: async ({ slug, character_name }) => {
+      try {
+        const squad = deps.getSquad(slug);
+        if (!squad) return `Squad not found: ${slug}`;
+        const agents = deps.listSquadAgents(slug);
+        const target = agents.find((a) => a.character_name === character_name);
+        if (!target) {
+          return `Agent "${character_name}" not found in squad "${slug}". Use squad_agents to list the roster.`;
+        }
+        deps.setSquadLead(slug, character_name);
+        return `⭐ ${character_name} (${target.role_title}) is now the team lead for squad "${squad.name}".`;
+      } catch (err) {
+        return `Error: ${err instanceof Error ? err.message : String(err)}`;
+      }
+    },
+  });
+
+  return [wikiRead, wikiWrite, wikiSearch, wikiDelete, wikiList, squadCreate, squadRecall, squadStatus, squadLogDecision, squadDelegate, squadTaskStatus, squadDelete, squadAnalyze, squadAddAgent, squadAgents, squadRemoveAgent, squadSetLead, skillList, skillInstall, skillRemove, skillSearch, configUpdate, checkUpdate, shell, fileOps, bash, readFile, viewTool, grepTool, strReplaceEditor, github];
 }
 
 function walkDirectory(dir: string, maxDepth = 3, depth = 0): string[] {

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -77,6 +77,7 @@ export function getDb(): BetterSqlite3.Database {
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
       UNIQUE(squad_slug, character_name)
     )`,
+    `ALTER TABLE squad_agents ADD COLUMN is_lead INTEGER NOT NULL DEFAULT 0`,
   ];
 
   for (const migration of migrations) {

--- a/src/store/squads.ts
+++ b/src/store/squads.ts
@@ -25,6 +25,7 @@ export interface SquadAgent {
   personality: string | null;
   copilot_session_id: string | null;
   status: string;
+  is_lead: number;
   created_at: string;
 }
 
@@ -235,4 +236,26 @@ export function getDecisionsSummary(squadSlug: string): string {
       return `- [${d.created_at}] ${d.decision}${ctx}`;
     })
     .join("\n");
+}
+
+
+export function setSquadLead(squadSlug: string, characterName: string): void {
+  const db = getDb();
+  const tx = db.transaction(() => {
+    db.prepare(
+      "UPDATE squad_agents SET is_lead = 0 WHERE squad_slug = ?",
+    ).run(squadSlug);
+    db.prepare(
+      "UPDATE squad_agents SET is_lead = 1 WHERE squad_slug = ? AND character_name = ?",
+    ).run(squadSlug, characterName);
+  });
+  tx();
+}
+
+export function getSquadLead(squadSlug: string): SquadAgent | undefined {
+  return getDb()
+    .prepare(
+      "SELECT * FROM squad_agents WHERE squad_slug = ? AND is_lead = 1 LIMIT 1",
+    )
+    .get(squadSlug) as SquadAgent | undefined;
 }


### PR DESCRIPTION
Closes #28

## What

Every squad now has a designated team lead. When IO delegates to a squad without specifying an agent, the task routes to the lead, who orchestrates the work and divvies subtasks to teammates.

## Changes

- **DB**: `is_lead` column on `squad_agents` (migration)
- **Store** (`src/store/squads.ts`): `SquadAgent.is_lead`, `setSquadLead`, `getSquadLead`
- **Routing** (`src/copilot/agents.ts`): `delegateToAgent` prefers the lead when no `targetAgent` given; falls back to first-idle as before
- **Lead system message**: lead agents get an extra "Team Lead Role" + "Your Team" section listing teammates and their charters
- **New lead-only tool** `delegate_to_teammate`: lead can hand a subtask to a named teammate and await the result synchronously (300s timeout, wrapped in try/catch, status flipped to working/idle/error)
- **Orchestrator tool** `squad_set_lead`: designate an agent as the team lead
- **UX**: `squad_agents` marks lead with ⭐ [LEAD]; `squad_status` surfaces the lead per squad
- **System message**: Delegating Work section updated; new Team Leads section explains the workflow

## Compatibility

Squads without a lead retain the original behavior (first idle agent gets delegated work). The `delegate_to_teammate` tool is only added to the lead's toolset, so non-lead agents are unaffected.

## Verified

- `npm run build` (tsc) ✅
- `web && vite build` ✅

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>