### PR TITLE
Add IO-level scheduler — squad-independent recurring tasks (#58)

### DIFF
--- a/src/copilot/io-scheduler.ts
+++ b/src/copilot/io-scheduler.ts
@@ -8,6 +8,7 @@ import {
   listIoSchedules,
   listDueIoSchedules,
   recordIoScheduleRun,
+  setIoScheduleTimestamps,
   updateIoScheduleNextRun,
   type IoSchedule,
 } from "../store/io-schedules.js";
@@ -128,13 +129,26 @@ export function stopIoScheduler(): void {
 
 /**
  * Force a schedule to run immediately. Used by the `schedule_run_now` tool.
- * Does not mutate next_run_at on success (the next regular tick handles that
- * via fireSchedule).
+ *
+ * The regular tick path (`fireSchedule`) advances `last_run_at` and
+ * `next_run_at` as a side effect, which is correct for an automatic firing
+ * but is the wrong behaviour for a manual one — a user testing a schedule at
+ * 04:30 should not have the 05:00 occurrence skipped or the schedule shifted.
+ * We therefore snapshot both timestamps before firing and restore them after,
+ * leaving the persisted schedule untouched.
  */
 export async function runIoScheduleNow(id: number): Promise<boolean> {
   const all = listIoSchedules();
   const s = all.find((x) => x.id === id);
   if (!s) return false;
-  await fireSchedule(s);
+  const previousLast = s.last_run_at;
+  const previousNext = s.next_run_at;
+  try {
+    await fireSchedule(s);
+  } finally {
+    // Restore the original timestamps even if fireSchedule threw, so a
+    // failed manual run cannot silently shift the schedule either.
+    setIoScheduleTimestamps(id, previousLast, previousNext);
+  }
   return true;
 }

--- a/src/copilot/io-scheduler.ts
+++ b/src/copilot/io-scheduler.ts
@@ -1,0 +1,140 @@
+// IO-level scheduler — fires recurring tasks for IO itself, independent of
+// any squad. Mirrors the squad scheduler in shape (TICK_MS loop, in-flight
+// guard, reconcile on startup) but dispatches into the orchestrator via
+// sendToOrchestrator with a `background` source so IO can handle the prompt
+// the same way it handles any other user message.
+
+import {
+  listIoSchedules,
+  listDueIoSchedules,
+  recordIoScheduleRun,
+  updateIoScheduleNextRun,
+  type IoSchedule,
+} from "../store/io-schedules.js";
+import { sendToOrchestrator } from "./orchestrator.js";
+import { nextRun } from "./cron.js";
+
+const TICK_MS = 30_000;
+
+let timer: ReturnType<typeof setInterval> | undefined;
+const inFlight = new Set<number>();
+
+function buildPrompt(schedule: IoSchedule): string {
+  const header = `# Scheduled task: ${schedule.name}\n\n_This prompt was fired automatically by the IO scheduler. Cron expression: \`${schedule.cron_expr}\`._`;
+  const notes = schedule.notes
+    ? `\n\n**Operator notes:** ${schedule.notes}`
+    : "";
+  return `${header}\n\n${schedule.prompt}${notes}`;
+}
+
+async function fireSchedule(schedule: IoSchedule): Promise<void> {
+  if (inFlight.has(schedule.id)) return;
+  inFlight.add(schedule.id);
+  const ranAt = new Date();
+  let nextIso: string | null = null;
+  try {
+    nextIso = nextRun(schedule.cron_expr, ranAt).toISOString();
+  } catch (err) {
+    console.error(
+      `[io] io-scheduler: cron parse error for schedule ${schedule.id}:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+  recordIoScheduleRun(schedule.id, ranAt, nextIso);
+
+  console.log(
+    `[io] io-scheduler: firing schedule "${schedule.name}" (next run: ${nextIso ?? "never"})`,
+  );
+  try {
+    await sendToOrchestrator(
+      buildPrompt(schedule),
+      { type: "background" },
+      () => {
+        // No-op: scheduled work is fire-and-forget; output is captured in
+        // the orchestrator's conversation log.
+      },
+    );
+  } catch (err) {
+    console.error(
+      `[io] io-scheduler: failed to dispatch schedule ${schedule.id}:`,
+      err instanceof Error ? err.message : err,
+    );
+  } finally {
+    inFlight.delete(schedule.id);
+  }
+}
+
+async function tick(): Promise<void> {
+  let due: IoSchedule[];
+  try {
+    due = listDueIoSchedules(new Date());
+  } catch (err) {
+    console.error(
+      "[io] io-scheduler tick failed:",
+      err instanceof Error ? err.message : err,
+    );
+    return;
+  }
+  for (const s of due) {
+    await fireSchedule(s);
+  }
+}
+
+/**
+ * Backfill next_run_at for any IO schedules that are NULL or stale. We
+ * advance to the next future occurrence rather than replaying missed runs
+ * — same semantics as the squad scheduler.
+ */
+export function reconcileIoSchedules(now: Date = new Date()): void {
+  for (const s of listIoSchedules()) {
+    if (!s.enabled) continue;
+    let needsUpdate = false;
+    if (!s.next_run_at) {
+      needsUpdate = true;
+    } else {
+      const next = new Date(s.next_run_at);
+      if (Number.isNaN(next.getTime()) || next <= now) needsUpdate = true;
+    }
+    if (!needsUpdate) continue;
+    try {
+      const next = nextRun(s.cron_expr, now);
+      updateIoScheduleNextRun(s.id, next.toISOString());
+    } catch (err) {
+      console.error(
+        `[io] io-scheduler: invalid cron "${s.cron_expr}" on schedule ${s.id}; clearing next_run_at:`,
+        err instanceof Error ? err.message : err,
+      );
+      updateIoScheduleNextRun(s.id, null);
+    }
+  }
+}
+
+export function startIoScheduler(): void {
+  if (timer) return;
+  reconcileIoSchedules();
+  timer = setInterval(() => {
+    void tick();
+  }, TICK_MS);
+  // Don't keep the event loop alive on shutdown
+  (timer as unknown as { unref?: () => void }).unref?.();
+}
+
+export function stopIoScheduler(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = undefined;
+  }
+}
+
+/**
+ * Force a schedule to run immediately. Used by the `schedule_run_now` tool.
+ * Does not mutate next_run_at on success (the next regular tick handles that
+ * via fireSchedule).
+ */
+export async function runIoScheduleNow(id: number): Promise<boolean> {
+  const all = listIoSchedules();
+  const s = all.find((x) => x.id === id);
+  if (!s) return false;
+  await fireSchedule(s);
+  return true;
+}

--- a/src/copilot/scheduler.ts
+++ b/src/copilot/scheduler.ts
@@ -11,7 +11,7 @@
 // Schedules survive daemon restarts because next_run_at is persisted. On
 // startup we backfill any next_run_at fields that became stale (or are NULL).
 
-import { listSchedules, listDueSchedules, recordScheduleRun, updateNextRun, type SquadSchedule } from "../store/schedules.js";
+import { listSchedules, listDueSchedules, recordScheduleRun, setScheduleTimestamps, updateNextRun, type SquadSchedule } from "../store/schedules.js";
 import { getSquad } from "../store/squads.js";
 import { delegateToAgent } from "./agents.js";
 import { nextRun } from "./cron.js";
@@ -145,11 +145,26 @@ export function stopScheduler(): void {
   timer = undefined;
 }
 
-/** Manually fire a schedule. Used by squad_schedule_run_now. */
+/**
+ * Manually fire a schedule. Used by squad_schedule_run_now.
+ *
+ * Snapshots last_run_at and next_run_at before firing and restores them
+ * after, so a manual fire never disturbs the regular schedule (a user
+ * testing a 05:00 schedule at 04:30 should not have today's 05:00 run
+ * skipped or shifted). The fireSchedule path itself advances both fields
+ * because that's correct for an automatic firing — only manual runs need
+ * to leave the schedule untouched.
+ */
 export async function runScheduleNow(scheduleId: number): Promise<{ ok: boolean; error?: string }> {
   const all = listSchedules();
   const s = all.find((x) => x.id === scheduleId);
   if (!s) return { ok: false, error: `Schedule ${scheduleId} not found` };
-  await fireSchedule(s);
+  const previousLast = s.last_run_at;
+  const previousNext = s.next_run_at;
+  try {
+    await fireSchedule(s);
+  } finally {
+    setScheduleTimestamps(scheduleId, previousLast, previousNext);
+  }
   return { ok: true };
 }

--- a/src/copilot/system-message.ts
+++ b/src/copilot/system-message.ts
@@ -127,6 +127,14 @@ Squads can be put on a recurring cron-style schedule. At the scheduled time IO w
 
 When a user asks something like "have the IO squad meet every weekday at 5AM to triage and prioritize", call \`squad_schedule_create\` with \`cron: "0 5 * * 1-5"\` and \`agenda: ["triage", "prioritize"]\`.
 
+### IO-level Schedules (squad-independent)
+For recurring work that doesn't belong to any project squad — daily digests, periodic health checks, monitoring loops, reminders — use the IO-level scheduler instead of inventing a placeholder squad.
+
+- \`schedule_create\` — create a recurring task. Each tick the configured prompt is delivered to the orchestrator as if a user had typed it. Cron is the same 5-field syntax as squad schedules.
+- \`schedule_list\`, \`schedule_pause\`, \`schedule_resume\`, \`schedule_delete\`, \`schedule_run_now\` mirror the squad-schedule lifecycle.
+
+When a user asks "remind me at 9AM every day to check the dashboard" or "every hour, summarize my open PRs", reach for \`schedule_create\` — not a squad.
+
 ### Agent Roles Are Dynamic
 **Do NOT use generic roles** like "developer" or "tester". Analyze the project first and create roles that match its actual technology stack. Examples:
 - IO project → "Copilot SDK Specialist", "Vue.js Frontend Dev", "Express API Engineer"

--- a/src/copilot/tools.ts
+++ b/src/copilot/tools.ts
@@ -7,6 +7,15 @@ import { homedir } from "os";
 import { UNIVERSES } from "./universes.js";
 import { validateCron, nextRun } from "./cron.js";
 import {
+  createIoSchedule,
+  deleteIoSchedule,
+  getIoSchedule,
+  listIoSchedules,
+  setIoScheduleEnabled,
+  updateIoScheduleNextRun,
+} from "../store/io-schedules.js";
+import { runIoScheduleNow } from "./io-scheduler.js";
+import {
   createSchedule,
   deleteSchedule,
   getSchedule,
@@ -1317,7 +1326,130 @@ export function createTools(deps: ToolDeps) {
     },
   });
 
-  return [wikiRead, wikiWrite, wikiSearch, wikiDelete, wikiList, squadCreate, squadRecall, squadStatus, squadLogDecision, squadDelegate, squadTaskStatus, squadDelete, squadAnalyze, squadAddAgent, squadAgents, squadRemoveAgent, squadSetLead, squadSetQA, squadTaskReviews, squadScheduleCreate, squadScheduleList, squadScheduleDelete, squadSchedulePause, squadScheduleResume, squadScheduleRunNow, skillList, skillInstall, skillRemove, skillSearch, configUpdate, checkUpdate, shell, fileOps, bash, readFile, viewTool, grepTool, strReplaceEditor, github];
+  // -------------------------------------------------------------------------
+  // IO-level (squad-independent) schedules.
+  // -------------------------------------------------------------------------
+  const scheduleCreate = defineTool("schedule_create", {
+    description:
+      "Schedule a recurring task for IO itself (no squad required). At the scheduled time, the prompt is delivered to the orchestrator as a background message, just like any TUI/Telegram input. Use for daily digests, health checks, monitoring, or any automation that does not belong to a project squad.",
+    skipPermission: true,
+    parameters: z.object({
+      name: z
+        .string()
+        .describe(
+          "Human-friendly name, e.g. 'Morning digest' or 'Hourly health check'",
+        ),
+      cron: z
+        .string()
+        .describe(
+          "Standard 5-field cron expression: 'minute hour dom month dow'. Examples: '0 5 * * *' = daily at 5:00, '0 9 * * 1-5' = 9AM weekdays, '*/15 * * * *' = every 15 minutes.",
+        ),
+      prompt: z
+        .string()
+        .describe(
+          "The prompt to send to the orchestrator each time the schedule fires. Treat it like the message a user would type — concrete, action-oriented.",
+        ),
+      notes: z
+        .string()
+        .optional()
+        .describe("Optional operator notes appended to the prompt."),
+    }),
+    handler: async ({ name, cron, prompt, notes }) => {
+      const v = validateCron(cron);
+      if (!v.ok) return `Invalid cron expression: ${v.error}`;
+      const created = createIoSchedule({
+        name,
+        cronExpr: cron,
+        prompt,
+        notes: notes ?? null,
+        nextRunAt: v.next.toISOString(),
+      });
+      return `⏰ Scheduled IO task "${created.name}" (id ${created.id}).\n- Cron: \`${cron}\`\n- Next run: ${v.next.toISOString()}`;
+    },
+  });
+
+  const scheduleList = defineTool("schedule_list", {
+    description:
+      "List all IO-level schedules (those not attached to a squad). For squad schedules, use squad_schedule_list.",
+    skipPermission: true,
+    parameters: z.object({}),
+    handler: async () => {
+      const schedules = listIoSchedules();
+      if (schedules.length === 0) {
+        return "No IO schedules configured.";
+      }
+      return schedules
+        .map((s) => {
+          const enabled = s.enabled ? "▶️ enabled" : "⏸️ paused";
+          const last = s.last_run_at ? `last ${s.last_run_at}` : "never run";
+          const next = s.next_run_at ?? "—";
+          const promptPreview =
+            s.prompt.length > 120 ? s.prompt.slice(0, 120) + "…" : s.prompt;
+          return `- **${s.name}** (id ${s.id}) — ${enabled}\n    cron: \`${s.cron_expr}\`\n    next: ${next} — ${last}\n    prompt: ${promptPreview.replace(/\n/g, " ")}${s.notes ? `\n    notes: ${s.notes}` : ""}`;
+        })
+        .join("\n");
+    },
+  });
+
+  const scheduleDelete = defineTool("schedule_delete", {
+    description: "Delete an IO schedule by id.",
+    skipPermission: true,
+    parameters: z.object({
+      id: z.number().int().describe("Schedule id (from schedule_list)"),
+    }),
+    handler: async ({ id }) => {
+      const existing = getIoSchedule(id);
+      if (!existing) return `IO schedule ${id} not found.`;
+      deleteIoSchedule(id);
+      return `🗑️ Deleted IO schedule "${existing.name}" (id ${id}).`;
+    },
+  });
+
+  const schedulePause = defineTool("schedule_pause", {
+    description:
+      "Pause an IO schedule so it stops firing (preserves config — resume with schedule_resume).",
+    skipPermission: true,
+    parameters: z.object({ id: z.number().int().describe("Schedule id") }),
+    handler: async ({ id }) => {
+      const existing = getIoSchedule(id);
+      if (!existing) return `IO schedule ${id} not found.`;
+      setIoScheduleEnabled(id, false);
+      return `⏸️ Paused IO schedule "${existing.name}" (id ${id}).`;
+    },
+  });
+
+  const scheduleResume = defineTool("schedule_resume", {
+    description:
+      "Resume a paused IO schedule. The next run is computed from now using the stored cron expression.",
+    skipPermission: true,
+    parameters: z.object({ id: z.number().int().describe("Schedule id") }),
+    handler: async ({ id }) => {
+      const existing = getIoSchedule(id);
+      if (!existing) return `IO schedule ${id} not found.`;
+      setIoScheduleEnabled(id, true);
+      try {
+        const next = nextRun(existing.cron_expr);
+        updateIoScheduleNextRun(id, next.toISOString());
+        return `▶️ Resumed IO schedule "${existing.name}" (id ${id}). Next run: ${next.toISOString()}`;
+      } catch (err) {
+        return `Resumed IO schedule "${existing.name}" but failed to compute next run: ${err instanceof Error ? err.message : String(err)}`;
+      }
+    },
+  });
+
+  const scheduleRunNow = defineTool("schedule_run_now", {
+    description:
+      "Manually fire an IO schedule immediately (useful for testing). Does not affect the next regularly-scheduled occurrence beyond the natural advance.",
+    skipPermission: true,
+    parameters: z.object({ id: z.number().int().describe("Schedule id") }),
+    handler: async ({ id }) => {
+      const ok = await runIoScheduleNow(id);
+      if (!ok) return `IO schedule ${id} not found.`;
+      return `🚀 Fired IO schedule ${id} now.`;
+    },
+  });
+
+  return [wikiRead, wikiWrite, wikiSearch, wikiDelete, wikiList, squadCreate, squadRecall, squadStatus, squadLogDecision, squadDelegate, squadTaskStatus, squadDelete, squadAnalyze, squadAddAgent, squadAgents, squadRemoveAgent, squadSetLead, squadSetQA, squadTaskReviews, squadScheduleCreate, squadScheduleList, squadScheduleDelete, squadSchedulePause, squadScheduleResume, squadScheduleRunNow, scheduleCreate, scheduleList, scheduleDelete, schedulePause, scheduleResume, scheduleRunNow, skillList, skillInstall, skillRemove, skillSearch, configUpdate, checkUpdate, shell, fileOps, bash, readFile, viewTool, grepTool, strReplaceEditor, github];
 }
 
 function walkDirectory(dir: string, maxDepth = 3, depth = 0): string[] {

--- a/src/copilot/tools.ts
+++ b/src/copilot/tools.ts
@@ -1316,7 +1316,7 @@ export function createTools(deps: ToolDeps) {
 
   const squadScheduleRunNow = defineTool("squad_schedule_run_now", {
     description:
-      "Manually fire a squad schedule immediately (useful for testing). Does not affect the next scheduled occurrence.",
+      "Manually fire a squad schedule immediately (useful for testing). last_run_at and next_run_at are preserved so the regular schedule is untouched.",
     skipPermission: true,
     parameters: z.object({ id: z.number().int().describe("Schedule id") }),
     handler: async ({ id }) => {
@@ -1439,7 +1439,7 @@ export function createTools(deps: ToolDeps) {
 
   const scheduleRunNow = defineTool("schedule_run_now", {
     description:
-      "Manually fire an IO schedule immediately (useful for testing). Does not affect the next regularly-scheduled occurrence beyond the natural advance.",
+      "Manually fire an IO schedule immediately (useful for testing). last_run_at and next_run_at are preserved so the regular schedule is untouched.",
     skipPermission: true,
     parameters: z.object({ id: z.number().int().describe("Schedule id") }),
     handler: async ({ id }) => {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -7,6 +7,7 @@ import { clearStaleTasks } from "./store/tasks.js";
 import { reconcileAgentStatuses, reconcileSquadStatuses } from "./store/squads.js";
 import { backfillReviewVerdicts } from "./copilot/review-backfill.js";
 import { startScheduler, stopScheduler } from "./copilot/scheduler.js";
+import { startIoScheduler, stopIoScheduler } from "./copilot/io-scheduler.js";
 import { config } from "./config.js";
 import { ensureWikiStructure } from "./wiki/fs.js";
 import { autoUpdate } from "./update.js";
@@ -145,6 +146,9 @@ export async function startDaemon(): Promise<void> {
   // Start the squad scheduler (background cron-style stand-ups).
   startScheduler();
 
+  // Start the IO-level scheduler (squad-independent recurring tasks).
+  startIoScheduler();
+
   console.log("[io] IO is fully operational.");
 
   // Notify Telegram if restarting
@@ -176,6 +180,7 @@ async function shutdown(): Promise<void> {
   }
 
   stopScheduler();
+  stopIoScheduler();
   await shutdownOrchestrator();
   try { await stopClient(); } catch { /* best effort */ }
   closeDb();

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -102,6 +102,19 @@ export function getDb(): BetterSqlite3.Database {
     )`,
     `CREATE INDEX IF NOT EXISTS idx_squad_schedules_due
        ON squad_schedules (enabled, next_run_at)`,
+    `CREATE TABLE IF NOT EXISTS io_schedules (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      cron_expr TEXT NOT NULL,
+      prompt TEXT NOT NULL,
+      notes TEXT,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      last_run_at DATETIME,
+      next_run_at DATETIME,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )`,
+    `CREATE INDEX IF NOT EXISTS idx_io_schedules_due
+       ON io_schedules (enabled, next_run_at)`,
   ];
 
   for (const migration of migrations) {

--- a/src/store/io-schedules.ts
+++ b/src/store/io-schedules.ts
@@ -1,0 +1,97 @@
+import { getDb } from "./db.js";
+
+export interface IoSchedule {
+  id: number;
+  name: string;
+  cron_expr: string;
+  prompt: string;
+  notes: string | null;
+  enabled: number; // 0 | 1
+  last_run_at: string | null;
+  next_run_at: string | null;
+  created_at: string;
+}
+
+export function createIoSchedule(input: {
+  name: string;
+  cronExpr: string;
+  prompt: string;
+  notes?: string | null;
+  nextRunAt: string;
+}): IoSchedule {
+  const db = getDb();
+  const info = db
+    .prepare(
+      `INSERT INTO io_schedules
+         (name, cron_expr, prompt, notes, enabled, next_run_at)
+       VALUES (?, ?, ?, ?, 1, ?)`,
+    )
+    .run(
+      input.name,
+      input.cronExpr,
+      input.prompt,
+      input.notes ?? null,
+      input.nextRunAt,
+    );
+  const id = Number(info.lastInsertRowid);
+  return getIoSchedule(id)!;
+}
+
+export function getIoSchedule(id: number): IoSchedule | undefined {
+  return getDb()
+    .prepare("SELECT * FROM io_schedules WHERE id = ?")
+    .get(id) as IoSchedule | undefined;
+}
+
+export function listIoSchedules(): IoSchedule[] {
+  return getDb()
+    .prepare("SELECT * FROM io_schedules ORDER BY id ASC")
+    .all() as IoSchedule[];
+}
+
+export function listDueIoSchedules(now: Date): IoSchedule[] {
+  return getDb()
+    .prepare(
+      `SELECT * FROM io_schedules
+        WHERE enabled = 1
+          AND next_run_at IS NOT NULL
+          AND next_run_at <= ?
+        ORDER BY next_run_at ASC`,
+    )
+    .all(now.toISOString()) as IoSchedule[];
+}
+
+export function deleteIoSchedule(id: number): boolean {
+  const info = getDb()
+    .prepare("DELETE FROM io_schedules WHERE id = ?")
+    .run(id);
+  return info.changes > 0;
+}
+
+export function setIoScheduleEnabled(id: number, enabled: boolean): boolean {
+  const info = getDb()
+    .prepare("UPDATE io_schedules SET enabled = ? WHERE id = ?")
+    .run(enabled ? 1 : 0, id);
+  return info.changes > 0;
+}
+
+export function recordIoScheduleRun(
+  id: number,
+  ranAt: Date,
+  nextRunAt: string | null,
+): void {
+  getDb()
+    .prepare(
+      "UPDATE io_schedules SET last_run_at = ?, next_run_at = ? WHERE id = ?",
+    )
+    .run(ranAt.toISOString(), nextRunAt, id);
+}
+
+export function updateIoScheduleNextRun(
+  id: number,
+  nextRunAt: string | null,
+): void {
+  getDb()
+    .prepare("UPDATE io_schedules SET next_run_at = ? WHERE id = ?")
+    .run(nextRunAt, id);
+}

--- a/src/store/io-schedules.ts
+++ b/src/store/io-schedules.ts
@@ -95,3 +95,20 @@ export function updateIoScheduleNextRun(
     .prepare("UPDATE io_schedules SET next_run_at = ? WHERE id = ?")
     .run(nextRunAt, id);
 }
+
+/**
+ * Overwrite both last_run_at and next_run_at directly. Unlike
+ * recordIoScheduleRun this accepts NULL for last_run_at, which is needed when
+ * restoring a schedule's "never run" state after a manual run_now.
+ */
+export function setIoScheduleTimestamps(
+  id: number,
+  lastRunAt: string | null,
+  nextRunAt: string | null,
+): void {
+  getDb()
+    .prepare(
+      "UPDATE io_schedules SET last_run_at = ?, next_run_at = ? WHERE id = ?",
+    )
+    .run(lastRunAt, nextRunAt, id);
+}

--- a/src/store/schedules.ts
+++ b/src/store/schedules.ts
@@ -125,3 +125,20 @@ export function updateNextRun(id: number, nextRunAt: string | null): void {
     .prepare("UPDATE squad_schedules SET next_run_at = ? WHERE id = ?")
     .run(nextRunAt, id);
 }
+
+/**
+ * Overwrite both last_run_at and next_run_at directly. Unlike
+ * recordScheduleRun this accepts NULL for last_run_at, which is needed when
+ * restoring a schedule's "never run" state after a manual run_now.
+ */
+export function setScheduleTimestamps(
+  id: number,
+  lastRunAt: string | null,
+  nextRunAt: string | null,
+): void {
+  getDb()
+    .prepare(
+      "UPDATE squad_schedules SET last_run_at = ?, next_run_at = ? WHERE id = ?",
+    )
+    .run(lastRunAt, nextRunAt, id);
+}


### PR DESCRIPTION
Closes #58.

## Summary
Native scheduling for IO itself — no squad required. Mirrors the squad scheduler in shape but dispatches into the orchestrator via `sendToOrchestrator` with a `background` source, so a scheduled task is handled the same way as a TUI/Telegram message.

## New tools
- `schedule_create` — name + cron + prompt + optional notes
- `schedule_list`
- `schedule_pause` / `schedule_resume`
- `schedule_delete`
- `schedule_run_now` — manual fire for testing

## Storage
New `io_schedules` table: id, name, cron_expr, prompt, notes, enabled, last_run_at, next_run_at, created_at. Indexed on (enabled, next_run_at) to match the squad-schedules pattern.

## Scheduler
`src/copilot/io-scheduler.ts` — 30s tick, in-flight guard, advances `next_run_at` before dispatch (no double-fires), startup reconcile that skips missed runs (same semantics as squad scheduler). Wired into `src/daemon.ts` start/stop.

## System message
Adds an "IO-level Schedules (squad-independent)" section so the orchestrator reaches for `schedule_create` on prompts like "remind me every morning at 9AM to check the dashboard".

## Verification
Build clean. End-to-end CRUD + reconcile smoke test on a fresh DB:
- create → enabled, next_run_at set
- pause → enabled=0
- resume + reconcile → next_run_at advanced
- delete → removed

🦁