### PR TITLE
fix: orchestrator delegates squad work to team leads

### DIFF
--- a/src/copilot/orchestrator.ts
+++ b/src/copilot/orchestrator.ts
@@ -158,6 +158,30 @@ function toolFingerprint(tools: SessionConfig["tools"]): string {
   return crypto.createHash("sha256").update(`${IO_VERSION}:${names}`).digest("hex").slice(0, 16);
 }
 
+function buildSquadRoster(): string {
+  const squads = listSquads();
+  if (squads.length === 0) return "";
+  return squads
+    .map((s) => {
+      const agents = listSquadAgents(s.slug);
+      const lead = agents.find((a) => a.is_lead === 1);
+      const agentList = agents
+        .map((a) => {
+          const badges = [
+            a.is_lead === 1 ? "⭐ LEAD" : "",
+            a.is_qa === 1 ? "🛡️ QA" : "",
+          ]
+            .filter(Boolean)
+            .join(", ");
+          return `  - ${a.character_name} (${a.role_title})${badges ? ` [${badges}]` : ""}`;
+        })
+        .join("\n");
+      const leadLine = lead ? `\nTeam Lead: ${lead.character_name}` : "";
+      return `**${s.name}** (\`${s.slug}\`) — ${s.status}\n📁 ${s.project_path}${leadLine}\n${agentList || "  _(no agents yet)_"}`;
+    })
+    .join("\n\n");
+}
+
 function buildFullSessionConfig(): SessionConfig {
   const { tools, skillDirectories } = getSessionConfig();
   return {
@@ -168,6 +192,7 @@ function buildFullSessionConfig(): SessionConfig {
       content: getOrchestratorSystemMessage({
         selfEditEnabled: config.selfEditEnabled,
         memorySummary: getWikiSummary() || undefined,
+        squadRoster: buildSquadRoster() || undefined,
       }),
     },
     tools,

--- a/src/copilot/system-message.ts
+++ b/src/copilot/system-message.ts
@@ -27,8 +27,8 @@ This restriction does NOT apply to:
 `;
 
   const squadBlock = opts?.squadRoster
-    ? `\n### Active Squads\n${opts.squadRoster}\n`
-    : "";
+    ? `\n## Active Squads\nThe following squads are available. Route relevant coding requests directly to them.\n\n${opts.squadRoster}\n`
+    : `\n## Active Squads\nNo squads created yet. Use \`squad_create\` to set up a project squad.\n`;
 
   const osName = process.platform === "darwin" ? "macOS"
     : process.platform === "win32" ? "Windows"
@@ -58,12 +58,22 @@ When no source tag is present, assume TUI.
 
 ## Your Role
 
-You receive messages and decide how to handle them:
+You receive messages and decide how to handle them based on a strict routing priority:
 
-- **Direct answer**: For simple questions, general knowledge, status checks — answer directly.
-- **Use tools**: For tasks requiring shell access, file operations, web lookups — use your tools.
-- **Create/delegate to squad**: For coding projects that need persistent context — create a squad with specialized agents.
-- **Use a skill**: If you have a skill for the task, use it.
+### 1. Squad routing (highest priority)
+If **active squads are listed below** and the request is clearly related to one of those projects (coding tasks, bugs, features, issues, PRs, architecture), **delegate immediately to that squad's team lead** using \`squad_delegate\` — do NOT plan the work yourself, do NOT break it into subtasks. Just pass the full request to the lead and let the team handle it internally.
+
+- The team lead will plan and delegate internally to teammates.
+- You do not need to understand the full scope of the work — the lead does.
+- Multiple squads? Pick the one whose \`project_path\` / name best matches the request.
+
+### 2. Direct tools (medium priority)
+For tasks that require shell access, file operations, web lookups, or knowledge base updates — and that are NOT squad project work — use your tools directly. Use a skill if one is available for the task.
+
+### 3. Direct answer (lowest priority)
+For general questions, conversation, status checks, or anything outside the scope of a squad's project — answer directly.
+
+> **Rule**: If a squad exists that covers the topic, always delegate. Never plan or implement squad work yourself.
 ${squadBlock}
 ## Squad System
 
@@ -81,14 +91,12 @@ Squads are persistent project teams with **named specialist agents**. Each squad
 - Check overall status with \`squad_status\`.
 
 ### Delegating Work
-After planning tasks with the user, **use \`squad_delegate\` to send each task to the right agent**:
-1. Plan the work with the user (break into concrete tasks).
-2. Call \`squad_delegate\` with the squad slug and task. Optionally specify an \`agent\` (character name) to target a specific specialist. **If omitted, the task routes to the squad's team lead** (if one is designated); the lead will then orchestrate the work, divvying subtasks to teammates via their \`delegate_to_teammate\` tool and synthesizing the results. If no lead is set, the system falls back to the first idle agent.
-3. The agent works autonomously in the background with their specialized system prompt.
-4. Use \`squad_task_status\` to check progress and retrieve results.
-5. Report results back to the user, mentioning the character name.
+**Do not plan squad work yourself.** When a squad-relevant request arrives:
+1. Call \`squad_delegate\` with the squad slug and the full request (as-is from the user). Do NOT specify an agent — let it route to the team lead automatically.
+2. The team lead breaks it down and delegates to teammates internally via \`delegate_to_teammate\`. If no lead is designated, the system falls back to the first idle agent.
+3. Use \`squad_task_status\` to monitor progress and report results back to the user.
 
-You can delegate multiple tasks to different agents in parallel.
+Only specify an \`agent\` when the user **explicitly asks** to target a specific squad member by name.
 
 ### Team Leads
 Every squad should have a **team lead**. After building the team with \`squad_add_agent\`, designate one agent as the lead using \`squad_set_lead\`. The lead receives delegated tasks (when no specific agent is targeted), breaks them into subtasks, and assigns work to teammates via the lead-only \`delegate_to_teammate\` tool. This keeps coordination inside the squad rather than forcing IO to micro-manage assignments.


### PR DESCRIPTION
Closes #36

## What

The orchestrator (IO) was planning and decomposing squad work itself before delegating piecemeal. Now it hands the **full request** to the squad's team lead and lets the team plan internally.

## Changes

- **`orchestrator.ts`**: `buildSquadRoster()` reads the live DB on every session-config build and renders each squad's status, project path, team lead, and roster (with `⭐ LEAD` / `🛡️ QA` badges). The roster is passed into `getOrchestratorSystemMessage` as `squadRoster`, so IO always sees the current state.
- **`system-message.ts`**:
  - Rewrote **Your Role** into a strict 3-tier routing priority:
    1. **Squad routing (highest)** — if a squad covers the topic, `squad_delegate` it immediately; do NOT plan or implement squad work yourself.
    2. **Direct tools (medium)** — shell, files, wiki, web lookups, skills.
    3. **Direct answer (lowest)** — general questions / status / conversation.
  - Rewrote **Delegating Work**: pass the full user request as-is, do NOT specify an agent (let it route to the lead), monitor with `squad_task_status`.
  - **Active Squads** block now always renders — shows the empty state ("No squads created yet…") instead of being hidden, so IO is always aware.

## Compatibility

Pure behavioral guidance + extra context — no runtime logic was changed. Squads without a lead still fall back to first-idle agent via the existing `delegateToAgent` routing.

## Verified

- `npm run build` (tsc) ✅
- `web && vite build` ✅

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>