### PR TITLE
Install skills from the Skills tab (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Install skills from the web UI** (#21) — the Skills tab now has an "Add Skill" form. Enter a git repository URL and click **Install** to install a skill without leaving the browser (mirrors the existing `skill_install` tool / TUI / Telegram path). The skills list refreshes after a successful install; validation and install errors are surfaced inline. Backed by a new `POST /api/skills` endpoint (auth-protected) that reuses `installSkill(repoUrl)` from `src/copilot/skills.ts`.
+
+
 ### Changed
 
 - **Lead briefing + fan-out enforcement** (#51) — the team-lead system message now mandates a fan-out plan (work-area breakdown + charter-keyed teammate scoring + per-area subtask) before the lead may touch shell, files, or self-implement. Direct lead implementation is restricted to trivial single-file changes that fit no teammate's charter.

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 import { existsSync } from "node:fs";
 import express, { type Request, type Response } from "express";
 import { config } from "../config.js";
-import { listSkills } from "../copilot/skills.js";
+import { listSkills, installSkill } from "../copilot/skills.js";
 import { listSquads, createSquad, listSquadAgents } from "../store/squads.js";
 import { getAgentInfo, cancelAgentTask, getTaskEvents, subscribeToTaskEvents } from "../copilot/agents.js";
 import { summarize, summarizeEvent } from "../copilot/event-summary.js";
@@ -84,6 +84,40 @@ export async function startApiServer(): Promise<void> {
     } catch (e) {
       console.error("Error listing skills:", e);
       res.status(500).json({ error: "Failed to list skills" });
+    }
+  });
+
+
+  // Install a skill from a git repo URL (mirrors the skill_install tool)
+  api.post("/skills", async (req: Request, res: Response) => {
+    const { repoUrl } = req.body as { repoUrl?: unknown };
+
+    if (repoUrl === undefined || repoUrl === null || typeof repoUrl !== "string") {
+      res.status(400).json({ error: "Missing required field: repoUrl" });
+      return;
+    }
+    if (repoUrl.trim() === "") {
+      res.status(400).json({ error: "repoUrl must not be empty" });
+      return;
+    }
+    const trimmed = repoUrl.trim();
+    const looksLikeGitUrl =
+      trimmed.startsWith("http://") ||
+      trimmed.startsWith("https://") ||
+      trimmed.startsWith("git@") ||
+      trimmed.startsWith("git://") ||
+      trimmed.endsWith(".git");
+    if (!looksLikeGitUrl) {
+      res.status(400).json({ error: "repoUrl does not look like a git repository URL" });
+      return;
+    }
+
+    try {
+      const skill = await installSkill(trimmed);
+      res.status(201).json({ skill });
+    } catch (e) {
+      console.error("Error installing skill:", e);
+      res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
     }
   });
 

--- a/web/src/views/SkillsView.vue
+++ b/web/src/views/SkillsView.vue
@@ -3,6 +3,36 @@
     <div class="flex-1 overflow-y-auto p-6">
       <h2 class="text-2xl font-bold mb-6">Skills</h2>
 
+      <!-- Add Skill form -->
+      <form @submit.prevent="installSkill" class="mb-6 max-w-2xl">
+        <div class="flex gap-2">
+          <input
+            v-model="newRepoUrl"
+            type="url"
+            placeholder="https://github.com/owner/repo.git"
+            aria-label="Git repository URL"
+            :disabled="installing"
+            class="flex-1 bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:border-blue-500 disabled:opacity-50"
+          />
+          <button
+            type="submit"
+            :disabled="installing || newRepoUrl.trim() === ''"
+            class="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:opacity-50 text-white px-4 py-2 rounded text-sm transition-colors whitespace-nowrap"
+          >
+            {{ installing ? 'Installing…' : 'Install' }}
+          </button>
+        </div>
+      </form>
+
+      <!-- Install feedback banners -->
+      <div v-if="installSuccess" class="bg-green-900 text-green-100 p-4 rounded-lg mb-4">
+        {{ installSuccess }}
+      </div>
+      <div v-if="installError" class="bg-red-900 text-red-100 p-4 rounded-lg mb-4">
+        {{ installError }}
+      </div>
+
+      <!-- Skills list -->
       <div v-if="loading" class="text-gray-400 text-center py-12">
         Loading skills...
       </div>
@@ -50,7 +80,12 @@ const skills = ref<Skill[]>([])
 const loading = ref(true)
 const error = ref<string | null>(null)
 
-onMounted(async () => {
+const newRepoUrl = ref<string>('')
+const installing = ref(false)
+const installError = ref<string | null>(null)
+const installSuccess = ref<string | null>(null)
+
+async function fetchSkills(): Promise<void> {
   try {
     const response = await apiFetch('/api/skills')
     if (!response.ok) {
@@ -63,7 +98,48 @@ onMounted(async () => {
   } finally {
     loading.value = false
   }
-})
+}
+
+async function installSkill(): Promise<void> {
+  if (installing.value || newRepoUrl.value.trim() === '') return
+  installing.value = true
+  installError.value = null
+  installSuccess.value = null
+
+  try {
+    const response = await apiFetch('/api/skills', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ repoUrl: newRepoUrl.value.trim() }),
+    })
+
+    if (response.ok) {
+      const data = (await response.json()) as { skill: Skill }
+      // Optimistic prepend for instant feedback while refetch is in flight
+      skills.value = [data.skill, ...skills.value]
+      newRepoUrl.value = ''
+      installSuccess.value = `✓ Installed: ${data.skill.name}`
+      setTimeout(() => { installSuccess.value = null }, 4000)
+      // Refetch so dedup/ordering from the server takes effect
+      void fetchSkills()
+    } else {
+      let message = 'Install failed'
+      try {
+        const body = (await response.json()) as { error?: string }
+        message = body.error ?? response.statusText ?? message
+      } catch {
+        message = response.statusText || message
+      }
+      installError.value = message
+    }
+  } catch (e) {
+    installError.value = e instanceof Error ? e.message : 'Install failed'
+  } finally {
+    installing.value = false
+  }
+}
+
+onMounted(fetchSkills)
 </script>
 
 <style scoped>


### PR DESCRIPTION
Closes #21.

## What

Adds an **Add Skill** form to the Skills tab of the web UI. Users can paste a git repository URL and click **Install** to install a skill — same effect as the existing `skill_install` tool / TUI / Telegram path, but without leaving the browser.

## API — `src/api/server.ts`

New `POST /api/skills` (auth-protected, sitting next to the existing `GET /api/skills`). Reuses `installSkill(repoUrl: string)` from `src/copilot/skills.ts` — no install-logic duplication.

| Case | Status | Body |
|---|---|---|
| Success | 201 | `{ skill: { name, slug, description, path } }` |
| Missing / non-string `repoUrl` | 400 | `{ error: "Missing required field: repoUrl" }` |
| Empty after trim | 400 | `{ error: "repoUrl must not be empty" }` |
| Doesn't look like a git URL (must start with `http://`, `https://`, `git@`, `git://`, or end `.git`) | 400 | `{ error: "repoUrl does not look like a git repository URL" }` |
| `installSkill` throws | 500 | `{ error: <err.message> }` (logged with `console.error` server-side; no stack in response) |

## Frontend — `web/src/views/SkillsView.vue`

- Extracted the original `onMounted` fetch into a reusable `fetchSkills()`.
- Added `newRepoUrl`, `installing`, `installError`, `installSuccess` refs.
- `<form @submit.prevent>` wrapper — Enter and button click route through the same handler.
- Button is disabled while installing or when the input is empty.
- On success: optimistic prepend of the returned skill object for instant feedback, then refetch for server-truth ordering. Green banner `✓ Installed: <name>` auto-clears after 4 s.
- On failure: red banner surfacing the server's `error` field verbatim; network/parse errors caught and surfaced the same way.
- Existing `loading` / `error` / empty / grid block preserved exactly.

## Acceptance criteria

- [x] Skills tab has an Add Skill input field + button.
- [x] User can enter a git repo URL.
- [x] Submitting calls a new `POST /api/skills` endpoint that installs the skill.
- [x] Skills list refreshes after successful installation.
- [x] Errors (invalid URL, install failure) surfaced clearly to the user.

## Verification

- `npx tsc --noEmit` ✅ clean (server)
- `cd web && npm run build` ✅ clean (90 modules, 4.80 s)

## Implementation

Delegated end-to-end:
- API half → **Tygra** (Express API engineer)
- UI half → **Panthro** (Vue 3 frontend developer)

API contract was locked up front so both halves built in parallel against the same shape.