### PR TITLE
Tiered human-readable activity log (#42)

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -6,6 +6,7 @@ import { config } from "../config.js";
 import { listSkills } from "../copilot/skills.js";
 import { listSquads, createSquad, listSquadAgents } from "../store/squads.js";
 import { getAgentInfo, cancelAgentTask, getTaskEvents, subscribeToTaskEvents } from "../copilot/agents.js";
+import { summarize, summarizeEvent } from "../copilot/event-summary.js";
 import { abortOrchestrator } from "../copilot/orchestrator.js";
 import { getActiveTasks, getTask, listRecentTasks } from "../store/tasks.js";
 import { IO_VERSION } from "../paths.js";
@@ -179,6 +180,18 @@ export async function startApiServer(): Promise<void> {
     }
   });
 
+  api.get("/tasks/:taskId/activity", (req: Request, res: Response) => {
+    const taskId = Array.isArray(req.params.taskId) ? req.params.taskId[0] : req.params.taskId;
+    try {
+      const events = getTaskEvents(taskId);
+      const activity = summarize(events);
+      res.json({ taskId, activity });
+    } catch (e) {
+      console.error("Error building task activity:", e);
+      res.status(500).json({ error: "Failed to build task activity" });
+    }
+  });
+
   api.get("/tasks/:taskId/events", (req: Request, res: Response) => {
     const taskId = Array.isArray(req.params.taskId) ? req.params.taskId[0] : req.params.taskId;
 
@@ -190,7 +203,9 @@ export async function startApiServer(): Promise<void> {
 
     const send = (ev: { ts: number; type: string; data: unknown }) => {
       try {
-        res.write(`data: ${JSON.stringify(ev)}\n\n`);
+        const summary = summarizeEvent(ev);
+        const payload = { ...ev, summary };
+        res.write(`data: ${JSON.stringify(payload)}\n\n`);
       } catch {
         // client likely disconnected; cleanup happens on req.close
       }

--- a/src/copilot/event-summary.ts
+++ b/src/copilot/event-summary.ts
@@ -1,0 +1,312 @@
+// Tiered activity log normalizer.
+//
+// Converts raw TaskStreamEvent records (forwarded from the Copilot SDK
+// session) into "activity entries" that present a clean human-readable
+// summary. Each entry preserves the underlying raw payload for drill-down so
+// no information is lost.
+//
+// Used by:
+//   - GET /tasks/:taskId/activity (full collapsed list)
+//   - the SSE per-event payload (single-event summary attached alongside raw)
+//   - the TUI /activity command
+
+import type { TaskStreamEvent } from "./agents.js";
+
+export type ActivityKind = "message" | "reasoning" | "tool" | "outcome" | "system";
+
+export interface ActivityEntry {
+  ts: number;
+  kind: ActivityKind;
+  icon: string;
+  summary: string;
+  /** Optional longer prose for inline expansion (still summarized, not raw). */
+  detail?: string;
+  /** Original event type (e.g. "tool.execution_start"). */
+  rawType: string;
+  /** Original event.data — full fidelity for the "raw" drill-down view. */
+  raw: unknown;
+  /** Tool calls share an ID across start/complete; UI uses this to merge. */
+  toolCallId?: string;
+  /** For tool entries after completion. */
+  status?: "pending" | "success" | "error";
+}
+
+const TOOL_VERBS: Record<string, string> = {
+  bash: "Ran shell command",
+  shell: "Ran shell command",
+  read_file: "Read file",
+  view: "Read file",
+  create: "Created file",
+  edit: "Edited file",
+  str_replace_editor: "Edited file",
+  grep: "Searched code",
+  glob: "Searched filenames",
+  web_fetch: "Fetched URL",
+  github: "Called GitHub API",
+  delegate_to_teammate: "Delegated to teammate",
+  squad_delegate: "Delegated to squad",
+  squad_status: "Listed squads",
+  squad_agents: "Listed squad agents",
+  squad_set_lead: "Set squad lead",
+  squad_set_qa: "Set squad QA",
+  squad_task_status: "Checked task status",
+  squad_task_reviews: "Read task reviews",
+  squad_log_decision: "Logged squad decision",
+  squad_schedule_create: "Created squad schedule",
+  squad_schedule_list: "Listed squad schedules",
+  squad_schedule_run_now: "Fired squad schedule",
+  wiki_read: "Read wiki page",
+  wiki_write: "Wrote wiki page",
+  wiki_search: "Searched wiki",
+  wiki_list: "Listed wiki pages",
+  skill_list: "Listed skills",
+  skill_install: "Installed skill",
+  skill_remove: "Removed skill",
+  skill_search: "Searched skills registry",
+  config_update: "Updated config",
+  check_update: "Checked for IO update",
+  file_ops: "File operation",
+};
+
+function trunc(s: string, n: number): string {
+  if (!s) return "";
+  const flat = s.replace(/\s+/g, " ").trim();
+  return flat.length > n ? flat.slice(0, n - 1) + "…" : flat;
+}
+
+function pickArgSummary(toolName: string, args: Record<string, unknown> | undefined): string {
+  if (!args) return "";
+  const a = args as Record<string, unknown>;
+  switch (toolName) {
+    case "bash":
+    case "shell": {
+      const cmd = typeof a.command === "string" ? a.command : "";
+      return trunc(cmd, 80);
+    }
+    case "read_file":
+    case "view":
+    case "create":
+    case "edit":
+    case "str_replace_editor": {
+      const p = typeof a.path === "string" ? a.path : (typeof a.file_path === "string" ? a.file_path : "");
+      return p;
+    }
+    case "grep": {
+      const pat = typeof a.pattern === "string" ? `"${trunc(a.pattern, 40)}"` : "";
+      const paths = Array.isArray(a.paths) ? a.paths.join(", ") : (typeof a.paths === "string" ? a.paths : "");
+      return [pat, paths].filter(Boolean).join(" in ");
+    }
+    case "glob": {
+      return typeof a.pattern === "string" ? a.pattern : "";
+    }
+    case "web_fetch": {
+      return typeof a.url === "string" ? a.url : "";
+    }
+    case "delegate_to_teammate": {
+      const teammate = typeof a.teammate === "string" ? a.teammate : "";
+      const task = typeof a.task === "string" ? trunc(a.task, 60) : "";
+      return [teammate, task].filter(Boolean).join(": ");
+    }
+    case "squad_delegate": {
+      const slug = typeof a.slug === "string" ? a.slug : "";
+      const agent = typeof a.agent === "string" ? ` → ${a.agent}` : "";
+      const task = typeof a.task === "string" ? trunc(a.task, 50) : "";
+      return `${slug}${agent}${task ? `: ${task}` : ""}`;
+    }
+    case "wiki_read":
+    case "wiki_write":
+    case "wiki_delete": {
+      return typeof a.path === "string" ? a.path : "";
+    }
+    case "wiki_search":
+    case "skill_search": {
+      return typeof a.query === "string" ? `"${trunc(a.query, 40)}"` : "";
+    }
+    case "github": {
+      const ep = typeof a.endpoint === "string" ? a.endpoint : "";
+      const method = typeof a.method === "string" ? a.method : "";
+      return [method, ep].filter(Boolean).join(" ");
+    }
+    case "file_ops": {
+      const op = typeof a.operation === "string" ? a.operation : "";
+      const p = typeof a.path === "string" ? a.path : "";
+      return [op, p].filter(Boolean).join(" ");
+    }
+    default: {
+      // Best-effort: stringify the first arg value.
+      const k = Object.keys(a)[0];
+      if (!k) return "";
+      const v = a[k];
+      const s = typeof v === "string" ? v : JSON.stringify(v);
+      return `${k}=${trunc(s ?? "", 50)}`;
+    }
+  }
+}
+
+/** Summarize a single TaskStreamEvent. */
+export function summarizeEvent(ev: TaskStreamEvent): ActivityEntry {
+  const data = (ev.data ?? {}) as Record<string, unknown>;
+  const base = { ts: ev.ts, rawType: ev.type, raw: ev.data };
+
+  switch (ev.type) {
+    case "assistant.intent": {
+      const intent = typeof data.intent === "string" ? data.intent : "";
+      return { ...base, kind: "reasoning", icon: "🧠", summary: intent || "(intent)" };
+    }
+    case "assistant.reasoning": {
+      const content = typeof data.content === "string" ? data.content : "";
+      return {
+        ...base,
+        kind: "reasoning",
+        icon: "🧠",
+        summary: trunc(content, 140) || "(reasoning)",
+        detail: content,
+      };
+    }
+    case "assistant.message": {
+      const content = typeof data.content === "string" ? data.content : "";
+      return {
+        ...base,
+        kind: "message",
+        icon: "💬",
+        summary: trunc(content, 200) || "(empty message)",
+        detail: content,
+      };
+    }
+    case "assistant.turn_start":
+      return { ...base, kind: "system", icon: "▶️", summary: "Turn started" };
+    case "assistant.turn_end":
+      return { ...base, kind: "system", icon: "⏹️", summary: "Turn ended" };
+    case "tool.execution_start": {
+      const name = typeof data.toolName === "string" ? data.toolName : "tool";
+      const verb = TOOL_VERBS[name] ?? `Used ${name}`;
+      const args = pickArgSummary(name, data.arguments as Record<string, unknown> | undefined);
+      return {
+        ...base,
+        kind: "tool",
+        icon: "🔧",
+        summary: args ? `${verb} — ${args}` : verb,
+        toolCallId: typeof data.toolCallId === "string" ? data.toolCallId : undefined,
+        status: "pending",
+      };
+    }
+    case "tool.execution_complete": {
+      const success = data.success === true;
+      const result = (data.result ?? {}) as { content?: string };
+      const content = typeof result.content === "string" ? result.content : "";
+      return {
+        ...base,
+        kind: "tool",
+        icon: success ? "✅" : "❌",
+        summary: success ? "Tool completed" : "Tool failed",
+        detail: trunc(content, 300),
+        toolCallId: typeof data.toolCallId === "string" ? data.toolCallId : undefined,
+        status: success ? "success" : "error",
+      };
+    }
+    case "tool.execution_progress": {
+      const message = typeof data.message === "string" ? data.message : "";
+      return {
+        ...base,
+        kind: "tool",
+        icon: "⏳",
+        summary: trunc(message, 140) || "Tool progress",
+        toolCallId: typeof data.toolCallId === "string" ? data.toolCallId : undefined,
+        status: "pending",
+      };
+    }
+    case "session.error": {
+      const msg = typeof data.message === "string" ? data.message : (typeof data.error === "string" ? data.error : "");
+      return { ...base, kind: "outcome", icon: "❌", summary: `Error: ${trunc(msg, 160) || "session error"}` };
+    }
+    case "session.warning": {
+      const msg = typeof data.message === "string" ? data.message : "";
+      return { ...base, kind: "outcome", icon: "⚠️", summary: `Warning: ${trunc(msg, 160) || "session warning"}` };
+    }
+    case "task.done": {
+      const r = typeof data.result === "string" ? data.result : "";
+      return { ...base, kind: "outcome", icon: "✅", summary: "Task completed", detail: trunc(r, 300) };
+    }
+    case "task.failed": {
+      const e = typeof data.error === "string" ? data.error : "";
+      return { ...base, kind: "outcome", icon: "❌", summary: `Task failed: ${trunc(e, 160)}` };
+    }
+    case "task.cancelled":
+      return { ...base, kind: "outcome", icon: "🛑", summary: "Task cancelled" };
+    case "task.review":
+      return {
+        ...base,
+        kind: "outcome",
+        icon: data.approved ? "👍" : "👎",
+        summary: `Review by ${data.reviewer ?? "?"}: ${data.approved ? "APPROVED" : "REJECTED"}${data.is_qa ? " (QA)" : ""}`,
+        detail: typeof data.comments === "string" ? data.comments : undefined,
+      };
+    case "task.review_complete":
+      return {
+        ...base,
+        kind: "outcome",
+        icon: data.promoted ? "🚀" : "ℹ️",
+        summary: data.promoted
+          ? `Promoted PR: ${data.prUrl ?? ""}`
+          : `Review complete: ${typeof data.reason === "string" ? data.reason : ""}`,
+      };
+    case "task.review_advisory":
+      return {
+        ...base,
+        kind: "outcome",
+        icon: "ℹ️",
+        summary: typeof data.reason === "string" ? data.reason : "Advisory review note",
+      };
+    case "task.review_error": {
+      const e = typeof data.error === "string" ? data.error : "";
+      return { ...base, kind: "outcome", icon: "❌", summary: `Review error: ${trunc(e, 160)}` };
+    }
+    default:
+      return { ...base, kind: "system", icon: "•", summary: ev.type };
+  }
+}
+
+/**
+ * Collapse a stream of events into the activity log. Tool start + complete
+ * pairs are merged into one entry (success/error and detail attached).
+ * Streaming deltas (assistant.message_delta, assistant.reasoning_delta,
+ * tool.execution_partial_result) are dropped — the "complete" sibling event
+ * is what we summarize.
+ */
+export function summarize(events: TaskStreamEvent[]): ActivityEntry[] {
+  const out: ActivityEntry[] = [];
+  const toolIndex = new Map<string, number>(); // toolCallId → index into out
+
+  for (const ev of events) {
+    if (
+      ev.type === "assistant.message_delta" ||
+      ev.type === "assistant.reasoning_delta" ||
+      ev.type === "tool.execution_partial_result"
+    ) {
+      continue;
+    }
+    const entry = summarizeEvent(ev);
+    if (entry.kind === "tool" && entry.toolCallId) {
+      const existing = toolIndex.get(entry.toolCallId);
+      if (existing != null && entry.status && entry.status !== "pending") {
+        // Merge: keep the verb from the start event, add status/detail/icon from completion.
+        const prior = out[existing];
+        out[existing] = {
+          ...prior,
+          icon: entry.icon,
+          status: entry.status,
+          detail: entry.detail ?? prior.detail,
+          // Append a brief outcome marker if the start summary is the only descriptor.
+          summary: prior.summary,
+          // Keep the completion event raw available for drill-down by stashing on detail when no detail present
+          raw: { start: prior.raw, complete: entry.raw },
+          rawType: `${prior.rawType}+${entry.rawType}`,
+        };
+        continue;
+      }
+      toolIndex.set(entry.toolCallId, out.length);
+    }
+    out.push(entry);
+  }
+  return out;
+}

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -1,4 +1,7 @@
 import { createInterface, type Interface } from "readline";
+import { listRecentTasks, getTask } from "../store/tasks.js";
+import { getTaskEvents } from "../copilot/agents.js";
+import { summarize } from "../copilot/event-summary.js";
 
 export type TuiMessageHandler = (
   text: string,
@@ -16,9 +19,47 @@ const WELCOME_BANNER = `
 ║          IO — AI Assistant           ║
 ╚══════════════════════════════════════╝
 Type a message to chat. Commands:
-  /status  — show status
-  /quit    — exit
+  /status              — show status
+  /activity [id|N]     — show summarized activity for a task (default: most recent)
+  /verbose             — toggle verbose mode (raw event detail in /activity)
+  /quit                — exit
 `;
+
+let verbose = false;
+
+function renderActivity(taskIdArg: string | undefined): void {
+  const recent = listRecentTasks(20);
+  let task = undefined;
+  if (!taskIdArg) {
+    task = recent[0];
+  } else if (/^\d+$/.test(taskIdArg)) {
+    task = recent[parseInt(taskIdArg, 10) - 1];
+  } else {
+    task = getTask(taskIdArg);
+  }
+  if (!task) {
+    console.log("[io] No task found for activity view.");
+    return;
+  }
+  const events = getTaskEvents(task.task_id);
+  if (events.length === 0) {
+    console.log(`[io] No buffered activity for task ${task.task_id} (${task.status}).`);
+    return;
+  }
+  const activity = summarize(events);
+  console.log(`[io] Activity for task ${task.task_id} (${task.agent_slug}, ${task.status}) — ${activity.length} entries${verbose ? " (verbose)" : ""}`);
+  for (const e of activity) {
+    const ts = new Date(e.ts).toISOString().slice(11, 19);
+    console.log(`  ${ts} ${e.icon} ${e.summary}`);
+    if (verbose) {
+      if (e.detail) {
+        for (const line of e.detail.split(/\r?\n/)) console.log(`        ${line}`);
+      } else if (e.raw && typeof e.raw === "object") {
+        console.log("        " + JSON.stringify(e.raw).slice(0, 400));
+      }
+    }
+  }
+}
 
 function clearLine(): void {
   process.stdout.write("\r\x1b[K");
@@ -50,6 +91,22 @@ export async function startTui(): Promise<void> {
 
     if (trimmed === "/status") {
       console.log(`[io] Uptime: ${Math.floor(process.uptime())}s`);
+      rl.prompt();
+      return;
+    }
+
+    if (trimmed === "/verbose") {
+      verbose = !verbose;
+      console.log(`[io] Verbose mode ${verbose ? "ON" : "OFF"}`);
+      rl.prompt();
+      return;
+    }
+
+    if (trimmed === "/activity" || trimmed.startsWith("/activity ")) {
+      const arg = trimmed.slice("/activity".length).trim() || undefined;
+      try { renderActivity(arg); } catch (err) {
+        console.error(`[io] /activity failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
       rl.prompt();
       return;
     }

--- a/web/src/views/AgentActivityView.vue
+++ b/web/src/views/AgentActivityView.vue
@@ -194,6 +194,111 @@
             </div>
 
             <div>
+              <div class="flex justify-between items-center mb-2">
+                <p class="text-xs uppercase tracking-wider text-gray-500">Activity</p>
+                <label class="flex items-center gap-2 text-xs text-gray-400 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    v-model="showActivityDetails"
+                    class="rounded bg-gray-700 border-gray-600"
+                  />
+                  Show details
+                </label>
+              </div>
+              <div
+                v-if="activityLoading && activity.length === 0"
+                class="text-sm text-gray-500 italic"
+              >Loading activity…</div>
+              <div
+                v-else-if="activity.length === 0"
+                class="text-sm text-gray-500 italic"
+              >No activity yet</div>
+              <ul
+                v-else
+                class="bg-gray-800 border border-gray-700 rounded divide-y divide-gray-700 max-h-96 overflow-y-auto"
+              >
+                <li
+                  v-for="(entry, idx) in activity"
+                  :key="`${entry.ts}-${idx}-${entry.rawType}`"
+                  class="px-3 py-2 text-sm hover:bg-gray-750 cursor-pointer"
+                  @click="toggleActivityEntry(idx)"
+                >
+                  <div class="flex items-start gap-2" :class="activityKindClass(entry)">
+                    <span class="shrink-0">{{ entry.icon }}</span>
+                    <span class="flex-1 break-words">{{ entry.summary }}</span>
+                    <span class="text-xs text-gray-500 shrink-0">
+                      {{ formatActivityTime(entry.ts) }}
+                    </span>
+                  </div>
+                  <div
+                    v-if="showActivityDetails || expandedActivity.has(idx)"
+                    class="mt-2 pl-6 space-y-1"
+                  >
+                    <pre
+                      v-if="entry.detail"
+                      class="text-xs text-gray-200 bg-gray-900 border border-gray-700 rounded p-2 whitespace-pre-wrap break-words font-mono"
+                    >{{ entry.detail }}</pre>
+                    <pre
+                      class="text-[11px] text-gray-500 bg-gray-900 border border-gray-700 rounded p-2 whitespace-pre-wrap break-words font-mono max-h-48 overflow-y-auto"
+                    >{{ formatRaw(entry.raw) }}</pre>
+                    <p class="text-[10px] text-gray-600 font-mono">{{ entry.rawType }}</p>
+                  </div>
+                </li>
+              </ul>
+            </div>
+
+            <!-- Activity log -->
+            <div>
+              <div class="flex justify-between items-center mb-2">
+                <p class="text-xs uppercase tracking-wider text-gray-500">Activity</p>
+                <label class="flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer select-none">
+                  <input type="checkbox" v-model="showAllDetails" class="accent-blue-500" />
+                  Show details
+                </label>
+              </div>
+              <div
+                v-if="activityLoading && activityEntries.length === 0"
+                class="text-sm text-gray-500 italic py-1"
+              >
+                No activity yet
+              </div>
+              <div
+                v-else-if="activityEntries.length === 0"
+                class="text-sm text-gray-500 italic py-1"
+              >
+                No activity yet
+              </div>
+              <ul v-else class="space-y-0.5">
+                <li v-for="(entry, idx) in activityEntries" :key="idx">
+                  <button
+                    type="button"
+                    @click="toggleEntry(idx)"
+                    class="w-full text-left flex items-start gap-2 px-2 py-1 rounded hover:bg-gray-800 transition-colors"
+                  >
+                    <span class="flex-shrink-0 text-base leading-5 mt-px">{{ entry.icon }}</span>
+                    <span :class="['text-sm flex-1 break-words leading-5', entryTextClass(entry)]">{{ entry.summary }}</span>
+                    <span
+                      v-if="entry.status"
+                      :class="['text-xs px-1.5 py-0.5 rounded flex-shrink-0 self-start', entryBadgeClass(entry.status)]"
+                    >
+                      {{ entry.status }}
+                    </span>
+                  </button>
+                  <div
+                    v-if="showAllDetails || expandedEntries.has(idx)"
+                    class="ml-8 mt-1 mb-1 space-y-2"
+                  >
+                    <pre
+                      v-if="entry.detail"
+                      class="text-sm text-gray-200 bg-gray-800 border border-gray-700 rounded p-2 whitespace-pre-wrap break-words"
+                    >{{ entry.detail }}</pre>
+                    <pre class="text-xs text-gray-500 bg-gray-950 border border-gray-800 rounded p-2 whitespace-pre-wrap break-words">{{ JSON.stringify(entry.raw, null, 2) }}</pre>
+                  </div>
+                </li>
+              </ul>
+            </div>
+
+            <div>
               <p class="text-xs uppercase tracking-wider text-gray-500 mb-1">Result</p>
               <pre v-if="selectedTask.result" class="text-sm text-gray-100 bg-gray-800 border border-gray-700 rounded p-3 whitespace-pre-wrap break-words font-mono max-h-96 overflow-y-auto">{{ selectedTask.result }}</pre>
               <p v-else class="text-sm text-gray-500 italic">No result yet</p>
@@ -227,7 +332,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
-import { apiFetch } from '../lib/api'
+import { apiFetch, authenticatedUrl } from '../lib/api'
 
 interface Agent {
   slug: string
@@ -262,6 +367,25 @@ const selectedTaskId = ref<string | null>(null)
 const selectedTask = ref<AgentTask | null>(null)
 const detailLoading = ref(false)
 const detailError = ref<string | null>(null)
+
+interface ActivityEntry {
+  ts: number
+  kind: 'message' | 'reasoning' | 'tool' | 'outcome' | 'system'
+  icon: string
+  summary: string
+  detail?: string
+  rawType: string
+  raw: unknown
+  toolCallId?: string
+  status?: 'pending' | 'success' | 'error'
+}
+
+const activity = ref<ActivityEntry[]>([])
+const activityLoading = ref(false)
+const showActivityDetails = ref(false)
+const expandedActivity = ref<Set<number>>(new Set())
+let activityEventSource: EventSource | null = null
+let activityRefreshTimer: ReturnType<typeof setTimeout> | null = null
 
 let refreshInterval: ReturnType<typeof setInterval> | null = null
 
@@ -376,16 +500,108 @@ const loadTaskDetail = async (taskId: string) => {
   }
 }
 
+const formatActivityTime = (ts: number) => {
+  if (!ts) return ''
+  const d = new Date(ts)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
+}
+
+const formatRaw = (raw: unknown) => {
+  try {
+    return JSON.stringify(raw, null, 2)
+  } catch {
+    return String(raw)
+  }
+}
+
+const activityKindClass = (entry: ActivityEntry) => {
+  if (entry.status === 'success') return 'text-green-300'
+  if (entry.status === 'error') return 'text-red-300'
+  if (entry.status === 'pending') return 'text-blue-300'
+  switch (entry.kind) {
+    case 'message': return 'text-gray-100'
+    case 'reasoning': return 'text-purple-300'
+    case 'tool': return 'text-blue-200'
+    case 'outcome': return 'text-yellow-200'
+    default: return 'text-gray-300'
+  }
+}
+
+const toggleActivityEntry = (idx: number) => {
+  if (showActivityDetails.value) return
+  const next = new Set(expandedActivity.value)
+  if (next.has(idx)) next.delete(idx)
+  else next.add(idx)
+  expandedActivity.value = next
+}
+
+const loadActivity = async (taskId: string, opts: { initial?: boolean } = {}) => {
+  if (opts.initial) activityLoading.value = true
+  try {
+    const response = await apiFetch(`/api/tasks/${encodeURIComponent(taskId)}/activity`)
+    if (!response.ok) return
+    const data = (await response.json()) as { activity: ActivityEntry[] }
+    activity.value = data.activity ?? []
+  } catch {
+    // Non-fatal — activity is best-effort.
+  } finally {
+    if (opts.initial) activityLoading.value = false
+  }
+}
+
+const scheduleActivityRefresh = (taskId: string) => {
+  if (activityRefreshTimer) return
+  activityRefreshTimer = setTimeout(() => {
+    activityRefreshTimer = null
+    if (selectedTaskId.value === taskId) loadActivity(taskId)
+  }, 250)
+}
+
+const startActivityStream = (taskId: string) => {
+  stopActivityStream()
+  loadActivity(taskId, { initial: true })
+  try {
+    activityEventSource = new EventSource(`/api/tasks/${encodeURIComponent(taskId)}/events`)
+    activityEventSource.onmessage = () => {
+      // Coalesce bursts of SSE events into one refetch every 250ms.
+      scheduleActivityRefresh(taskId)
+    }
+    activityEventSource.onerror = () => {
+      // EventSource auto-reconnects; nothing to do.
+    }
+  } catch {
+    activityEventSource = null
+  }
+}
+
+const stopActivityStream = () => {
+  if (activityEventSource) {
+    activityEventSource.close()
+    activityEventSource = null
+  }
+  if (activityRefreshTimer) {
+    clearTimeout(activityRefreshTimer)
+    activityRefreshTimer = null
+  }
+}
+
 const openTask = (taskId: string) => {
   selectedTaskId.value = taskId
   selectedTask.value = null
+  activity.value = []
+  expandedActivity.value = new Set()
   loadTaskDetail(taskId)
+  startActivityStream(taskId)
 }
 
 const closeTask = () => {
   selectedTaskId.value = null
   selectedTask.value = null
   detailError.value = null
+  activity.value = []
+  expandedActivity.value = new Set()
+  stopActivityStream()
 }
 
 const onKeydown = (e: KeyboardEvent) => {
@@ -405,9 +621,21 @@ onMounted(() => {
   refreshInterval = setInterval(refreshAll, 5000)
 })
 
+watch(
+  () => selectedTask.value?.status,
+  (status) => {
+    if (status && status !== 'running') {
+      // Final refresh once, then stop the stream — no more updates expected.
+      if (selectedTaskId.value) loadActivity(selectedTaskId.value)
+      stopActivityStream()
+    }
+  }
+)
+
 onUnmounted(() => {
   if (refreshInterval) clearInterval(refreshInterval)
   document.removeEventListener('keydown', onKeydown)
+  stopActivityStream()
 })
 </script>
 


### PR DESCRIPTION
Closes #42

## Summary
Adds a tiered activity-log experience: a clean scannable summary by default with full raw detail accessible on demand, consistent across the web UI agent activity view and the TUI. No information lost — the detail view contains the original event payload verbatim.

## Architecture

### `src/copilot/event-summary.ts` (new — shared core)
Pure summarizer. `summarizeEvent(ev)` turns a raw `TaskStreamEvent` into an `ActivityEntry`:
```ts
interface ActivityEntry {
  ts: number;
  kind: 'message' | 'reasoning' | 'tool' | 'outcome' | 'system';
  icon: string;        // 💬 🧠 🔧 ✅ ❌ etc.
  summary: string;     // one-liner
  detail?: string;     // optional longer prose for inline expansion
  rawType: string;     // original event.type
  raw: unknown;        // ORIGINAL event.data — full fidelity drill-down
  toolCallId?: string;
  status?: 'pending' | 'success' | 'error';
}
```
Tool-name → human-verb table for the common tools (`bash` → 'Ran shell command', `grep` → 'Searched code', `squad_delegate` → 'Delegated to squad', `web_fetch` → 'Fetched URL', etc.) plus best-effort argument summarization (paths, patterns, commands). `summarize(events[])` merges tool start + complete events into one entry carrying success/error status, and drops streaming deltas.

### `src/api/server.ts`
- SSE `/tasks/:id/events`: each payload now includes a `summary` field alongside the raw event (backward-compatible — old consumers ignore the new field).
- New `GET /tasks/:id/activity` returns the merged `ActivityEntry[]` from the in-memory replay buffer for fast initial render.

### `web/src/views/AgentActivityView.vue`
- New **Activity** section in the existing task-detail modal (above the existing Result block — Result preserved unchanged).
- Initial render via `/activity` endpoint; live updates via SSE on `/events` with a 250ms-coalesced refetch so bursty event streams don't thrash.
- Each row: `{icon} {summary}` with status-aware color (green/red/blue/purple/yellow), click-to-expand inline showing detail prose + raw JSON + raw event type.
- Master **Show details** checkbox auto-expands all rows.
- Stream auto-stops when task transitions out of `running` or modal closes; reopened tasks rebuild from scratch.

### `src/tui/index.ts`
- New `/activity [id|N]` command. With no arg: most recent task. With a number: that index into the recent task list. With a `task_id`: that specific task.
- New `/verbose` toggle. When verbose, `/activity` also prints the detail (or raw payload) under each summary line.
- Help banner updated.

## Verification
- `npm run build` (tsc) ✅
- `vue-tsc --noEmit` in `web/` ✅
- Summarizer smoke test:
  ```
  🧠 Investigating auth code
  ✅ Searched code — "login" in src/api/        [success]
  ❌ Ran shell command — npm test --silent       [error]
  💬 I found 2 places where login is referenced.
  ✅ Task completed
  ```

— Lion-O 🦁