### PR TITLE
Display model in use when agent is running (#31)

### DIFF
--- a/src/copilot/agents.ts
+++ b/src/copilot/agents.ts
@@ -52,6 +52,7 @@ export interface AgentInfo {
   status: "idle" | "working" | "error";
   currentTask?: string;
   currentTaskId?: string;
+  model?: string;
 }
 
 // Key format: "squadSlug:characterName" for per-agent sessions, "squadSlug" for legacy
@@ -96,6 +97,7 @@ export function getAgentInfo(): AgentInfo[] {
         status: agent?.status === "working" ? "working" : currentTask ? "working" : "idle",
         currentTask,
         currentTaskId,
+        model: agentSessionModels.get(key),
       });
     } else {
       // Legacy generic agent
@@ -107,6 +109,7 @@ export function getAgentInfo(): AgentInfo[] {
         status: currentTask ? "working" : squad?.status === "error" ? "error" : "idle",
         currentTask,
         currentTaskId,
+        model: agentSessionModels.get(key),
       });
     }
   }

--- a/web/src/views/AgentActivityView.vue
+++ b/web/src/views/AgentActivityView.vue
@@ -42,6 +42,13 @@
                   <span v-if="agent.universe" class="text-xs bg-purple-900 text-purple-200 px-2 py-0.5 rounded">
                     🎬 {{ agent.universe }}
                   </span>
+                  <span
+                    v-if="agent.model && agent.status === 'working'"
+                    class="text-xs bg-emerald-900 text-emerald-200 px-2 py-0.5 rounded"
+                    :title="`Model: ${agent.model}`"
+                  >
+                    🧠 {{ agent.model }}
+                  </span>
                 </div>
               </div>
               <span :class="[
@@ -231,6 +238,7 @@ interface Agent {
   status: 'idle' | 'working' | 'error'
   currentTask?: string
   currentTaskId?: string
+  model?: string
 }
 
 interface AgentTask {


### PR DESCRIPTION
Closes #31

## Summary
When an agent is actively working, surface the model it's currently using in the web UI.

## Changes
**Backend (`src/copilot/agents.ts`)**
- Added `model?: string` to `AgentInfo`.
- `getAgentInfo()` now reads from the existing `agentSessionModels` map and includes the resolved model for each agent (both named squad agents and legacy generic agents). This is the same model identifier returned by the model router, so it reflects any per-task tier upgrades.

**Frontend (`web/src/views/AgentActivityView.vue`)**
- Added `model?: string` to the `Agent` interface.
- Added an emerald `🧠 {model}` badge next to the role/universe badges on the agent card. Only rendered when the agent has a cached model and status is `working`, so idle agents stay uncluttered.

## Verification
- `npm run build` (tsc) ✅
- `vue-tsc --noEmit` in `web/` ✅

— Lion-O 🦁