### PR TITLE
Enforce QA reviewer + test engineer roles on squads (#40)

### DIFF
--- a/src/copilot/system-message.ts
+++ b/src/copilot/system-message.ts
@@ -104,11 +104,19 @@ Every squad should have a **team lead**. After building the team with \`squad_ad
 ### Peer Review & QA Approvals
 When an agent finishes a task, the other squad members automatically review the work and vote APPROVED or REJECTED. Reviews are recorded and emitted as \`task.review\` events.
 
-- Designate QA reviewers with \`squad_set_qa\` — typically agents focused on testing, security, or quality.
+- **Required**: every squad must have at least one agent designated as QA via \`squad_set_qa\`, AND at least one agent whose role title implies a testing/quality focus (e.g. role contains "test", "qa", or "quality"). Both can be the same agent.
+- \`squad_status\`, \`squad_agents\`, and \`squad_delegate\` will surface a ⚠️ warning when either is missing. Delegation is not blocked, but you should fix the gap before promoting work.
 - **QA agents have veto power**: if any QA reviewer rejects, the PR stays as a draft.
 - Non-QA rejections are advisory — they're recorded but don't block promotion.
 - When all QA approvals pass (or no QA agents exist) and the task result contains a GitHub PR URL, the PR is automatically promoted from draft to ready via \`gh pr ready\`.
 - Use \`squad_task_reviews\` to inspect the reviews on any completed task.
+
+### Squad Build Checklist
+After \`squad_create\`, before delegating real work:
+1. Add agents with \`squad_add_agent\` (use roles tailored to the project's stack).
+2. Include at least one **test/quality engineer** role (e.g. "Integration Test Engineer", "QA Specialist", "Quality Reviewer").
+3. Designate a team lead with \`squad_set_lead\`.
+4. Designate at least one QA reviewer with \`squad_set_qa\` (often the same agent as the test engineer).
 
 ### Agent Roles Are Dynamic
 **Do NOT use generic roles** like "developer" or "tester". Analyze the project first and create roles that match its actual technology stack. Examples:

--- a/src/copilot/tools.ts
+++ b/src/copilot/tools.ts
@@ -6,6 +6,53 @@ import { join, dirname, resolve, sep } from "path";
 import { homedir } from "os";
 import { UNIVERSES } from "./universes.js";
 
+// ---------------------------------------------------------------------------
+// QA / test coverage heuristics
+//
+// Every squad must have:
+//   1. At least one agent designated as QA (is_qa === 1) - see squad_set_qa.
+//   2. At least one agent whose role title implies a testing/quality focus.
+//
+// These are surfaced as warnings on squad_status, squad_agents, and
+// squad_delegate so users can fix coverage gaps before promoting work.
+// ---------------------------------------------------------------------------
+
+const TEST_ROLE_KEYWORDS = ["test", "qa", "quality", "tester", "sdet", "qe"];
+
+export function roleLooksLikeTesting(roleTitle: string | null | undefined): boolean {
+  if (!roleTitle) return false;
+  const lower = roleTitle.toLowerCase();
+  return TEST_ROLE_KEYWORDS.some((kw) => {
+    const re = new RegExp(`(^|[^a-z])${kw}([^a-z]|$)`);
+    return re.test(lower);
+  });
+}
+
+export interface SquadCoverage {
+  hasQa: boolean;
+  hasTestRole: boolean;
+  missing: string[];
+  warning: string | null;
+}
+
+export function assessSquadCoverage(
+  agents: Array<{ role_title: string; is_qa?: number }>,
+): SquadCoverage {
+  const hasQa = agents.some((a) => a.is_qa === 1);
+  const hasTestRole = agents.some((a) => roleLooksLikeTesting(a.role_title));
+  const missing: string[] = [];
+  if (!hasQa) missing.push("QA reviewer (use squad_set_qa)");
+  if (!hasTestRole) {
+    missing.push(
+      "test/quality engineer (add an agent whose role_title contains 'test', 'qa', or 'quality')",
+    );
+  }
+  const warning = missing.length > 0
+    ? `⚠️ Squad coverage gap: missing ${missing.join(" and ")}.`
+    : null;
+  return { hasQa, hasTestRole, missing, warning };
+}
+
 // Ensure child processes have HOME set (systemd services often don't)
 function shellEnv(): NodeJS.ProcessEnv {
   const env = { ...process.env };
@@ -150,7 +197,9 @@ export function createTools(deps: ToolDeps) {
           const agentList = agents.length > 0
             ? "\n  Agents: " + agents.map((a) => `${a.character_name} (${a.role_title})`).join(", ")
             : "\n  Agents: none — use squad_add_agent to build the team";
-          return `- **${s.name}** (\`${s.slug}\`) — ${s.status} — 🎬 ${universeName}${leadLine}${agentList}\n  📁 ${s.projectPath}`;
+          const coverage = assessSquadCoverage(agents);
+          const coverageLine = coverage.warning ? `\n  ${coverage.warning}` : "";
+          return `- **${s.name}** (\`${s.slug}\`) — ${s.status} — 🎬 ${universeName}${leadLine}${agentList}${coverageLine}\n  📁 ${s.projectPath}`;
         })
         .join("\n");
     },
