### PR TITLE
Apply Repository Hygiene to getOrCreateSession fallback (#69)

### DIFF
--- a/src/copilot/agents.ts
+++ b/src/copilot/agents.ts
@@ -498,6 +498,17 @@ async function getOrCreateSession(
 ## Past Decisions
 ${decisions}
 
+## Repository Hygiene
+Before you make ANY code changes, you MUST sync your working copy with the remote default branch and work from a fresh feature branch. This prevents the merge conflicts the team hit on PRs like #45.
+
+1. \`cd\` to the project path above.
+2. \`git fetch origin\` — pick up everything that has merged since your last task.
+3. \`git checkout main && git pull origin main\` — fast-forward your local main.
+4. \`git checkout -b <your-handle>/<short-slug>\` — create a fresh branch from the updated main. Never commit directly to main, and never reuse a stale branch from a prior task.
+5. Only THEN start editing files, running tools, or delegating subtasks.
+
+If the project's default branch is not \`main\` (e.g. \`master\`, \`develop\`), substitute it everywhere above. If you are not in a git repository, skip this section and proceed normally.
+
 ## Your Role
 You are a coding agent. Use the shell tool to run commands and file_ops to read/write files.
 Log important decisions with squad_log_decision so they persist.`,


### PR DESCRIPTION
Closes #69. Follow-up to #68.

## Gap
PR #68 added the **Repository Hygiene** block to `getOrCreateAgentSession` (the named-agent path in `src/copilot/agents.ts`) but missed `getOrCreateSession`, the legacy fallback used when a squad has no named agents or when no specific target agent is identified. That left a hole — squad-wide dispatches into that path skipped the rule entirely.

## Fix
Identical block, identical wording, inserted between `## Past Decisions` and `## Your Role` in the fallback's system message. Both code paths now produce sessions that begin work with the same fetch → checkout main → pull → fresh-branch contract.

## Verify
`npm run build` — clean (tsc).