### PR TITLE
feat: squad peer-review approvals with QA veto

### DIFF
--- a/src/copilot/agents.ts
+++ b/src/copilot/agents.ts
@@ -34,6 +34,7 @@ import type { SquadAgent } from "../store/squads.js";
 import {
   createTask,
   completeTask,
+  createReview,
   failTask,
   getActiveTasks,
   getTask,
@@ -242,6 +243,28 @@ export async function delegateToAgent(
       updateSquadStatus(squadSlug, "idle");
       if (agent) updateAgentStatus(squadSlug, agent.character_name, "idle");
       recordTaskEvent(taskId, { ts: Date.now(), type: "task.done", data: { result } });
+      try {
+        await runPeerReview(
+          squadSlug,
+          agent?.character_name ?? "",
+          taskId,
+          task,
+          result,
+        );
+      } catch (reviewErr) {
+        console.error(
+          "[io] Peer review error:",
+          reviewErr instanceof Error ? reviewErr.message : reviewErr,
+        );
+        recordTaskEvent(taskId, {
+          ts: Date.now(),
+          type: "task.review_error",
+          data: {
+            error:
+              reviewErr instanceof Error ? reviewErr.message : String(reviewErr),
+          },
+        });
+      }
       onComplete(taskId, result);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -679,6 +702,157 @@ function walkDirectory(dir: string, maxDepth = 3, depth = 0): string[] {
     }
   }
   return results;
+}
+
+
+/**
+ * Run a peer review phase after a task completes. Every other agent on the
+ * squad reviews the work and votes APPROVED / REJECTED. QA agents
+ * (is_qa === 1) have veto power: if any QA agent rejects, the PR is left as
+ * draft. Otherwise, any GitHub PR URL found in the task result is promoted
+ * from draft to ready via `gh pr ready`.
+ */
+async function runPeerReview(
+  squadSlug: string,
+  originalAgentCharacter: string,
+  taskId: string,
+  taskDescription: string,
+  taskResult: string,
+): Promise<void> {
+  const reviewers = listSquadAgents(squadSlug).filter(
+    (a) => a.character_name !== originalAgentCharacter,
+  );
+
+  if (reviewers.length === 0) {
+    recordTaskEvent(taskId, {
+      ts: Date.now(),
+      type: "task.review_complete",
+      data: { promoted: false, reason: "No other agents to review" },
+    });
+    return;
+  }
+
+  const reviewPrompt = `You are reviewing the following completed task:
+
+## Task
+${taskDescription}
+
+## Work Done
+${taskResult}
+
+Review the work. Respond with:
+- First line: APPROVED or REJECTED
+- Remaining lines: your review comments`;
+
+  const reviews: Array<{
+    reviewer: string;
+    is_qa: boolean;
+    approved: boolean;
+    comments: string;
+  }> = [];
+
+  for (const reviewer of reviewers) {
+    try {
+      const session = await getOrCreateAgentSession(
+        squadSlug,
+        reviewer,
+        `Peer review of task ${taskId}`,
+      );
+      const response = await session.sendAndWait(
+        { prompt: reviewPrompt },
+        300_000,
+      );
+      const content = response?.data?.content ?? "";
+      const lines = content.split(/\r?\n/);
+      const firstLine = (lines[0] ?? "").trim().toUpperCase();
+      const approved =
+        firstLine.includes("APPROVED") && !firstLine.includes("REJECTED");
+      const comments = lines.slice(1).join("\n").trim() || null;
+
+      createReview(
+        taskId,
+        squadSlug,
+        reviewer.character_name,
+        approved,
+        comments ?? undefined,
+      );
+      recordTaskEvent(taskId, {
+        ts: Date.now(),
+        type: "task.review",
+        data: {
+          reviewer: reviewer.character_name,
+          is_qa: reviewer.is_qa === 1,
+          approved,
+          comments,
+        },
+      });
+      reviews.push({
+        reviewer: reviewer.character_name,
+        is_qa: reviewer.is_qa === 1,
+        approved,
+        comments: comments ?? "",
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(
+        `[io] Reviewer ${reviewer.character_name} failed:`,
+        message,
+      );
+      recordTaskEvent(taskId, {
+        ts: Date.now(),
+        type: "task.review_error",
+        data: { reviewer: reviewer.character_name, error: message },
+      });
+    }
+  }
+
+  const qaRejection = reviews.find((r) => r.is_qa && !r.approved);
+  const prMatch = taskResult.match(
+    /https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/pull\/(\d+)/,
+  );
+
+  if (qaRejection) {
+    recordTaskEvent(taskId, {
+      ts: Date.now(),
+      type: "task.review_complete",
+      data: {
+        promoted: false,
+        reason: `QA veto from ${qaRejection.reviewer}`,
+        prUrl: prMatch ? prMatch[0] : null,
+      },
+    });
+    return;
+  }
+
+  if (!prMatch) {
+    recordTaskEvent(taskId, {
+      ts: Date.now(),
+      type: "task.review_complete",
+      data: { promoted: false, reason: "No PR URL found in task result" },
+    });
+    return;
+  }
+
+  const [prUrl, owner, repo, prNumber] = prMatch;
+  try {
+    execSync(`gh pr ready ${prNumber} --repo ${owner}/${repo}`, {
+      encoding: "utf-8",
+      timeout: 30_000,
+      env: { ...process.env, HOME: process.env.HOME || homedir() },
+    });
+    recordTaskEvent(taskId, {
+      ts: Date.now(),
+      type: "task.review_complete",
+      data: { promoted: true, prUrl },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    recordTaskEvent(taskId, {
+      ts: Date.now(),
+      type: "task.review_complete",
+      data: { promoted: false, reason: `gh pr ready failed: ${message}`, prUrl },
+    });
+  }
 }
 
 

--- a/src/copilot/orchestrator.ts
+++ b/src/copilot/orchestrator.ts
@@ -8,7 +8,7 @@ import {
 import { config } from "../config.js";
 import { SESSIONS_DIR, IO_VERSION } from "../paths.js";
 import { getState, setState, deleteState, logConversation } from "../store/db.js";
-import { clearStaleTasks, getTask } from "../store/tasks.js";
+import { clearStaleTasks, getTask, getTaskReviews } from "../store/tasks.js";
 import {
   getSquad,
   listSquads,
@@ -22,6 +22,7 @@ import {
   removeSquadAgent,
   setSquadLead,
   getSquadLead,
+  setSquadQA,
 } from "../store/squads.js";
 import { readPage, writePage, assertPagePath, deletePage, listPages } from "../wiki/fs.js";
 import { resolveModelTiers } from "./model-router.js";
@@ -120,6 +121,7 @@ function getToolDeps() {
         personality: a.personality,
         status: a.status,
         is_lead: a.is_lead,
+        is_qa: a.is_qa,
       })),
     removeSquadAgent,
     setSquadLead,
@@ -129,6 +131,13 @@ function getToolDeps() {
         ? { character_name: lead.character_name, role_title: lead.role_title }
         : undefined;
     },
+    setSquadQA,
+    getTaskReviews: (taskId: string) =>
+      getTaskReviews(taskId).map((r) => ({
+        reviewer_character: r.reviewer_character,
+        approved: r.approved,
+        comments: r.comments,
+      })),
     listSkills,
     installSkill,
     removeSkill,

--- a/src/copilot/system-message.ts
+++ b/src/copilot/system-message.ts
@@ -93,6 +93,15 @@ You can delegate multiple tasks to different agents in parallel.
 ### Team Leads
 Every squad should have a **team lead**. After building the team with \`squad_add_agent\`, designate one agent as the lead using \`squad_set_lead\`. The lead receives delegated tasks (when no specific agent is targeted), breaks them into subtasks, and assigns work to teammates via the lead-only \`delegate_to_teammate\` tool. This keeps coordination inside the squad rather than forcing IO to micro-manage assignments.
 
+### Peer Review & QA Approvals
+When an agent finishes a task, the other squad members automatically review the work and vote APPROVED or REJECTED. Reviews are recorded and emitted as \`task.review\` events.
+
+- Designate QA reviewers with \`squad_set_qa\` — typically agents focused on testing, security, or quality.
+- **QA agents have veto power**: if any QA reviewer rejects, the PR stays as a draft.
+- Non-QA rejections are advisory — they're recorded but don't block promotion.
+- When all QA approvals pass (or no QA agents exist) and the task result contains a GitHub PR URL, the PR is automatically promoted from draft to ready via \`gh pr ready\`.
+- Use \`squad_task_reviews\` to inspect the reviews on any completed task.
+
 ### Agent Roles Are Dynamic
 **Do NOT use generic roles** like "developer" or "tester". Analyze the project first and create roles that match its actual technology stack. Examples:
 - IO project → "Copilot SDK Specialist", "Vue.js Frontend Dev", "Express API Engineer"

--- a/src/copilot/tools.ts
+++ b/src/copilot/tools.ts
@@ -31,10 +31,12 @@ export interface ToolDeps {
   getTask: (taskId: string) => { task_id: string; agent_slug: string; description: string; status: string; result: string | null } | undefined;
   getActiveAgentTasks: () => Array<{ taskId: string; agentSlug: string; description: string; status: string }>;
   addSquadAgent: (squadSlug: string, roleTitle: string, charter: string, modelTier?: string) => { character_name: string; role_title: string; personality: string | null; model_tier: string };
-  listSquadAgents: (squadSlug: string) => Array<{ character_name: string; role_title: string; charter: string | null; model_tier: string; personality: string | null; status: string; is_lead?: number }>;
+  listSquadAgents: (squadSlug: string) => Array<{ character_name: string; role_title: string; charter: string | null; model_tier: string; personality: string | null; status: string; is_lead?: number; is_qa?: number }>;
   removeSquadAgent: (squadSlug: string, characterName: string) => boolean;
   setSquadLead: (squadSlug: string, characterName: string) => void;
   getSquadLead: (squadSlug: string) => { character_name: string; role_title: string } | undefined;
+  setSquadQA: (squadSlug: string, characterName: string, isQA: boolean) => void;
+  getTaskReviews: (taskId: string) => Array<{ reviewer_character: string; approved: number; comments: string | null }>;
   listSkills: () => Array<{ name: string; slug: string; description: string; path: string }>;
   installSkill: (repoUrl: string) => Promise<{ name: string; slug: string; description: string; path: string }>;
   removeSkill: (slug: string) => boolean;
@@ -424,7 +426,8 @@ export function createTools(deps: ToolDeps) {
 
       const lines = agents.map((a) => {
         const leadBadge = a.is_lead === 1 ? " ⭐ [LEAD]" : "";
-        return `- **${a.character_name}**${leadBadge} — ${a.role_title} (${a.model_tier}) — ${a.status}${a.personality ? `\n  _${a.personality}_` : ""}`;
+        const qaBadge = a.is_qa === 1 ? " 🛡️ [QA]" : "";
+        return `- **${a.character_name}**${leadBadge}${qaBadge} — ${a.role_title} (${a.model_tier}) — ${a.status}${a.personality ? `\n  _${a.personality}_` : ""}`;
       });
 
       return `**${squad.name}** — 🎬 ${universeName}\n\n${lines.join("\n")}`;
@@ -1003,6 +1006,58 @@ export function createTools(deps: ToolDeps) {
     },
   });
 
+  const squadSetQA = defineTool("squad_set_qa", {
+    description:
+      "Mark a squad agent as a QA reviewer with veto power. QA agents must approve before a PR is promoted from draft to ready.",
+    skipPermission: true,
+    parameters: z.object({
+      slug: z.string().describe("Squad slug"),
+      character_name: z.string().describe("Character name of the agent"),
+      is_qa: z
+        .boolean()
+        .describe("Whether this agent is a QA reviewer (true) or not (false)"),
+    }),
+    handler: async ({ slug, character_name, is_qa }) => {
+      try {
+        const squad = deps.getSquad(slug);
+        if (!squad) return `Squad not found: ${slug}`;
+        const agents = deps.listSquadAgents(slug);
+        const target = agents.find((a) => a.character_name === character_name);
+        if (!target) {
+          return `Agent "${character_name}" not found in squad "${slug}".`;
+        }
+        deps.setSquadQA(slug, character_name, is_qa);
+        return is_qa
+          ? `🛡️ ${character_name} (${target.role_title}) is now a QA reviewer for squad "${squad.name}". They have veto power over PR promotion.`
+          : `${character_name} is no longer a QA reviewer for squad "${squad.name}".`;
+      } catch (err) {
+        return `Error: ${err instanceof Error ? err.message : String(err)}`;
+      }
+    },
+  });
+
+  const squadTaskReviews = defineTool("squad_task_reviews", {
+    description:
+      "Get the peer reviews left on a completed task by the squad. Shows who approved or rejected and any comments.",
+    skipPermission: true,
+    parameters: z.object({
+      task_id: z.string().describe("The task ID to fetch reviews for"),
+    }),
+    handler: async ({ task_id }) => {
+      const reviews = deps.getTaskReviews(task_id);
+      if (reviews.length === 0) {
+        return `No reviews found for task ${task_id}.`;
+      }
+      return reviews
+        .map((r) => {
+          const verdict = r.approved === 1 ? "✅ APPROVED" : "❌ REJECTED";
+          const comments = r.comments ? `\n  ${r.comments.replace(/\n/g, "\n  ")}` : "";
+          return `- **${r.reviewer_character}** — ${verdict}${comments}`;
+        })
+        .join("\n");
+    },
+  });
+
   const squadSetLead = defineTool("squad_set_lead", {
     description:
       "Designate an agent as the team lead for their squad. The lead receives delegated tasks (when no specific agent is targeted) and orchestrates the team by divvying subtasks to teammates.",
@@ -1030,7 +1085,7 @@ export function createTools(deps: ToolDeps) {
     },
   });
 
-  return [wikiRead, wikiWrite, wikiSearch, wikiDelete, wikiList, squadCreate, squadRecall, squadStatus, squadLogDecision, squadDelegate, squadTaskStatus, squadDelete, squadAnalyze, squadAddAgent, squadAgents, squadRemoveAgent, squadSetLead, skillList, skillInstall, skillRemove, skillSearch, configUpdate, checkUpdate, shell, fileOps, bash, readFile, viewTool, grepTool, strReplaceEditor, github];
+  return [wikiRead, wikiWrite, wikiSearch, wikiDelete, wikiList, squadCreate, squadRecall, squadStatus, squadLogDecision, squadDelegate, squadTaskStatus, squadDelete, squadAnalyze, squadAddAgent, squadAgents, squadRemoveAgent, squadSetLead, squadSetQA, squadTaskReviews, skillList, skillInstall, skillRemove, skillSearch, configUpdate, checkUpdate, shell, fileOps, bash, readFile, viewTool, grepTool, strReplaceEditor, github];
 }
 
 function walkDirectory(dir: string, maxDepth = 3, depth = 0): string[] {

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -78,6 +78,16 @@ export function getDb(): BetterSqlite3.Database {
       UNIQUE(squad_slug, character_name)
     )`,
     `ALTER TABLE squad_agents ADD COLUMN is_lead INTEGER NOT NULL DEFAULT 0`,
+    `ALTER TABLE squad_agents ADD COLUMN is_qa INTEGER NOT NULL DEFAULT 0`,
+    `CREATE TABLE IF NOT EXISTS squad_task_reviews (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id TEXT NOT NULL,
+      squad_slug TEXT NOT NULL,
+      reviewer_character TEXT NOT NULL,
+      approved INTEGER NOT NULL DEFAULT 0,
+      comments TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )`,
   ];
 
   for (const migration of migrations) {

--- a/src/store/squads.ts
+++ b/src/store/squads.ts
@@ -26,6 +26,7 @@ export interface SquadAgent {
   copilot_session_id: string | null;
   status: string;
   is_lead: number;
+  is_qa: number;
   created_at: string;
 }
 
@@ -258,4 +259,13 @@ export function getSquadLead(squadSlug: string): SquadAgent | undefined {
       "SELECT * FROM squad_agents WHERE squad_slug = ? AND is_lead = 1 LIMIT 1",
     )
     .get(squadSlug) as SquadAgent | undefined;
+}
+
+
+export function setSquadQA(squadSlug: string, characterName: string, isQA: boolean): void {
+  getDb()
+    .prepare(
+      "UPDATE squad_agents SET is_qa = ? WHERE squad_slug = ? AND character_name = ?",
+    )
+    .run(isQA ? 1 : 0, squadSlug, characterName);
 }

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -75,3 +75,39 @@ export function listRecentTasks(limit = 50): AgentTask[] {
     )
     .all(limit) as AgentTask[];
 }
+
+export interface TaskReview {
+  id: number;
+  task_id: string;
+  squad_slug: string;
+  reviewer_character: string;
+  approved: number;
+  comments: string | null;
+  created_at: string;
+}
+
+export function createReview(
+  taskId: string,
+  squadSlug: string,
+  reviewerCharacter: string,
+  approved: boolean,
+  comments?: string,
+): TaskReview {
+  const db = getDb();
+  const info = db
+    .prepare(
+      "INSERT INTO squad_task_reviews (task_id, squad_slug, reviewer_character, approved, comments) VALUES (?, ?, ?, ?, ?)",
+    )
+    .run(taskId, squadSlug, reviewerCharacter, approved ? 1 : 0, comments ?? null);
+  return db
+    .prepare("SELECT * FROM squad_task_reviews WHERE id = ?")
+    .get(info.lastInsertRowid) as TaskReview;
+}
+
+export function getTaskReviews(taskId: string): TaskReview[] {
+  return getDb()
+    .prepare(
+      "SELECT * FROM squad_task_reviews WHERE task_id = ? ORDER BY created_at ASC, id ASC",
+    )
+    .all(taskId) as TaskReview[];
+}


### PR DESCRIPTION
Closes #27

## What

After an agent finishes a task, every other squad member reviews the work and votes APPROVED / REJECTED with comments. QA-flagged agents have veto power over promoting a PR from draft to ready.

## Changes

- **DB**: `is_qa` column on `squad_agents` and new `squad_task_reviews` table (migrations)
- **Store**:
  - `squads.ts`: `SquadAgent.is_qa` + `setSquadQA`
  - `tasks.ts`: `TaskReview` interface + `createReview` / `getTaskReviews`
- **Review phase** (`agents.ts` → `runPeerReview`): runs after `completeTask` and before `onComplete`. For each non-original squad agent: open their session, ask for an APPROVED/REJECTED verdict + comments, persist via `createReview`, and emit a `task.review` event for the live preview stream. Wrapped in try/catch — review errors never break the underlying task.
- **PR promotion**: if any QA agent rejects → leave draft (emit `task.review_complete` with reason "QA veto"). Otherwise, if a `https://github.com/owner/repo/pull/N` URL appears in the task result, run `gh pr ready N --repo owner/repo` to promote it.
- **Tools**:
  - `squad_set_qa` — designate / unflag QA reviewers
  - `squad_task_reviews` — inspect reviews for any completed task
  - `squad_agents` output now shows `⭐ [LEAD]` and `🛡️ [QA]` badges
- **System message** documents the workflow and QA veto power.

## Behavior notes

- Solo-agent squads skip review silently (no `task.review_complete` reviewer pool).
- Non-QA rejections are advisory — they're persisted and emitted, but they do not block PR promotion.
- If no PR URL is found in the result, `task.review_complete` emits with `promoted: false, reason: "No PR URL found..."`.

## Verified

- `npm run build` (tsc) ✅
- `web && vite build` ✅

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>