### PR TITLE
Enforce dedicated team lead + expanded veto power (#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- **Dedicated team lead enforcement** (#71) — squad creation guidance now requires the team lead to be a PM / Senior Engineer with **no domain responsibility** (their sole job is coordinating, delegating, and reviewing). `squad_status`, `squad_agents`, and `squad_delegate` now surface a ⚠️ coverage warning when no lead is designated *or* when the lead's role title looks like a domain specialist (e.g. "Frontend Lead", "Test Manager"). `squad_set_lead` echoes the same warning at designation time. The team lead's automatic veto power on PR promotion (added in #48) is now documented alongside QA veto power as first-class — any QA reviewer, test engineer (when designated as QA), or the team lead can block a draft PR from being promoted to ready.
+
 ## [0.4.0] - 2026-05-13
 
 ### Added

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -54,6 +54,9 @@ All tools are created in `src/copilot/tools.ts` via the `createTools(deps)` fact
 | `squad_status` | List all squads and their status | _(none)_ |
 | `squad_log_decision` | Log an important decision for a squad | `slug: string` — squad slug; `decision: string` — the decision made; `context?: string` — reasoning |
 | `squad_delegate` | Delegate a task to a squad's worker agent | `slug: string` — squad slug; `task: string` — the task to delegate; `agent?: string` — character name of a specific agent to target (e.g., `"Hannibal"`, `"Optimus Prime"`) |
+| `squad_set_lead` | Designate an agent as the squad's team lead. The lead must be a **dedicated PM / Senior Engineer with no domain responsibility** — their sole job is coordinating, delegating, and reviewing. The lead automatically holds veto power on PR promotion. | `slug: string` — squad slug; `character_name: string` — character name of the agent to make team lead |
+| `squad_set_qa` | Mark a squad agent as a QA reviewer with veto power. QA agents must approve before a PR is promoted from draft to ready. | `slug: string` — squad slug; `character_name: string` — character name of the agent; `is_qa: boolean` — whether this agent is a QA reviewer |
+| `squad_task_reviews` | Get the peer reviews left on a completed task. Reviewers tagged ⭐ (lead) and 🛡️ (QA) hold veto power — any rejection from either blocks PR promotion. | `task_id: string` — the task ID to fetch reviews for |
 | `squad_delete` | Delete a squad | `slug: string` — squad slug |
 
 #### Available Universes
@@ -70,6 +73,16 @@ When creating a squad, you can optionally specify one of six 80s pop culture uni
 | `ghostbusters` | Venkman, Egon, Ray, Winston, Janine, Louis, Dana, Gozer |
 
 Each character comes with a personality description that influences the agent's communication style in its responses.
+
+#### Squad Coverage Warnings
+
+`squad_status`, `squad_agents`, and `squad_delegate` surface a ⚠️ warning when any of the following are missing:
+
+- A **dedicated team lead** designated via `squad_set_lead` whose role is coordination-only (PM / Senior Engineer with no domain responsibility). The warning also fires if a lead is set but their role title looks like a domain specialist (e.g. "Frontend Lead", "Test Manager").
+- A **QA reviewer** designated via `squad_set_qa`.
+- A **test/quality engineer** — an agent whose `role_title` contains `test`, `qa`, or `quality`.
+
+Delegation is not blocked by these warnings, but the gap should be fixed before promoting work. The team lead, QA reviewers, and test engineers (when designated as QA) all hold veto power on PR promotion — any rejection from any of them keeps the PR as a draft.
 
 ### Shell
 

--- a/src/copilot/system-message.ts
+++ b/src/copilot/system-message.ts
@@ -99,24 +99,25 @@ Squads are persistent project teams with **named specialist agents**. Each squad
 Only specify an \`agent\` when the user **explicitly asks** to target a specific squad member by name.
 
 ### Team Leads
-Every squad should have a **team lead**. After building the team with \`squad_add_agent\`, designate one agent as the lead using \`squad_set_lead\`. The lead receives delegated tasks (when no specific agent is targeted), breaks them into subtasks, and assigns work to teammates via the lead-only \`delegate_to_teammate\` tool. This keeps coordination inside the squad rather than forcing IO to micro-manage assignments.
+Every squad **must** have a **dedicated team lead** — a PM / Senior Engineer whose **sole** responsibility is coordinating the team, delegating tasks, and reviewing results. The lead must NOT also own a hands-on engineering domain (no "Frontend Lead", "Test Manager", or "QA Lead" — those mix coordination with domain ownership). When building the squad, explicitly add a lead agent with a role title like "Senior Engineering Lead", "Project Manager", "Tech Lead", or "Principal Engineer" *in addition to* the domain specialists, then designate them with \`squad_set_lead\`. The lead receives delegated tasks (when no specific agent is targeted), breaks them into subtasks, assigns work to teammates via the lead-only \`delegate_to_teammate\` tool, and holds automatic veto power on PR promotion. This keeps coordination inside the squad rather than forcing IO to micro-manage assignments.
 
 ### Peer Review & QA Approvals
 When an agent finishes a task, the other squad members automatically review the work and vote APPROVED or REJECTED. Reviews are recorded and emitted as \`task.review\` events.
 
-- **Required**: every squad must have at least one agent designated as QA via \`squad_set_qa\`, AND at least one agent whose role title implies a testing/quality focus (e.g. role contains "test", "qa", or "quality"). Both can be the same agent.
-- \`squad_status\`, \`squad_agents\`, and \`squad_delegate\` will surface a ⚠️ warning when either is missing. Delegation is not blocked, but you should fix the gap before promoting work.
-- **QA agents and the team lead have veto power**: if any QA reviewer or the team lead rejects, the PR stays as a draft. The lead's veto is automatic — no need to also designate them as QA.
+- **Required**: every squad must have (1) a **dedicated team lead** designated via \`squad_set_lead\` whose role is coordination-only with no domain ownership, (2) at least one agent designated as QA via \`squad_set_qa\`, and (3) at least one agent whose role title implies a testing/quality focus (e.g. role contains "test", "qa", or "quality"). The QA and test-engineer roles can be the same agent, but the lead must be separate from the domain specialists.
+- \`squad_status\`, \`squad_agents\`, and \`squad_delegate\` will surface a ⚠️ warning when any of these are missing — including when a lead is set but their role title looks like a domain specialist. Delegation is not blocked, but you should fix the gap before promoting work.
+- **QA agents, test engineers, and the team lead all have veto power**: if any of them rejects, the PR stays as a draft. The lead's veto is automatic — no need to also designate them as QA. Designating your test engineer as QA gives them the same explicit veto authority.
 - Non-QA rejections are advisory — they're recorded but don't block promotion.
 - When all QA approvals pass (or no QA agents exist) and the task result contains a GitHub PR URL, the PR is automatically promoted from draft to ready via \`gh pr ready\`.
 - Use \`squad_task_reviews\` to inspect the reviews on any completed task.
 
 ### Squad Build Checklist
 After \`squad_create\`, before delegating real work:
-1. Add agents with \`squad_add_agent\` (use roles tailored to the project's stack).
-2. Include at least one **test/quality engineer** role (e.g. "Integration Test Engineer", "QA Specialist", "Quality Reviewer").
-3. Designate a team lead with \`squad_set_lead\`.
-4. Designate at least one QA reviewer with \`squad_set_qa\` (often the same agent as the test engineer).
+1. Add domain-specialist agents with \`squad_add_agent\` (use roles tailored to the project's stack).
+2. Add a **dedicated team lead agent** with a coordination-only role like "Senior Engineering Lead", "Project Manager", "Tech Lead", or "Principal Engineer". The lead must NOT also own a hands-on domain (no "Frontend Lead" — that's still a frontend engineer).
+3. Include at least one **test/quality engineer** role (e.g. "Integration Test Engineer", "QA Specialist", "Quality Reviewer"). This is a separate agent from the lead.
+4. Designate the team lead with \`squad_set_lead\`. The lead automatically holds veto power on PR promotion.
+5. Designate at least one QA reviewer with \`squad_set_qa\` (often the same agent as the test engineer). QA reviewers also hold veto power.
 
 ### Scheduled Stand-ups
 Squads can be put on a recurring cron-style schedule. At the scheduled time IO wakes the team lead, who runs the agenda by delegating to teammates. This runs in the background even when no human is in the TUI/Telegram.

--- a/src/copilot/tools.ts
+++ b/src/copilot/tools.ts
@@ -25,11 +25,15 @@ import {
 import { runScheduleNow } from "./scheduler.js";
 
 // ---------------------------------------------------------------------------
-// QA / test coverage heuristics
+// Squad coverage heuristics
 //
 // Every squad must have:
-//   1. At least one agent designated as QA (is_qa === 1) - see squad_set_qa.
-//   2. At least one agent whose role title implies a testing/quality focus.
+//   1. A dedicated team lead — a PM / Senior Engineer with no domain
+//      responsibility — designated via squad_set_lead. The lead's job is
+//      coordination, delegation, and review only. Lead veto power on PR
+//      promotion is automatic (see runPeerReview in agents.ts).
+//   2. At least one agent designated as QA (is_qa === 1) — see squad_set_qa.
+//   3. At least one agent whose role title implies a testing/quality focus.
 //
 // These are surfaced as warnings on squad_status, squad_agents, and
 // squad_delegate so users can fix coverage gaps before promoting work.
@@ -37,16 +41,96 @@ import { runScheduleNow } from "./scheduler.js";
 
 const TEST_ROLE_KEYWORDS = ["test", "qa", "quality", "tester", "sdet", "qe"];
 
+// Words in a role title that imply the agent owns a hands-on engineering
+// domain (and therefore should NOT be the team lead).
+const DOMAIN_ROLE_KEYWORDS = [
+  "frontend",
+  "backend",
+  "fullstack",
+  "full-stack",
+  "api",
+  "ui",
+  "ux",
+  "test",
+  "tester",
+  "qa",
+  "quality",
+  "sdet",
+  "qe",
+  "devops",
+  "sre",
+  "ops",
+  "infrastructure",
+  "platform",
+  "data",
+  "database",
+  "db",
+  "ml",
+  "ai",
+  "sdk",
+  "mobile",
+  "ios",
+  "android",
+  "web",
+  "security",
+  "embedded",
+  "integration",
+  "telegram",
+  "tui",
+  "vue",
+  "react",
+  "angular",
+  "express",
+  "sqlite",
+  "wiki",
+];
+
+// Words that mark a role as coordination/leadership-focused.
+const LEAD_ROLE_KEYWORDS = [
+  "lead",
+  "manager",
+  "pm",
+  "principal",
+  "coordinator",
+  "director",
+];
+
+function containsWord(haystack: string, word: string): boolean {
+  const re = new RegExp(`(^|[^a-z])${word}([^a-z]|$)`);
+  return re.test(haystack);
+}
+
 export function roleLooksLikeTesting(roleTitle: string | null | undefined): boolean {
   if (!roleTitle) return false;
   const lower = roleTitle.toLowerCase();
-  return TEST_ROLE_KEYWORDS.some((kw) => {
-    const re = new RegExp(`(^|[^a-z])${kw}([^a-z]|$)`);
-    return re.test(lower);
-  });
+  return TEST_ROLE_KEYWORDS.some((kw) => containsWord(lower, kw));
+}
+
+/**
+ * A dedicated team lead has a role title that emphasises coordination/seniority
+ * and does NOT also claim a hands-on engineering domain. Examples:
+ *   ✅ "Engineering Lead", "Project Manager", "Senior Engineering Lead",
+ *      "Principal Engineer", "Tech Lead", "Senior Engineer"
+ *   ❌ "Frontend Lead", "Test Manager", "QA Lead", "Backend Engineer",
+ *      "Express API Engineer"
+ */
+export function roleLooksLikeDedicatedLead(
+  roleTitle: string | null | undefined,
+): boolean {
+  if (!roleTitle) return false;
+  const lower = roleTitle.toLowerCase();
+  const hasDomainKw = DOMAIN_ROLE_KEYWORDS.some((kw) => containsWord(lower, kw));
+  if (hasDomainKw) return false;
+  const hasLeadKw = LEAD_ROLE_KEYWORDS.some((kw) => containsWord(lower, kw));
+  if (hasLeadKw) return true;
+  // "Senior Engineer" / "Sr. Engineer" with no domain qualifier also counts.
+  if (/(^|[^a-z])(senior|sr\.?)\s+engineer($|[^a-z])/.test(lower)) return true;
+  return false;
 }
 
 export interface SquadCoverage {
+  hasLead: boolean;
+  hasDedicatedLead: boolean;
   hasQa: boolean;
   hasTestRole: boolean;
   missing: string[];
@@ -54,21 +138,35 @@ export interface SquadCoverage {
 }
 
 export function assessSquadCoverage(
-  agents: Array<{ role_title: string; is_qa?: number }>,
+  agents: Array<{ role_title: string; is_qa?: number; is_lead?: number }>,
 ): SquadCoverage {
+  const leadAgent = agents.find((a) => a.is_lead === 1);
+  const hasLead = !!leadAgent;
+  const hasDedicatedLead =
+    !!leadAgent && roleLooksLikeDedicatedLead(leadAgent.role_title);
   const hasQa = agents.some((a) => a.is_qa === 1);
   const hasTestRole = agents.some((a) => roleLooksLikeTesting(a.role_title));
   const missing: string[] = [];
+  if (!hasLead) {
+    missing.push(
+      "dedicated team lead (use squad_set_lead with a PM/Senior Engineer who owns no domain)",
+    );
+  } else if (!hasDedicatedLead) {
+    missing.push(
+      `dedicated lead role (current lead "${leadAgent!.role_title}" looks like a domain specialist — team leads must be PM/Senior Engineer with no domain ownership)`,
+    );
+  }
   if (!hasQa) missing.push("QA reviewer (use squad_set_qa)");
   if (!hasTestRole) {
     missing.push(
       "test/quality engineer (add an agent whose role_title contains 'test', 'qa', or 'quality')",
     );
   }
-  const warning = missing.length > 0
-    ? `⚠️ Squad coverage gap: missing ${missing.join(" and ")}.`
-    : null;
-  return { hasQa, hasTestRole, missing, warning };
+  const warning =
+    missing.length > 0
+      ? `⚠️ Squad coverage gap: missing ${missing.join("; ")}.`
+      : null;
+  return { hasLead, hasDedicatedLead, hasQa, hasTestRole, missing, warning };
 }
 
 // Ensure child processes have HOME set (systemd services often don't)
@@ -267,7 +365,7 @@ export function createTools(deps: ToolDeps) {
         }, agent);
         const agentLabel = agent ? `agent "${agent}" in squad "${slug}"` : `squad "${slug}"`;
         const warningPrefix = coverage.warning
-          ? `${coverage.warning} Reviews from this squad will not be vetoed by a designated QA agent until this is fixed.\n\n`
+          ? `${coverage.warning} A dedicated lead and a QA reviewer should both hold veto power on PR promotion — fix gaps before promoting work.\n\n`
           : "";
         return `${warningPrefix}Task delegated to ${agentLabel}. Task ID: ${taskId}\n\nThe agent is working on this in the background. Use squad_task_status to check progress.`;
       } catch (err) {
@@ -1167,13 +1265,15 @@ export function createTools(deps: ToolDeps) {
 
   const squadSetLead = defineTool("squad_set_lead", {
     description:
-      "Designate an agent as the team lead for their squad. The lead receives delegated tasks (when no specific agent is targeted) and orchestrates the team by divvying subtasks to teammates.",
+      "Designate an agent as the team lead for their squad. The lead MUST be a dedicated PM / Senior Engineer with NO domain responsibility — their sole job is coordinating, delegating, and reviewing the team's work. Do not pick an agent who also owns the backend, frontend, tests, or any other implementation domain. The lead receives delegated tasks (when no specific agent is targeted), orchestrates the team via delegate_to_teammate, and holds automatic veto power on PR promotion.",
     skipPermission: true,
     parameters: z.object({
       slug: z.string().describe("Squad slug"),
       character_name: z
         .string()
-        .describe("Character name of the agent to make team lead"),
+        .describe(
+          "Character name of the agent to make team lead. Choose a PM / Senior Engineer with no domain ownership.",
+        ),
     }),
     handler: async ({ slug, character_name }) => {
       try {
@@ -1185,7 +1285,12 @@ export function createTools(deps: ToolDeps) {
           return `Agent "${character_name}" not found in squad "${slug}". Use squad_agents to list the roster.`;
         }
         deps.setSquadLead(slug, character_name);
-        return `⭐ ${character_name} (${target.role_title}) is now the team lead for squad "${squad.name}".`;
+        const dedicated = roleLooksLikeDedicatedLead(target.role_title);
+        const base = `⭐ ${character_name} (${target.role_title}) is now the team lead for squad "${squad.name}". They have automatic veto power on PR promotion.`;
+        if (!dedicated) {
+          return `${base}\n\n⚠️ "${target.role_title}" looks like a domain specialist. Team leads should be a dedicated PM / Senior Engineer with no other domain responsibility — consider adding a dedicated lead agent (e.g. role "Senior Engineering Lead" or "Project Manager") and reassigning.`;
+        }
+        return base;
       } catch (err) {
         return `Error: ${err instanceof Error ? err.message : String(err)}`;
       }


### PR DESCRIPTION
Closes #71.

## Summary

Tightens squad creation to require a **dedicated team lead** (PM / Senior Engineer with no domain responsibility) and formalises that QA reviewers, test engineers (when designated as QA), AND the team lead all hold veto power on PR promotion.

## Changes

### 1. Dedicated lead enforcement (coverage warning)
- New `roleLooksLikeDedicatedLead(role)` heuristic in `src/copilot/tools.ts`: a role is "dedicated" iff it contains a coordination keyword (`lead`, `manager`, `pm`, `principal`, `coordinator`, `director`) — *or* matches "Senior Engineer" — **and** contains no hands-on domain keyword (`frontend`, `backend`, `api`, `test`, `qa`, `sdk`, `vue`, `express`, etc.). Examples: ✅ \"Senior Engineering Lead\", \"Project Manager\", \"Principal Engineer\" — ❌ \"Frontend Lead\", \"Test Manager\", \"Express API Engineer\".
- `assessSquadCoverage` now reports `hasLead` and `hasDedicatedLead` and emits a ⚠️ warning when either is missing. The same warning is already surfaced by `squad_status`, `squad_agents`, and `squad_delegate`, so propagation is automatic.
- `squad_set_lead` updates its description to spell out the requirement and echoes a warning at designation time when the chosen agent's role title looks domain-y.

### 2. Veto power (already implemented in #48, now documented)
The team lead's veto on PR auto-promotion already exists in `runPeerReview` (agents.ts:907-949). This PR documents it as first-class alongside QA veto. To give a test engineer explicit veto power, designate them as QA via `squad_set_qa` (often the same agent — already supported).

### 3. Docs / system message
- `src/copilot/system-message.ts`: rewrote the **Team Leads** section, **Peer Review & QA Approvals** required-coverage bullet, and **Squad Build Checklist** to require a separate, coordination-only lead agent.
- `docs/reference/tools.md`: added `squad_set_lead`, `squad_set_qa`, `squad_task_reviews` to the squad-tools table, plus a new \"Squad Coverage Warnings\" subsection.
- `CHANGELOG.md`: new `[Unreleased]` entry.

## Acceptance criteria
- [x] Squad creation docs/system message requires a dedicated PM/Senior lead with no domain responsibility
- [x] Team lead is automatically granted veto power on peer reviews (alongside QA agents) — preserved from #48, now first-class in docs
- [x] Warning surfaced if no dedicated lead is designated (in `squad_status`, `squad_agents`, `squad_delegate`)
- [x] `squad_set_lead` enforces/documents this expectation (description + post-designation warning)

## Verification
- `npx tsc --noEmit` clean.
- Smoke-tested `roleLooksLikeDedicatedLead` + `assessSquadCoverage` against a dozen role titles (positives, negatives, lead-but-domainy, no-lead-at-all) — all expected results.