### PR TITLE
Require fetch + branch-from-main preamble for all agents (#46)

### DIFF
--- a/src/copilot/agents.ts
+++ b/src/copilot/agents.ts
@@ -422,6 +422,17 @@ ${agent.charter ?? "General-purpose agent. Handle tasks as they come."}
 ## Past Decisions
 ${decisions}${leadSection}
 
+## Repository Hygiene
+Before you make ANY code changes, you MUST sync your working copy with the remote default branch and work from a fresh feature branch. This prevents the merge conflicts the team hit on PRs like #45.
+
+1. \`cd\` to the project path above.
+2. \`git fetch origin\` — pick up everything that has merged since your last task.
+3. \`git checkout main && git pull origin main\` — fast-forward your local main.
+4. \`git checkout -b <your-handle>/<short-slug>\` — create a fresh branch from the updated main. Never commit directly to main, and never reuse a stale branch from a prior task.
+5. Only THEN start editing files, running tools, or delegating subtasks.
+
+If the project's default branch is not \`main\` (e.g. \`master\`, \`develop\`), substitute it everywhere above. If you are not in a git repository, skip this section and proceed normally.
+
 ## Instructions
 You are a coding agent. Use the shell tool to run commands and file_ops to read/write files.
 Log important decisions with squad_log_decision so they persist.

--- a/src/copilot/system-message.ts
+++ b/src/copilot/system-message.ts
@@ -198,5 +198,6 @@ The model is selected automatically. Tell the user which model tier was chosen w
 7. **Use your tools proactively.** When a task requires shell or file operations, call the appropriate tool immediately. Do not describe what command you *would* run — just run it. For git operations, use the \`shell\` tool. For file operations, use \`file_ops\` or \`shell\`.
 8. **Never fabricate errors.** Only report errors that a tool actually returned. If you haven't called a tool, you don't know whether it will succeed or fail.
 9. **Prefer your custom tools over built-in tools.** Always use \`shell\` instead of \`bash\`. Always use \`file_ops\` instead of built-in file tools like \`str_replace_editor\` or \`read_file\`.
+10. **Pull main before starting code work.** Whether you delegate to a squad or operate on a repo directly, the first step on ANY coding task is \`git fetch origin && git checkout main && git pull origin main\` followed by creating a fresh feature branch. Squad agents are also instructed to do this — remind them if they appear to skip it.
 ${selfEditBlock}${memoryBlock}`;
 }


### PR DESCRIPTION
Closes #46.

## Problem
PRs like #45 hit avoidable merge conflicts because the branching agent started from a stale local clone. The merge base predated recent merges into `main`, even though those merges had nothing to do with the agent's task.

## Fix
Every squad agent now sees a mandatory **Repository Hygiene** section at the top of its system message (in `src/copilot/agents.ts`), inserted right after the Charter and before generic Instructions:

1. `cd` to the project path
2. `git fetch origin`
3. `git checkout main && git pull origin main`
4. `git checkout -b <handle>/<slug>` — fresh branch from updated main
5. Only THEN edit files or delegate subtasks

Includes the right escape hatches:
- Default branch is configurable (mentions `master`/`develop`).
- Non-git directories: skip the section and proceed normally.

The same rule is mirrored in IO's own system message as guideline #10 so direct-mode coding work follows the same hygiene, and IO can remind squad agents that appear to skip it.

## Why the system message and not the per-task prompt
The system message persists across session resumes — a system-message change applies to every future task on every agent that gets a fresh session (or whose session re-bootstraps), without needing to thread plumbing through `delegateToAgent`. The per-task prompt fires once and is invisible after the session compacts.

## Verify
`npm run build` — clean (tsc).