### PR TITLE
Scheduled stand-ups for squads (#26)

### DIFF
--- a/src/copilot/cron.ts
+++ b/src/copilot/cron.ts
@@ -1,0 +1,148 @@
+// Minimal standard 5-field cron parser + next-run calculator.
+//
+// Fields (in order): minute, hour, day-of-month, month, day-of-week.
+// Supported syntax per field:
+//   *           — all values
+//   N           — single value
+//   A,B,C       — list
+//   A-B         — range
+//   A-B/N or */N — step (A-B/N restricts to range; */N applies to full range)
+//
+// Day-of-week: 0 or 7 = Sunday, 1 = Monday … (standard Unix cron).
+//
+// Matching semantics: when both day-of-month and day-of-week are restricted
+// (i.e. neither is "*"), Vixie cron uses an OR between them — we follow that.
+
+interface CronExpr {
+  minutes: Set<number>;
+  hours: Set<number>;
+  doms: Set<number>;
+  months: Set<number>;
+  dows: Set<number>;
+  domStar: boolean;
+  dowStar: boolean;
+}
+
+const FIELD_RANGES: Array<[number, number]> = [
+  [0, 59],
+  [0, 23],
+  [1, 31],
+  [1, 12],
+  [0, 7],
+];
+
+function parseField(raw: string, [min, max]: [number, number]): Set<number> {
+  const out = new Set<number>();
+  for (const part of raw.split(",")) {
+    const stepMatch = part.match(/^(.+?)\/(\d+)$/);
+    const body = stepMatch ? stepMatch[1] : part;
+    const step = stepMatch ? parseInt(stepMatch[2], 10) : 1;
+    if (!(step >= 1)) throw new Error(`Invalid step in cron field: "${part}"`);
+
+    let lo: number, hi: number;
+    if (body === "*") {
+      lo = min;
+      hi = max;
+    } else if (body.includes("-")) {
+      const [a, b] = body.split("-").map((n) => parseInt(n, 10));
+      if (Number.isNaN(a) || Number.isNaN(b)) {
+        throw new Error(`Invalid range in cron field: "${part}"`);
+      }
+      lo = a;
+      hi = b;
+    } else {
+      const v = parseInt(body, 10);
+      if (Number.isNaN(v)) throw new Error(`Invalid cron field value: "${part}"`);
+      lo = v;
+      hi = v;
+    }
+    if (lo < min || hi > max || lo > hi) {
+      throw new Error(`Cron field out of range [${min}-${max}]: "${part}"`);
+    }
+    for (let v = lo; v <= hi; v += step) out.add(v);
+  }
+  return out;
+}
+
+export function parseCron(expr: string): CronExpr {
+  const trimmed = expr.trim().replace(/\s+/g, " ");
+  const parts = trimmed.split(" ");
+  if (parts.length !== 5) {
+    throw new Error(
+      `Cron expression must have 5 fields (minute hour dom month dow), got ${parts.length}: "${expr}"`,
+    );
+  }
+  const [mRaw, hRaw, domRaw, monRaw, dowRaw] = parts;
+  const minutes = parseField(mRaw, FIELD_RANGES[0]);
+  const hours = parseField(hRaw, FIELD_RANGES[1]);
+  const doms = parseField(domRaw, FIELD_RANGES[2]);
+  const months = parseField(monRaw, FIELD_RANGES[3]);
+  const dowsRaw = parseField(dowRaw, FIELD_RANGES[4]);
+  const dows = new Set<number>();
+  for (const v of dowsRaw) dows.add(v === 7 ? 0 : v);
+
+  return {
+    minutes,
+    hours,
+    doms,
+    months,
+    dows,
+    domStar: domRaw === "*",
+    dowStar: dowRaw === "*",
+  };
+}
+
+/**
+ * Return the next Date strictly after `after` that matches the cron expression.
+ * Iterates minute-by-minute with month/day fast-forwarding. Capped at ~5
+ * years lookahead to guard against unsatisfiable expressions.
+ */
+export function nextRun(expr: string | CronExpr, after: Date = new Date()): Date {
+  const c = typeof expr === "string" ? parseCron(expr) : expr;
+  const cursor = new Date(after.getTime());
+  cursor.setSeconds(0, 0);
+  cursor.setMinutes(cursor.getMinutes() + 1);
+
+  const limit = new Date(after.getTime() + 5 * 366 * 24 * 60 * 60 * 1000);
+  while (cursor <= limit) {
+    const month = cursor.getMonth() + 1;
+    if (!c.months.has(month)) {
+      cursor.setMonth(cursor.getMonth() + 1, 1);
+      cursor.setHours(0, 0, 0, 0);
+      continue;
+    }
+    const dom = cursor.getDate();
+    const dow = cursor.getDay();
+    const dayOk = c.domStar && c.dowStar
+      ? true
+      : c.domStar
+        ? c.dows.has(dow)
+        : c.dowStar
+          ? c.doms.has(dom)
+          : c.doms.has(dom) || c.dows.has(dow);
+    if (!dayOk) {
+      cursor.setDate(cursor.getDate() + 1);
+      cursor.setHours(0, 0, 0, 0);
+      continue;
+    }
+    if (!c.hours.has(cursor.getHours())) {
+      cursor.setHours(cursor.getHours() + 1, 0, 0, 0);
+      continue;
+    }
+    if (!c.minutes.has(cursor.getMinutes())) {
+      cursor.setMinutes(cursor.getMinutes() + 1, 0, 0);
+      continue;
+    }
+    return cursor;
+  }
+  throw new Error(`No next run found within 5 years for cron expression`);
+}
+
+export function validateCron(expr: string): { ok: true; next: Date } | { ok: false; error: string } {
+  try {
+    const next = nextRun(expr);
+    return { ok: true, next };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/src/copilot/scheduler.ts
+++ b/src/copilot/scheduler.ts
@@ -1,0 +1,155 @@
+// Squad scheduler — fires recurring "stand-up" meetings on a cron schedule.
+//
+// Design:
+//   - Runs as a single setInterval on the daemon (TICK_MS).
+//   - Each tick: fetch schedules whose next_run_at is in the past.
+//   - For each due schedule: compose a stand-up prompt and delegate it to the
+//     squad lead via the existing delegateToAgent() pipeline. The lead then
+//     orchestrates the agenda by delegating subtasks to teammates internally.
+//   - After firing, advance next_run_at to the next cron occurrence.
+//
+// Schedules survive daemon restarts because next_run_at is persisted. On
+// startup we backfill any next_run_at fields that became stale (or are NULL).
+
+import { listSchedules, listDueSchedules, recordScheduleRun, updateNextRun, type SquadSchedule } from "../store/schedules.js";
+import { getSquad } from "../store/squads.js";
+import { delegateToAgent } from "./agents.js";
+import { nextRun } from "./cron.js";
+
+const TICK_MS = 30_000;
+
+const AGENDA_BLOCKS: Record<string, string> = {
+  triage: `**Triage**
+- Use the GitHub CLI (\`gh issue list\`) to pull open issues with the \`needs-triage\` label.
+- For each issue: read the body and decide on appropriate labels (priority, area, type, etc).
+- Apply labels with \`gh issue edit <num> --add-label "..."\` and remove \`needs-triage\` once labelled.
+- If the issue lacks information, post a clarifying comment with \`gh issue comment\` instead of labelling, and leave \`needs-triage\` on it.`,
+  prioritize: `**Prioritize**
+- Identify open issues that are ready to be worked on: properly labelled, not blocked, no \`needs-triage\` or \`needs-review\` label, no open PR already addressing them.
+- Rank by priority labels and surface the top candidate.
+- After the stand-up, the team lead should immediately begin work on the highest-priority ready issue by delegating it to the right teammate.`,
+  ideation: `**Ideation**
+- Brainstorm 1–3 concrete improvements or new features for the project.
+- Discuss as a team (use \`delegate_to_teammate\` to gather input from members whose expertise fits the idea).
+- For each idea the team agrees on, create a GitHub issue with \`gh issue create\` tagged with the \`needs-review\` label so the human can approve it before work begins.`,
+};
+
+function buildStandupPrompt(squad: { name: string; slug: string; project_path: string }, schedule: SquadSchedule): string {
+  const blocks = schedule.agenda
+    .map((item) => AGENDA_BLOCKS[item] ?? `**${item}** _(no built-in template — improvise)_`)
+    .join("\n\n");
+  const notes = schedule.notes ? `\n\n**Operator notes:** ${schedule.notes}` : "";
+  return `# Scheduled stand-up: ${schedule.name}
+
+You are the team lead for the **${squad.name}** squad (\`${squad.slug}\`). Run a stand-up meeting now.
+
+**Project path:** \`${squad.project_path}\` — \`cd\` here before invoking the GitHub CLI so it picks up the right repo.
+
+**Agenda** (work through these in order; use \`delegate_to_teammate\` to pull in the right specialist for each item):
+
+${blocks}
+
+When you finish the agenda, summarise what was triaged, what was prioritised (and what work you've kicked off), and what new issues were filed during ideation.${notes}`;
+}
+
+let timer: ReturnType<typeof setInterval> | undefined;
+const inFlight = new Set<number>();
+
+async function fireSchedule(schedule: SquadSchedule): Promise<void> {
+  if (inFlight.has(schedule.id)) return;
+  const squad = getSquad(schedule.squad_slug);
+  if (!squad) {
+    console.error(`[io] scheduler: squad "${schedule.squad_slug}" missing for schedule ${schedule.id}; disabling next_run_at`);
+    updateNextRun(schedule.id, null);
+    return;
+  }
+  inFlight.add(schedule.id);
+  const ranAt = new Date();
+  let nextIso: string | null = null;
+  try {
+    nextIso = nextRun(schedule.cron_expr, ranAt).toISOString();
+  } catch (err) {
+    console.error(`[io] scheduler: cron parse error for schedule ${schedule.id}:`, err instanceof Error ? err.message : err);
+  }
+  recordScheduleRun(schedule.id, ranAt, nextIso);
+
+  const prompt = buildStandupPrompt(
+    { name: squad.name, slug: squad.slug, project_path: squad.project_path },
+    schedule,
+  );
+  console.log(`[io] scheduler: firing schedule "${schedule.name}" for squad "${squad.slug}" (next run: ${nextIso ?? "never"})`);
+  try {
+    await delegateToAgent(squad.slug, prompt, () => {
+      // No-op: result is recorded on the agent task; the standup is fire-and-forget.
+    });
+  } catch (err) {
+    console.error(`[io] scheduler: failed to delegate stand-up for schedule ${schedule.id}:`, err instanceof Error ? err.message : err);
+  } finally {
+    inFlight.delete(schedule.id);
+  }
+}
+
+async function tick(): Promise<void> {
+  let due: SquadSchedule[];
+  try {
+    due = listDueSchedules(new Date());
+  } catch (err) {
+    console.error("[io] scheduler tick failed:", err instanceof Error ? err.message : err);
+    return;
+  }
+  for (const s of due) {
+    // Sequential — avoid stampeding multiple stand-ups simultaneously.
+    await fireSchedule(s);
+  }
+}
+
+/**
+ * Backfill next_run_at for any schedules where it's NULL or already in the past
+ * but should not have fired (e.g. daemon was offline). We deliberately advance
+ * to the next future occurrence rather than replaying missed runs.
+ */
+export function reconcileSchedules(now: Date = new Date()): void {
+  for (const s of listSchedules()) {
+    if (!s.enabled) continue;
+    let needsUpdate = false;
+    if (!s.next_run_at) {
+      needsUpdate = true;
+    } else {
+      const next = new Date(s.next_run_at);
+      if (Number.isNaN(next.getTime()) || next <= now) needsUpdate = true;
+    }
+    if (!needsUpdate) continue;
+    try {
+      const next = nextRun(s.cron_expr, now);
+      updateNextRun(s.id, next.toISOString());
+    } catch (err) {
+      console.error(`[io] scheduler: invalid cron "${s.cron_expr}" on schedule ${s.id}; disabling next_run_at:`, err instanceof Error ? err.message : err);
+      updateNextRun(s.id, null);
+    }
+  }
+}
+
+export function startScheduler(): void {
+  if (timer) return;
+  reconcileSchedules();
+  timer = setInterval(() => {
+    void tick();
+  }, TICK_MS);
+  if (typeof timer.unref === "function") timer.unref();
+  console.log(`[io] Scheduler started (tick every ${TICK_MS / 1000}s)`);
+}
+
+export function stopScheduler(): void {
+  if (!timer) return;
+  clearInterval(timer);
+  timer = undefined;
+}
+
+/** Manually fire a schedule. Used by squad_schedule_run_now. */
+export async function runScheduleNow(scheduleId: number): Promise<{ ok: boolean; error?: string }> {
+  const all = listSchedules();
+  const s = all.find((x) => x.id === scheduleId);
+  if (!s) return { ok: false, error: `Schedule ${scheduleId} not found` };
+  await fireSchedule(s);
+  return { ok: true };
+}

--- a/src/copilot/system-message.ts
+++ b/src/copilot/system-message.ts
@@ -118,6 +118,15 @@ After \`squad_create\`, before delegating real work:
 3. Designate a team lead with \`squad_set_lead\`.
 4. Designate at least one QA reviewer with \`squad_set_qa\` (often the same agent as the test engineer).
 
+### Scheduled Stand-ups
+Squads can be put on a recurring cron-style schedule. At the scheduled time IO wakes the team lead, who runs the agenda by delegating to teammates. This runs in the background even when no human is in the TUI/Telegram.
+
+- \`squad_schedule_create\` — create a recurring stand-up. Cron uses standard 5-field syntax: "minute hour day-of-month month day-of-week". Examples: \`0 5 * * *\` (daily 5AM), \`0 9 * * 1-5\` (9AM weekdays), \`30 14 * * 1\` (Mondays 14:30).
+- Built-in agenda items: \`triage\` (process \`needs-triage\` issues), \`prioritize\` (pick highest-priority ready work and start on it), \`ideation\` (brainstorm and open \`needs-review\` issues for the human). Custom items are passed verbatim to the lead.
+- \`squad_schedule_list\`, \`squad_schedule_pause\`, \`squad_schedule_resume\`, \`squad_schedule_delete\`, \`squad_schedule_run_now\` round out the lifecycle.
+
+When a user asks something like "have the IO squad meet every weekday at 5AM to triage and prioritize", call \`squad_schedule_create\` with \`cron: "0 5 * * 1-5"\` and \`agenda: ["triage", "prioritize"]\`.
+
 ### Agent Roles Are Dynamic
 **Do NOT use generic roles** like "developer" or "tester". Analyze the project first and create roles that match its actual technology stack. Examples:
 - IO project → "Copilot SDK Specialist", "Vue.js Frontend Dev", "Express API Engineer"

--- a/src/copilot/tools.ts
+++ b/src/copilot/tools.ts
@@ -5,6 +5,15 @@ import { readFileSync, writeFileSync, readdirSync, statSync, existsSync, mkdirSy
 import { join, dirname, resolve, sep } from "path";
 import { homedir } from "os";
 import { UNIVERSES } from "./universes.js";
+import { validateCron, nextRun } from "./cron.js";
+import {
+  createSchedule,
+  deleteSchedule,
+  getSchedule,
+  listSchedules,
+  setScheduleEnabled,
+} from "../store/schedules.js";
+import { runScheduleNow } from "./scheduler.js";
 
 // ---------------------------------------------------------------------------
 // QA / test coverage heuristics
@@ -1141,7 +1150,141 @@ export function createTools(deps: ToolDeps) {
     },
   });
 
-  return [wikiRead, wikiWrite, wikiSearch, wikiDelete, wikiList, squadCreate, squadRecall, squadStatus, squadLogDecision, squadDelegate, squadTaskStatus, squadDelete, squadAnalyze, squadAddAgent, squadAgents, squadRemoveAgent, squadSetLead, squadSetQA, squadTaskReviews, skillList, skillInstall, skillRemove, skillSearch, configUpdate, checkUpdate, shell, fileOps, bash, readFile, viewTool, grepTool, strReplaceEditor, github];
+
+  // ---------------------------------------------------------------------------
+  // Squad schedules — recurring stand-ups via cron-style expressions.
+  // ---------------------------------------------------------------------------
+
+  const KNOWN_AGENDA_ITEMS = ["triage", "prioritize", "ideation"] as const;
+
+  const squadScheduleCreate = defineTool("squad_schedule_create", {
+    description:
+      "Schedule a recurring stand-up for a squad. The squad wakes on the cron schedule, the team lead runs the agenda, and teammates are pulled in via delegate_to_teammate. Built-in agenda items: triage (process needs-triage issues), prioritize (pick highest-priority ready work and start it), ideation (brainstorm + open needs-review issues). Custom agenda items are passed through to the lead verbatim.",
+    skipPermission: true,
+    parameters: z.object({
+      slug: z.string().describe("Squad slug to schedule"),
+      name: z
+        .string()
+        .describe("Human-friendly name for this schedule, e.g. 'Daily 5AM stand-up'"),
+      cron: z
+        .string()
+        .describe(
+          "Standard 5-field cron expression: 'minute hour dom month dow'. Examples: '0 5 * * *' = daily at 5:00, '0 9 * * 1-5' = 9AM weekdays, '*/15 * * * *' = every 15 minutes.",
+        ),
+      agenda: z
+        .array(z.string())
+        .min(1)
+        .describe(
+          `Ordered agenda. Built-in items: ${KNOWN_AGENDA_ITEMS.join(", ")}. You may include custom items; the team lead will improvise.`,
+        ),
+      notes: z
+        .string()
+        .optional()
+        .describe("Optional operator notes appended to the stand-up prompt."),
+    }),
+    handler: async ({ slug, name, cron, agenda, notes }) => {
+      const squad = deps.getSquad(slug);
+      if (!squad) return `Squad not found: ${slug}`;
+      const v = validateCron(cron);
+      if (!v.ok) return `Invalid cron expression: ${v.error}`;
+      const created = createSchedule({
+        squadSlug: slug,
+        name,
+        cronExpr: cron,
+        agenda,
+        notes: notes ?? null,
+        nextRunAt: v.next.toISOString(),
+      });
+      return `📅 Scheduled "${created.name}" for squad "${squad.name}" (id ${created.id}).\n- Cron: \`${cron}\`\n- Agenda: ${agenda.join(", ")}\n- Next run: ${v.next.toISOString()}`;
+    },
+  });
+
+  const squadScheduleList = defineTool("squad_schedule_list", {
+    description:
+      "List squad stand-up schedules. Pass a slug to filter to one squad, or omit to list all.",
+    skipPermission: true,
+    parameters: z.object({
+      slug: z.string().optional().describe("Optional squad slug to filter"),
+    }),
+    handler: async ({ slug }) => {
+      const schedules = listSchedules(slug);
+      if (schedules.length === 0) {
+        return slug
+          ? `No schedules for squad "${slug}".`
+          : "No squad schedules configured.";
+      }
+      return schedules
+        .map((s) => {
+          const enabled = s.enabled ? "▶️ enabled" : "⏸️ paused";
+          const last = s.last_run_at ? `last ${s.last_run_at}` : "never run";
+          const next = s.next_run_at ?? "—";
+          return `- **${s.name}** (id ${s.id}) — squad \`${s.squad_slug}\` — ${enabled}\n    cron: \`${s.cron_expr}\` — agenda: ${s.agenda.join(", ")}\n    next: ${next} — ${last}${s.notes ? `\n    notes: ${s.notes}` : ""}`;
+        })
+        .join("\n");
+    },
+  });
+
+  const squadScheduleDelete = defineTool("squad_schedule_delete", {
+    description: "Delete a squad schedule by id.",
+    skipPermission: true,
+    parameters: z.object({
+      id: z.number().int().describe("Schedule id (from squad_schedule_list)"),
+    }),
+    handler: async ({ id }) => {
+      const existing = getSchedule(id);
+      if (!existing) return `Schedule ${id} not found.`;
+      deleteSchedule(id);
+      return `🗑️ Deleted schedule "${existing.name}" (id ${id}).`;
+    },
+  });
+
+  const squadSchedulePause = defineTool("squad_schedule_pause", {
+    description: "Pause a squad schedule so it stops firing (preserves config).",
+    skipPermission: true,
+    parameters: z.object({ id: z.number().int().describe("Schedule id") }),
+    handler: async ({ id }) => {
+      const existing = getSchedule(id);
+      if (!existing) return `Schedule ${id} not found.`;
+      setScheduleEnabled(id, false);
+      return `⏸️ Paused schedule "${existing.name}" (id ${id}).`;
+    },
+  });
+
+  const squadScheduleResume = defineTool("squad_schedule_resume", {
+    description:
+      "Resume a paused squad schedule. The next run is computed from now using the stored cron expression.",
+    skipPermission: true,
+    parameters: z.object({ id: z.number().int().describe("Schedule id") }),
+    handler: async ({ id }) => {
+      const existing = getSchedule(id);
+      if (!existing) return `Schedule ${id} not found.`;
+      setScheduleEnabled(id, true);
+      try {
+        const next = nextRun(existing.cron_expr);
+        // Update next_run_at via the store's helper would be cleaner, but we
+        // can also just re-run reconcile on next tick. Inline update:
+        const { updateNextRun } = await import("../store/schedules.js");
+        updateNextRun(id, next.toISOString());
+        return `▶️ Resumed schedule "${existing.name}" (id ${id}). Next run: ${next.toISOString()}`;
+      } catch (err) {
+        return `Resumed schedule "${existing.name}" but failed to compute next run: ${err instanceof Error ? err.message : String(err)}`;
+      }
+    },
+  });
+
+  const squadScheduleRunNow = defineTool("squad_schedule_run_now", {
+    description:
+      "Manually fire a squad schedule immediately (useful for testing). Does not affect the next scheduled occurrence.",
+    skipPermission: true,
+    parameters: z.object({ id: z.number().int().describe("Schedule id") }),
+    handler: async ({ id }) => {
+      const result = await runScheduleNow(id);
+      if (!result.ok) return `Failed: ${result.error}`;
+      return `🚀 Fired schedule ${id} now. Use squad_task_status to follow the resulting stand-up.`;
+    },
+  });
+
+  return [wikiRead, wikiWrite, wikiSearch, wikiDelete, wikiList, squadCreate, squadRecall, squadStatus, squadLogDecision, squadDelegate, squadTaskStatus, squadDelete, squadAnalyze, squadAddAgent, squadAgents, squadRemoveAgent, squadSetLead, squadSetQA, squadTaskReviews, squadScheduleCreate, squadScheduleList, squadScheduleDelete, squadSchedulePause, squadScheduleResume, squadScheduleRunNow, skillList, skillInstall, skillRemove, skillSearch, configUpdate, checkUpdate, shell, fileOps, bash, readFile, viewTool, grepTool, strReplaceEditor, github];
 }
 
 function walkDirectory(dir: string, maxDepth = 3, depth = 0): string[] {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -4,6 +4,7 @@ import { startApiServer, setMessageHandler as setApiHandler, broadcastToSSE } fr
 import { createBot, startBot, stopBot, sendProactiveMessage, setMessageHandler as setTelegramHandler } from "./telegram/bot.js";
 import { getDb, closeDb } from "./store/db.js";
 import { clearStaleTasks } from "./store/tasks.js";
+import { startScheduler, stopScheduler } from "./copilot/scheduler.js";
 import { config } from "./config.js";
 import { ensureWikiStructure } from "./wiki/fs.js";
 import { autoUpdate } from "./update.js";
@@ -112,6 +113,9 @@ export async function startDaemon(): Promise<void> {
     console.log("[io] Telegram not configured — skipping bot. Set telegramBotToken in ~/.io/config.json");
   }
 
+  // Start the squad scheduler (background cron-style stand-ups).
+  startScheduler();
+
   console.log("[io] IO is fully operational.");
 
   // Notify Telegram if restarting
@@ -142,6 +146,7 @@ async function shutdown(): Promise<void> {
     try { await stopBot(); } catch { /* best effort */ }
   }
 
+  stopScheduler();
   await shutdownOrchestrator();
   try { await stopClient(); } catch { /* best effort */ }
   closeDb();

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -88,6 +88,20 @@ export function getDb(): BetterSqlite3.Database {
       comments TEXT,
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP
     )`,
+    `CREATE TABLE IF NOT EXISTS squad_schedules (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      squad_slug TEXT NOT NULL,
+      name TEXT NOT NULL,
+      cron_expr TEXT NOT NULL,
+      agenda TEXT NOT NULL,
+      notes TEXT,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      last_run_at DATETIME,
+      next_run_at DATETIME,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )`,
+    `CREATE INDEX IF NOT EXISTS idx_squad_schedules_due
+       ON squad_schedules (enabled, next_run_at)`,
   ];
 
   for (const migration of migrations) {

--- a/src/store/schedules.ts
+++ b/src/store/schedules.ts
@@ -1,0 +1,127 @@
+import { getDb } from "./db.js";
+
+export interface SquadSchedule {
+  id: number;
+  squad_slug: string;
+  name: string;
+  cron_expr: string;
+  agenda: string[]; // parsed JSON
+  notes: string | null;
+  enabled: number; // 0 | 1
+  last_run_at: string | null;
+  next_run_at: string | null;
+  created_at: string;
+}
+
+interface ScheduleRow {
+  id: number;
+  squad_slug: string;
+  name: string;
+  cron_expr: string;
+  agenda: string;
+  notes: string | null;
+  enabled: number;
+  last_run_at: string | null;
+  next_run_at: string | null;
+  created_at: string;
+}
+
+function rowToSchedule(row: ScheduleRow): SquadSchedule {
+  let agenda: string[] = [];
+  try {
+    agenda = JSON.parse(row.agenda);
+    if (!Array.isArray(agenda)) agenda = [];
+  } catch {
+    agenda = [];
+  }
+  return { ...row, agenda };
+}
+
+export function createSchedule(input: {
+  squadSlug: string;
+  name: string;
+  cronExpr: string;
+  agenda: string[];
+  notes?: string | null;
+  nextRunAt: string;
+}): SquadSchedule {
+  const db = getDb();
+  const info = db
+    .prepare(
+      `INSERT INTO squad_schedules
+         (squad_slug, name, cron_expr, agenda, notes, enabled, next_run_at)
+       VALUES (?, ?, ?, ?, ?, 1, ?)`,
+    )
+    .run(
+      input.squadSlug,
+      input.name,
+      input.cronExpr,
+      JSON.stringify(input.agenda),
+      input.notes ?? null,
+      input.nextRunAt,
+    );
+  const id = Number(info.lastInsertRowid);
+  return getSchedule(id)!;
+}
+
+export function getSchedule(id: number): SquadSchedule | undefined {
+  const row = getDb()
+    .prepare("SELECT * FROM squad_schedules WHERE id = ?")
+    .get(id) as ScheduleRow | undefined;
+  return row ? rowToSchedule(row) : undefined;
+}
+
+export function listSchedules(squadSlug?: string): SquadSchedule[] {
+  const rows = squadSlug
+    ? (getDb()
+        .prepare(
+          "SELECT * FROM squad_schedules WHERE squad_slug = ? ORDER BY id ASC",
+        )
+        .all(squadSlug) as ScheduleRow[])
+    : (getDb()
+        .prepare("SELECT * FROM squad_schedules ORDER BY squad_slug, id ASC")
+        .all() as ScheduleRow[]);
+  return rows.map(rowToSchedule);
+}
+
+export function listDueSchedules(now: Date): SquadSchedule[] {
+  const iso = now.toISOString();
+  const rows = getDb()
+    .prepare(
+      `SELECT * FROM squad_schedules
+        WHERE enabled = 1
+          AND next_run_at IS NOT NULL
+          AND next_run_at <= ?
+        ORDER BY next_run_at ASC`,
+    )
+    .all(iso) as ScheduleRow[];
+  return rows.map(rowToSchedule);
+}
+
+export function deleteSchedule(id: number): boolean {
+  const info = getDb()
+    .prepare("DELETE FROM squad_schedules WHERE id = ?")
+    .run(id);
+  return info.changes > 0;
+}
+
+export function setScheduleEnabled(id: number, enabled: boolean): boolean {
+  const info = getDb()
+    .prepare("UPDATE squad_schedules SET enabled = ? WHERE id = ?")
+    .run(enabled ? 1 : 0, id);
+  return info.changes > 0;
+}
+
+export function recordScheduleRun(id: number, ranAt: Date, nextRunAt: string | null): void {
+  getDb()
+    .prepare(
+      "UPDATE squad_schedules SET last_run_at = ?, next_run_at = ? WHERE id = ?",
+    )
+    .run(ranAt.toISOString(), nextRunAt, id);
+}
+
+export function updateNextRun(id: number, nextRunAt: string | null): void {
+  getDb()
+    .prepare("UPDATE squad_schedules SET next_run_at = ? WHERE id = ?")
+    .run(nextRunAt, id);
+}


### PR DESCRIPTION
Closes #26

## Summary
Squads can now be put on a recurring cron schedule. At the appointed time the daemon wakes the squad's team lead and runs a stand-up agenda — triage, prioritize, ideate, or any custom items — by handing the whole thing to the existing `delegateToAgent` pipeline so the lead orchestrates teammates with `delegate_to_teammate` exactly as for user-initiated work. Runs in the background regardless of whether the user is in the TUI/Telegram.

## Architecture

### Storage
`squad_schedules` table added via the existing migration list in `src/store/db.ts`:
- `id, squad_slug, name, cron_expr, agenda (JSON), notes, enabled, last_run_at, next_run_at, created_at`
- Indexed on `(enabled, next_run_at)` for cheap due-row lookups every tick.

### Cron parser — `src/copilot/cron.ts`
Hand-rolled minimal but correct standard 5-field parser + `nextRun(after)` calculator. **No new npm dependencies.** Supports:
- `*`, single `N`, lists `A,B,C`, ranges `A-B`, steps `*/N` and `A-B/N`
- Vixie-cron OR semantics when both day-of-month and day-of-week are restricted
- Sunday as both `0` and `7`
- Bounded 5-year lookahead (guards against unsatisfiable expressions)

Verified on:
```
0 5 * * *      → daily 05:00
0 9 * * 1-5    → 09:00 weekdays
*/15 * * * *   → every 15 minutes
30 14 1 * *    → 14:30 on the 1st
0 0 29 2 *     → next Feb 29 (correctly jumps 2026 → 2028)
```

### Scheduler — `src/copilot/scheduler.ts`
- 30s tick driven by `setInterval` (`.unref()` so it doesn't block shutdown).
- Each tick: `listDueSchedules(now)` → for each, `recordScheduleRun` (advances `next_run_at` *before* firing so a long-running stand-up doesn't double-fire) → compose agenda-aware prompt → `delegateToAgent(squadSlug, prompt, …)`.
- `inFlight` Set guards against re-entry on a single schedule.
- `reconcileSchedules()` runs at startup: any `next_run_at` that's `NULL` or in the past is rebased to the next future occurrence — **we deliberately do not replay missed runs** while the daemon was offline.

### Tools — `src/copilot/tools.ts`
- `squad_schedule_create` (slug, name, cron, agenda[], notes?)
- `squad_schedule_list` (slug?)
- `squad_schedule_delete` (id)
- `squad_schedule_pause` (id), `squad_schedule_resume` (id) — pause preserves config; resume recomputes next run from now
- `squad_schedule_run_now` (id) — manual trigger, doesn't affect next scheduled occurrence

### Built-in agenda items
- `triage` — pull `needs-triage` issues with `gh`, label them, request info on under-specified ones
- `prioritize` — find ready work, pick highest priority, start on it after the meeting
- `ideation` — brainstorm features, open `needs-review` GitHub issues for human approval

Custom items are passed verbatim to the lead — they improvise.

### Daemon wiring — `src/daemon.ts`
- `startScheduler()` after orchestrator init
- `stopScheduler()` in graceful shutdown

### System message — `src/copilot/system-message.ts`
New 'Scheduled Stand-ups' section so the user can configure things conversationally — e.g. "have the IO squad meet every weekday at 5AM to triage and prioritize" → `squad_schedule_create({ slug:'io', cron:'0 5 * * 1-5', agenda:['triage','prioritize'] })`.

## Verification
- `npm run build` (tsc) ✅
- Cron next-run calculator tested on 5 representative cases including Feb 29 leap-year jump
- End-to-end store test: create → list → due-window query → pause → confirm no longer due
  ```
  due now: 0
  due in 10d: 1
  after pause due in 10d: 0
  ```

— Lion-O 🦁