@@ -192,12 +241,17 @@ export function createTools(deps: ToolDeps) {
     }),
     handler: async ({ slug, task, agent }) => {
       console.error(`[io] squad_delegate called: ${slug}${agent ? ` → ${agent}` : ""} — ${task.slice(0, 100)}…`);
+      const roster = deps.listSquadAgents(slug);
+      const coverage = assessSquadCoverage(roster);
       try {
         const taskId = await deps.delegateToAgent(slug, task, (id, result) => {
           console.error(`[io] Agent task ${id} completed for squad ${slug}`);
         }, agent);
         const agentLabel = agent ? `agent "${agent}" in squad "${slug}"` : `squad "${slug}"`;
-        return `Task delegated to ${agentLabel}. Task ID: ${taskId}\n\nThe agent is working on this in the background. Use squad_task_status to check progress.`;
+        const warningPrefix = coverage.warning
+          ? `${coverage.warning} Reviews from this squad will not be vetoed by a designated QA agent until this is fixed.\n\n`
+          : "";
+        return `${warningPrefix}Task delegated to ${agentLabel}. Task ID: ${taskId}\n\nThe agent is working on this in the background. Use squad_task_status to check progress.`;
       } catch (err) {
         return `Error delegating task: ${err instanceof Error ? err.message : String(err)}`;
       }
@@ -430,7 +484,9 @@ export function createTools(deps: ToolDeps) {
         return `- **${a.character_name}**${leadBadge}${qaBadge} — ${a.role_title} (${a.model_tier}) — ${a.status}${a.personality ? `\n  _${a.personality}_` : ""}`;
       });
 
-      return `**${squad.name}** — 🎬 ${universeName}\n\n${lines.join("\n")}`;
+      const coverage = assessSquadCoverage(agents);
+      const coverageBlock = coverage.warning ? `\n\n${coverage.warning}` : "";
+      return `**${squad.name}** — 🎬 ${universeName}\n\n${lines.join("\n")}${coverageBlock}`;
     },
   });
 


### PR DESCRIPTION
Closes #40

## Summary
Squads previously required a team lead but had no equivalent enforcement for **QA reviewers** or **testing-focused agents**. This PR mirrors the lead pattern by surfacing non-blocking warnings everywhere a user interacts with squad composition or delegation.

## Approach
The lead requirement isn't "blocked" today either — `squad_set_lead` exposes the affordance and `getSquadLead` falls back to the first idle agent during delegation. Same posture here: warn loudly, don't block, so users can fix the gap without tools failing mid-flow.

## Changes
**`src/copilot/tools.ts`**
- New `roleLooksLikeTesting(roleTitle)` — token-aware check (regex with non-letter boundaries) for `test`, `qa`, `quality`, `tester`, `sdet`, `qe`. Avoids false positives like "latest" or "equality".
- New `assessSquadCoverage(agents)` returning `{ hasQa, hasTestRole, missing[], warning }`. A squad is covered iff it has at least one `is_qa === 1` agent AND at least one agent whose role title matches a testing keyword.
- `squad_status` appends a ⚠️ line per squad when coverage is incomplete.
- `squad_agents` appends a ⚠️ block after the roster.
- `squad_delegate` prefixes its success response with the warning so the user sees the gap before the task runs.

**`src/copilot/system-message.ts`**
- QA section now states the requirement explicitly: every squad must have at least one `squad_set_qa` agent AND at least one agent with a testing/quality role.
- New "Squad Build Checklist" listing the post-`squad_create` steps in order.

## Verification
- `npm run build` (tsc) ✅
- Smoke-tested helpers via node:
  - `roleLooksLikeTesting('Latest News Reporter')` → `false`
  - `roleLooksLikeTesting('Integration Test Engineer')` → `true`
  - `roleLooksLikeTesting('QA Specialist')` → `true`
  - `assessSquadCoverage([{role_title:'QA Engineer', is_qa:1}]).warning` → `null`
  - `assessSquadCoverage([{role_title:'QA Engineer', is_qa:0}]).warning` → missing QA reviewer

— Lion-O 🦁