### PR TITLE
Recover stale agent error states + backfill misparsed reviews (#50, #55)

### DIFF
--- a/src/copilot/agents.ts
+++ b/src/copilot/agents.ts
@@ -336,18 +336,31 @@ async function getOrCreateAgentSession(
   const effectiveTier = tierRank[taskTier] >= tierRank[agentTier] ? taskTier : agentTier;
   const model = getModelForTier(effectiveTier);
 
-  // If we have a cached session, check if the model matches; if not, destroy and recreate
+  // If we have a cached session, check if the model matches AND the agent
+  // hasn't been left in an error state by a previous task. If either is off,
+  // destroy and recreate. Reusing a session whose underlying SDK process has
+  // been throwing is how Panthro got "stuck" in error after the issue #42
+  // delegation timeout (issue #55).
   const existing = agentSessions.get(key);
   if (existing) {
-    // Sessions don't expose their model, so track it separately
-    const cachedModel = agentSessionModels.get(key);
-    if (cachedModel === model) return existing;
+    const fresh = getSquadAgent(squadSlug, agent.character_name);
+    const persistedStatus = fresh?.status ?? agent.status;
+    if (persistedStatus === "error") {
+      console.error(`[io] Agent ${agent.character_name}: previous session ended in error — discarding cached session and recreating`);
+      try { await existing.destroy(); } catch { /* best-effort */ }
+      agentSessions.delete(key);
+      agentSessionModels.delete(key);
+    } else {
+      // Sessions don't expose their model, so track it separately
+      const cachedModel = agentSessionModels.get(key);
+      if (cachedModel === model) return existing;
 
-    // Model changed — destroy old session for the upgraded model
-    console.error(`[io] Agent ${agent.character_name}: upgrading model ${cachedModel} → ${model} for task complexity`);
-    try { await existing.destroy(); } catch { /* best-effort */ }
-    agentSessions.delete(key);
-    agentSessionModels.delete(key);
+      // Model changed — destroy old session for the upgraded model
+      console.error(`[io] Agent ${agent.character_name}: upgrading model ${cachedModel} → ${model} for task complexity`);
+      try { await existing.destroy(); } catch { /* best-effort */ }
+      agentSessions.delete(key);
+      agentSessionModels.delete(key);
+    }
   }
 
   const squad = getSquad(squadSlug)!;

--- a/src/copilot/review-backfill.ts
+++ b/src/copilot/review-backfill.ts
@@ -1,0 +1,70 @@
+import { getDb } from "../store/db.js";
+import { parseReviewVerdict } from "./agents.js";
+
+interface ReviewRow {
+  id: number;
+  approved: number;
+  comments: string | null;
+}
+
+/**
+ * Surgically correct historical peer-review rows that were stored as REJECTED
+ * (approved=0) but whose comments unambiguously begin with `APPROVED` (issue
+ * #50). Earlier daemon builds (pre-#43) inspected only the literal first line,
+ * which silently flipped many APPROVED reviews into REJECTED whenever the
+ * agent began its response with a markdown rule, blank line, header, or a
+ * short prose preamble.
+ *
+ * We only flip 0 -> 1, and only when the *current* parser sees an explicit
+ * line-leading APPROVED token in the prose. We never flip 1 -> 0: doing so
+ * would destroy data on legitimate prose-only approvals (e.g. "Excellent
+ * work — ships it") that the conservative parser would otherwise downgrade.
+ *
+ * Returns the number of rows updated.
+ */
+export function backfillReviewVerdicts(): number {
+  const db = getDb();
+  const rows = db
+    .prepare(
+      "SELECT id, approved, comments FROM squad_task_reviews WHERE approved = 0 AND comments IS NOT NULL AND comments != ''",
+    )
+    .all() as ReviewRow[];
+
+  const update = db.prepare(
+    "UPDATE squad_task_reviews SET approved = 1 WHERE id = ?",
+  );
+
+  let fixed = 0;
+  const tx = db.transaction((batch: ReviewRow[]) => {
+    for (const r of batch) {
+      if (hasExplicitApproval(r.comments ?? "")) {
+        update.run(r.id);
+        fixed++;
+      }
+    }
+  });
+  tx(rows);
+  return fixed;
+}
+
+/**
+ * True when the comment body unambiguously starts with an APPROVED verdict —
+ * either as the first non-empty line (after stripping markdown noise) or as
+ * the verdict the current parser extracts before any REJECTED token. Anything
+ * shorter than that is left as the daemon originally recorded it.
+ */
+function hasExplicitApproval(content: string): boolean {
+  const stripped = content.replace(/[*_`#>]/g, "");
+  const lines = stripped
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .slice(0, 10);
+  for (const line of lines) {
+    const lead = line
+      .toUpperCase()
+      .match(/^[^A-Z]*\b(APPROVED|REJECTED)\b/);
+    if (lead) return lead[1] === "APPROVED";
+  }
+  return false;
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -4,6 +4,8 @@ import { startApiServer, setMessageHandler as setApiHandler, broadcastToSSE } fr
 import { createBot, startBot, stopBot, sendProactiveMessage, setMessageHandler as setTelegramHandler } from "./telegram/bot.js";
 import { getDb, closeDb } from "./store/db.js";
 import { clearStaleTasks } from "./store/tasks.js";
+import { reconcileAgentStatuses, reconcileSquadStatuses } from "./store/squads.js";
+import { backfillReviewVerdicts } from "./copilot/review-backfill.js";
 import { startScheduler, stopScheduler } from "./copilot/scheduler.js";
 import { config } from "./config.js";
 import { ensureWikiStructure } from "./wiki/fs.js";
@@ -70,8 +72,35 @@ export async function startDaemon(): Promise<void> {
     console.log("[io] Created wiki at ~/.io/wiki/");
   }
 
-  // Clear stale tasks from previous run
+  // Clear stale tasks from previous run, and reset any agent/squad rows left
+  // in 'working' or 'error' state — the in-memory Copilot sessions backing
+  // those rows did not survive the restart, so the persisted status is lying.
   clearStaleTasks();
+  const resetAgents = reconcileAgentStatuses();
+  const resetSquads = reconcileSquadStatuses();
+  if (resetAgents > 0 || resetSquads > 0) {
+    console.log(
+      `[io] Reconciled stale statuses on startup: ${resetAgents} agent(s), ${resetSquads} squad(s) → idle`,
+    );
+  }
+
+  // Backfill any historical peer-review rows whose recorded verdict (approved
+  // 0/1) does not match what the current parser would extract from the prose.
+  // Earlier daemon builds had a brittle first-line-only parser that flipped
+  // many APPROVED reviews into REJECTED (issue #50).
+  try {
+    const fixed = backfillReviewVerdicts();
+    if (fixed > 0) {
+      console.log(
+        `[io] Backfilled ${fixed} peer-review verdict(s) using current parser`,
+      );
+    }
+  } catch (err) {
+    console.error(
+      "[io] Review-verdict backfill failed:",
+      err instanceof Error ? err.message : err,
+    );
+  }
 
   // Prune old sessions
   pruneOldSessions();

--- a/src/store/squads.ts
+++ b/src/store/squads.ts
@@ -203,6 +203,33 @@ export function updateAgentStatus(
     .run(status, squadSlug, characterName);
 }
 
+/**
+ * Reset any agent left in a non-idle status from a previous daemon run.
+ * The in-memory Copilot sessions don't survive a restart, so persisted
+ * "working" or "error" rows can never be accurate after startup. Returns
+ * the number of rows reset for logging.
+ */
+export function reconcileAgentStatuses(): number {
+  const info = getDb()
+    .prepare(
+      "UPDATE squad_agents SET status = 'idle' WHERE status IN ('working', 'error')",
+    )
+    .run();
+  return info.changes;
+}
+
+/**
+ * Mirror of reconcileAgentStatuses for squads themselves.
+ */
+export function reconcileSquadStatuses(): number {
+  const info = getDb()
+    .prepare(
+      "UPDATE squads SET status = 'idle' WHERE status IN ('working', 'error')",
+    )
+    .run();
+  return info.changes;
+}
+
 export function logDecision(
   squadSlug: string,
   decision: string,


### PR DESCRIPTION
Closes #55. Closes #50.

## Investigation

The user asked why **Panthro** and **Murdock** entered error states. Live DB inspection showed both currently `idle` (Panthro was reset out-of-band; Murdock has never been used). The structural defect that *put* Panthro in error and would have trapped Murdock the same way is real:

- `runAgentTask` sets `status='error'` on any `sendAndWait` failure (timeout, SDK error).
- The Copilot session is **kept** in the `agentSessions` Map.
- The next call to `getOrCreateAgentSession` returns the same broken session — error perpetuates.

Combined with #50, the daemon was also serving recorded reviews whose `approved` flag did not match the prose (the older first-line-only parser flipped APPROVED → REJECTED on common formats like `---\n\nAPPROVED`).

## Changes

- **`src/copilot/agents.ts`** — `getOrCreateAgentSession` re-reads the persisted agent row before reusing a cached session. If status is `error`, the cached session is destroyed and a fresh one is built. (#55)
- **`src/store/squads.ts`** — `reconcileAgentStatuses()` / `reconcileSquadStatuses()` reset any `working`/`error` rows to `idle` on startup. The in-memory sessions backing them cannot survive a restart.
- **`src/copilot/review-backfill.ts`** (new) — surgical, idempotent backfill that flips `approved=0 → 1` *only* when the prose unambiguously starts with a line-leading APPROVED (after markdown stripping). Never flips `1 → 0` so it can't destroy data on prose-only approvals.
- **`src/daemon.ts`** — calls reconcile + backfill right after `clearStaleTasks`, with logging.

## Verification

Run against a copy of the live DB:
```
rows fixed: 13
per-reviewer after backfill:
  Cheetara: 7/7  ✅
  Panthro:  6/6  ✅
  Tygra:    7/7  ✅
  WilyKit:  6/6  ✅
second pass fixed: 0       (idempotent)
```

Build clean. 🦁