### PR TITLE
Per-agent delegation stats + stalest-specialist hint (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+- **Per-agent delegation stats in `squad_agents` + stalest-specialist hint** (#61) — new `agent_stats` SQL view (`COUNT(*) / MAX(started_at)` over `agent_tasks` grouped by `agent_slug`) gives drift-free per-character delegation history with no schema migration on `squad_agents`. `squad_agents` rows now show `📊 N tasks · last <relative-time>` (or `📊 never delegated`), and append a ⚠️ `<Character> has not been delegated to in <N>d/h` (or `never been delegated to`) hint when the squad is unbalanced. `squad_task_status` adds the same hint inline on a single-task lookup and a `**Distribution hints:**` block on the active-task list (one line per affected squad). The hint is suppressed when every specialist has been delegated to within the last 48 hours, and the lead is always excluded from the staleness check. Storage helpers: new `getAgentTaskStats(squadSlug, characterNames)` and `getStalestSpecialist(squadSlug, characterNames, options?)` in `src/store/tasks.ts`. Plus a small `formatRelativeTime` helper in `src/copilot/tools.ts`.
+
+
 - **Install skills from the web UI** (#21) — the Skills tab now has an "Add Skill" form. Enter a git repository URL and click **Install** to install a skill without leaving the browser (mirrors the existing `skill_install` tool / TUI / Telegram path). The skills list refreshes after a successful install; validation and install errors are surfaced inline. Backed by a new `POST /api/skills` endpoint (auth-protected) that reuses `installSkill(repoUrl)` from `src/copilot/skills.ts`.
 
 

--- a/src/copilot/orchestrator.ts
+++ b/src/copilot/orchestrator.ts
@@ -8,7 +8,7 @@ import {
 import { config } from "../config.js";
 import { SESSIONS_DIR, IO_VERSION } from "../paths.js";
 import { getState, setState, deleteState, logConversation } from "../store/db.js";
-import { clearStaleTasks, getSquadWorkDistribution, getTask, getTaskReviews } from "../store/tasks.js";
+import { clearStaleTasks, getAgentTaskStats, getSquadWorkDistribution, getStalestSpecialist, getTask, getTaskReviews } from "../store/tasks.js";
 import {
   getSquad,
   listSquads,
@@ -169,6 +169,13 @@ function getToolDeps() {
       })),
     getSquadWorkDistribution: (slug: string, limit?: number) =>
       getSquadWorkDistribution(slug, limit),
+    getAgentTaskStats: (squadSlug: string, characterNames: string[]) =>
+      getAgentTaskStats(squadSlug, characterNames),
+    getStalestSpecialist: (
+      squadSlug: string,
+      characterNames: string[],
+      options?: { excludeCharacters?: string[]; freshIfWithinHours?: number },
+    ) => getStalestSpecialist(squadSlug, characterNames, options),
     listSkills,
     installSkill,
     removeSkill,

--- a/src/copilot/tools.ts
+++ b/src/copilot/tools.ts
@@ -234,6 +234,65 @@ function formatWorkDistribution(
   return lines.join("");
 }
 
+// ---------------------------------------------------------------------------
+// Per-agent delegation-stat formatters (issue #61)
+// ---------------------------------------------------------------------------
+
+/**
+ * Format an ISO timestamp as a short relative time string. SQLite emits
+ * naive UTC strings, so we suffix "Z" before parsing if it isn't already
+ * timezone-qualified.
+ */
+function formatRelativeTime(iso: string | null): string {
+  if (!iso) return "never";
+  const tzQualified = /[zZ]$|[+-]\d{2}:?\d{2}$/.test(iso);
+  const ts = new Date(tzQualified ? iso : iso + "Z").getTime();
+  if (Number.isNaN(ts)) return "never";
+  const deltaMs = Date.now() - ts;
+  if (deltaMs < 60_000) return "just now";
+  if (deltaMs < 3_600_000) {
+    const m = Math.round(deltaMs / 60_000);
+    return `${m}m ago`;
+  }
+  if (deltaMs < 86_400_000) {
+    const h = Math.round(deltaMs / 3_600_000);
+    return `${h}h ago`;
+  }
+  const d = Math.round(deltaMs / 86_400_000);
+  return `${d}d ago`;
+}
+
+/**
+ * Format a stale-hours number as a short duration. >=24h rounds to days,
+ * smaller values stay in hours. Floors to keep behaviour consistent across
+ * the squad_agents and squad_task_status renderers.
+ */
+function formatStaleDuration(staleHours: number): string {
+  if (staleHours >= 24) {
+    const d = Math.floor(staleHours / 24);
+    return `${d}d`;
+  }
+  return `${Math.floor(staleHours)}h`;
+}
+
+/**
+ * Build the ⚠️ stalest-specialist hint string from a getStalestSpecialist
+ * result. Returns "" if the input is null (squad is healthy).
+ */
+function formatStalestHint(
+  stalest: {
+    character_name: string;
+    last_delegated_at: string | null;
+    staleHours: number | null;
+  } | null,
+): string {
+  if (!stalest) return "";
+  if (stalest.staleHours == null) {
+    return `⚠️ ${stalest.character_name} has never been delegated to`;
+  }
+  return `⚠️ ${stalest.character_name} has not been delegated to in ${formatStaleDuration(stalest.staleHours)}`;
+}
+
 // Ensure child processes have HOME set (systemd services often don't)
 function shellEnv(): NodeJS.ProcessEnv {
   const env = { ...process.env };
@@ -264,6 +323,17 @@ export interface ToolDeps {
   getActiveAgentTasks: () => Array<{ taskId: string; agentSlug: string; description: string; status: string }>;
   addSquadAgent: (squadSlug: string, roleTitle: string, charter: string, modelTier?: string) => { character_name: string; role_title: string; personality: string | null; model_tier: string };
   listSquadAgents: (squadSlug: string) => Array<{ character_name: string; role_title: string; charter: string | null; model_tier: string; personality: string | null; status: string; is_lead?: number; is_qa?: number }>;
+  getAgentTaskStats: (squadSlug: string, characterNames: string[]) => Array<{
+    character_name: string;
+    agent_slug: string;
+    task_count: number;
+    last_delegated_at: string | null;
+  }>;
+  getStalestSpecialist: (
+    squadSlug: string,
+    characterNames: string[],
+    options?: { excludeCharacters?: string[]; freshIfWithinHours?: number },
+  ) => { character_name: string; last_delegated_at: string | null; staleHours: number | null } | null;
   removeSquadAgent: (squadSlug: string, characterName: string) => boolean;
   resetSquadAgent: (squadSlug: string, characterName: string) => { found: boolean; previousStatus: string; agent: { character_name: string; role_title: string } | null };
   setSquadLead: (squadSlug: string, characterName: string) => void;
@@ -475,13 +545,56 @@ export function createTools(deps: ToolDeps) {
           const result = task.result.length > 4000 ? task.result.slice(0, 4000) + "\n[…truncated]" : task.result;
           response += `\n\nResult:\n${result}`;
         }
+        // Stalest-specialist hint for the squad this task belongs to (#61).
+        try {
+          const squadSlug = task.agent_slug.split(":")[0];
+          if (squadSlug) {
+            const roster = deps.listSquadAgents(squadSlug);
+            const characterNames = roster.map((a) => a.character_name);
+            const lead = roster.find((a) => a.is_lead === 1);
+            const stalest = deps.getStalestSpecialist(squadSlug, characterNames, {
+              excludeCharacters: lead ? [lead.character_name] : [],
+            });
+            const hint = formatStalestHint(stalest);
+            if (hint) response += `\n\n${hint}`;
+          }
+        } catch (err) {
+          console.error("[io] squad_task_status: stalest-specialist hint failed:", err);
+        }
         return response;
       }
       const tasks = deps.getActiveAgentTasks();
       if (tasks.length === 0) return "No active tasks.";
-      return tasks
+      const taskLines = tasks
         .map((t) => `- **${t.taskId}** (${t.agentSlug}) — ${t.status} — ${t.description}`)
         .join("\n");
+
+      // Per-squad stalest-specialist hint block (#61).
+      let hintsBlock = "";
+      try {
+        const uniqueSquadSlugs = Array.from(
+          new Set(tasks.map((t) => t.agentSlug.split(":")[0]).filter((x): x is string => !!x)),
+        );
+        const hintLines: string[] = [];
+        for (const squadSlug of uniqueSquadSlugs) {
+          const roster = deps.listSquadAgents(squadSlug);
+          if (roster.length === 0) continue;
+          const characterNames = roster.map((a) => a.character_name);
+          const lead = roster.find((a) => a.is_lead === 1);
+          const stalest = deps.getStalestSpecialist(squadSlug, characterNames, {
+            excludeCharacters: lead ? [lead.character_name] : [],
+          });
+          const hint = formatStalestHint(stalest);
+          if (hint) hintLines.push(`- ${squadSlug}: ${hint}`);
+        }
+        if (hintLines.length > 0) {
+          hintsBlock = `\n\n**Distribution hints:**\n${hintLines.join("\n")}`;
+        }
+      } catch (err) {
+        console.error("[io] squad_task_status: distribution hints failed:", err);
+      }
+
+      return `${taskLines}${hintsBlock}`;
     },
   });
 
@@ -676,15 +789,50 @@ export function createTools(deps: ToolDeps) {
         ? UNIVERSES.find((u) => u.id === squad.universe)?.name ?? squad.universe
         : "none";
 
+      // Pull per-agent task stats once and key by character_name (issue #61).
+      // If the helper throws (e.g. brand-new DB before view migration), fall
+      // back to an empty map so rendering is unchanged rather than 500-ing.
+      const characterNames = agents.map((a) => a.character_name);
+      const statsByName = new Map<string, { task_count: number; last_delegated_at: string | null }>();
+      try {
+        for (const st of deps.getAgentTaskStats(slug, characterNames)) {
+          statsByName.set(st.character_name, {
+            task_count: st.task_count,
+            last_delegated_at: st.last_delegated_at,
+          });
+        }
+      } catch (err) {
+        console.error("[io] squad_agents: getAgentTaskStats failed:", err);
+      }
+
       const lines = agents.map((a) => {
         const leadBadge = a.is_lead === 1 ? " ⭐ [LEAD]" : "";
         const qaBadge = a.is_qa === 1 ? " 🛡️ [QA]" : "";
-        return `- **${a.character_name}**${leadBadge}${qaBadge} — ${a.role_title} (${a.model_tier}) — ${a.status}${a.personality ? `\n  _${a.personality}_` : ""}`;
+        const st = statsByName.get(a.character_name) ?? { task_count: 0, last_delegated_at: null };
+        const statsStr = st.task_count === 0
+          ? " — 📊 never delegated"
+          : ` — 📊 ${st.task_count} ${st.task_count === 1 ? "task" : "tasks"} · last ${formatRelativeTime(st.last_delegated_at)}`;
+        return `- **${a.character_name}**${leadBadge}${qaBadge} — ${a.role_title} (${a.model_tier}) — ${a.status}${statsStr}${a.personality ? `\n  _${a.personality}_` : ""}`;
       });
 
       const coverage = assessSquadCoverage(agents);
       const coverageBlock = coverage.warning ? `\n\n${coverage.warning}` : "";
-      return `**${squad.name}** — 🎬 ${universeName}\n\n${lines.join("\n")}${coverageBlock}`;
+
+      // Stalest-specialist hint (issue #61): exclude the lead so the hint
+      // points at an under-utilised teammate rather than the coordinator.
+      let stalestBlock = "";
+      try {
+        const lead = agents.find((a) => a.is_lead === 1);
+        const stalest = deps.getStalestSpecialist(slug, characterNames, {
+          excludeCharacters: lead ? [lead.character_name] : [],
+        });
+        const hint = formatStalestHint(stalest);
+        if (hint) stalestBlock = `\n\n${hint}`;
+      } catch (err) {
+        console.error("[io] squad_agents: getStalestSpecialist failed:", err);
+      }
+
+      return `**${squad.name}** — 🎬 ${universeName}\n\n${lines.join("\n")}${coverageBlock}${stalestBlock}`;
     },
   });
 

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -115,6 +115,12 @@ export function getDb(): BetterSqlite3.Database {
     )`,
     `CREATE INDEX IF NOT EXISTS idx_io_schedules_due
        ON io_schedules (enabled, next_run_at)`,
+    `CREATE VIEW IF NOT EXISTS agent_stats AS
+SELECT agent_slug,
+       COUNT(*)        AS task_count,
+       MAX(started_at) AS last_delegated_at
+FROM agent_tasks
+GROUP BY agent_slug`,
   ];
 
   for (const migration of migrations) {

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -144,3 +144,135 @@ export function getTaskReviews(taskId: string): TaskReview[] {
     )
     .all(taskId) as TaskReview[];
 }
+
+export interface AgentTaskStats {
+  character_name: string;       // bare squad-slug agents map to "" (legacy lead row)
+  agent_slug: string;           // raw column value: "<squad>" or "<squad>:<char>"
+  task_count: number;           // 0 if the agent has never been delegated to
+  last_delegated_at: string | null; // ISO datetime string or null if never
+}
+
+/**
+ * Per-character delegation stats for a squad.
+ *
+ * Returns one row PER CHARACTER NAME passed in `characterNames`, plus an
+ * extra row with character_name="" for any tasks routed to the bare squad
+ * slug (legacy lead tasks). Always returns a row for every requested
+ * character, even if they have never been delegated to (task_count: 0,
+ * last_delegated_at: null).
+ *
+ * Reads from the agent_stats view. Filters with `agent_slug = ?`
+ * (for the bare slug) and `agent_slug = ?` for each `<slug>:<char>`.
+ */
+export function getAgentTaskStats(
+  squadSlug: string,
+  characterNames: string[],
+): AgentTaskStats[] {
+  // Build the full set of agent_slug values we care about
+  const bareSlug = squadSlug;
+  const namedSlugs = characterNames.map((c) => `${squadSlug}:${c}`);
+  const allSlugs = [bareSlug, ...namedSlugs];
+
+  const placeholders = allSlugs.map(() => "?").join(", ");
+  interface StatRow { agent_slug: string; task_count: number; last_delegated_at: string | null }
+  const rows = getDb()
+    .prepare(
+      `SELECT agent_slug, task_count, last_delegated_at FROM agent_stats WHERE agent_slug IN (${placeholders})`,
+    )
+    .all(...allSlugs) as StatRow[];
+
+  const bySlug = new Map<string, StatRow>();
+  for (const row of rows) bySlug.set(row.agent_slug, row);
+
+  const results: AgentTaskStats[] = [];
+
+  // Bare slug row (legacy lead tasks routed without a named agent)
+  const bareRow = bySlug.get(bareSlug);
+  results.push({
+    character_name: "",
+    agent_slug: bareSlug,
+    task_count: bareRow?.task_count ?? 0,
+    last_delegated_at: bareRow?.last_delegated_at ?? null,
+  });
+
+  // One row per requested character
+  for (const char of characterNames) {
+    const slug = `${squadSlug}:${char}`;
+    const row = bySlug.get(slug);
+    results.push({
+      character_name: char,
+      agent_slug: slug,
+      task_count: row?.task_count ?? 0,
+      last_delegated_at: row?.last_delegated_at ?? null,
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Pick the stalest specialist in a squad. "Stalest" = the character who
+ * has been delegated to least recently (oldest last_delegated_at), with
+ * never-delegated agents considered staler than any delegated agent.
+ *
+ * Excludes character names listed in `excludeCharacters` (use this to
+ * skip the lead). Returns null if the squad has no eligible agents OR if
+ * all eligible agents have been delegated to within `freshIfWithinHours`
+ * (default 48). The threshold is meant to suppress the hint when the
+ * squad is already distributing well.
+ *
+ * On tie (e.g. two agents have never been delegated), returns the one
+ * that sorts first by character_name (deterministic).
+ */
+export function getStalestSpecialist(
+  squadSlug: string,
+  characterNames: string[],
+  options?: {
+    excludeCharacters?: string[];
+    freshIfWithinHours?: number;
+  },
+): { character_name: string; last_delegated_at: string | null; staleHours: number | null } | null {
+  const exclude = new Set(options?.excludeCharacters ?? []);
+  const freshThresholdHours = options?.freshIfWithinHours ?? 48;
+
+  const stats = getAgentTaskStats(squadSlug, characterNames);
+
+  // Filter: named agents only (skip the bare-slug "" row), skip excluded
+  const eligible = stats.filter(
+    (s) => s.character_name !== "" && !exclude.has(s.character_name),
+  );
+
+  if (eligible.length === 0) return null;
+
+  const now = Date.now();
+
+  // Sort: never-delegated (null) first, then ascending by last_delegated_at
+  eligible.sort((a, b) => {
+    if (a.last_delegated_at === null && b.last_delegated_at === null) {
+      return a.character_name.localeCompare(b.character_name);
+    }
+    if (a.last_delegated_at === null) return -1;
+    if (b.last_delegated_at === null) return 1;
+    const tA = new Date(a.last_delegated_at + "Z").getTime();
+    const tB = new Date(b.last_delegated_at + "Z").getTime();
+    if (tA !== tB) return tA - tB;
+    return a.character_name.localeCompare(b.character_name);
+  });
+
+  const stalest = eligible[0];
+  let staleHours: number | null = null;
+
+  if (stalest.last_delegated_at !== null) {
+    const delegatedAt = new Date(stalest.last_delegated_at + "Z").getTime();
+    staleHours = Math.round((now - delegatedAt) / 3_600_000);
+    // Squad is distributing well — suppress the hint
+    if (staleHours < freshThresholdHours) return null;
+  }
+  // null last_delegated_at means never-delegated: always considered stale
+
+  return {
+    character_name: stalest.character_name,
+    last_delegated_at: stalest.last_delegated_at,
+    staleHours,
+  };
+}


### PR DESCRIPTION
Closes #61.

## What

Surfaces per-character delegation stats in `squad_agents` and adds a stalest-specialist hint to both `squad_agents` and `squad_task_status` to nudge the lead toward better fan-out. No schema migration on `squad_agents` — a SQL view computes everything on read.

## Storage — `src/store/db.ts` + `src/store/tasks.ts`

### New view (added as a migration)

```sql
CREATE VIEW IF NOT EXISTS agent_stats AS
SELECT agent_slug, COUNT(*) AS task_count, MAX(started_at) AS last_delegated_at
FROM agent_tasks GROUP BY agent_slug;
```

### New helpers

```typescript
export function getAgentTaskStats(
  squadSlug: string,
  characterNames: string[],
): AgentTaskStats[];   // one row per requested character (zero-default), plus a '' row for bare-slug tasks

export function getStalestSpecialist(
  squadSlug: string,
  characterNames: string[],
  options?: { excludeCharacters?: string[]; freshIfWithinHours?: number /* default 48 */ },
): { character_name: string; last_delegated_at: string | null; staleHours: number | null } | null;
```

`getStalestSpecialist` returns `null` when the squad is healthy (everyone delegated to within 48h) so the rendering layer can suppress the hint without extra logic.

## Rendering — `src/copilot/tools.ts`

### `squad_agents`

Each row gains `📊 N tasks · last <relative-time>` (or `📊 never delegated`), plus an optional ⚠️ hint at the bottom:

```
- **Lion-O** ⭐ [LEAD] — Copilot SDK & Orchestration Engineer (premium) — idle — 📊 47 tasks · last just now
- **Tygra** — Express API Engineer (standard) — idle — 📊 9 tasks · last 2h ago
- **Cheetara** — Telegram & TUI Integration Engineer (standard) — idle — 📊 1 task · last 6d ago
- **WilyKat** — TypeScript & Integration Test Engineer (standard) — idle — 📊 never delegated

⚠️ WilyKat has never been delegated to
```

### `squad_task_status`

Both branches gain the hint:

- **Single-task lookup** — appends one inline line under the existing response.
- **Active-task list** — appends a `**Distribution hints:**` block with one bullet per affected squad (omitted entirely when no squad is unbalanced). `"No active tasks."` reply unchanged.

```
- **task_abc123** (io:Tygra) — running — Implement POST /api/skills
- **task_def456** (acme-web:Optimus) — running — Refactor router

**Distribution hints:**
- io: ⚠️ WilyKat has never been delegated to
- acme-web: ⚠️ Bumblebee has not been delegated to in 3d
```

The lead is always excluded from the staleness check (via `excludeCharacters`).

### Defensive

All new `deps.getAgentTaskStats` / `deps.getStalestSpecialist` calls in tool handlers are wrapped in try/catch + `console.error` so a transient storage error degrades gracefully to the pre-existing rendering instead of breaking the tool.

## Verification

- `npx tsc --noEmit` ✅ clean.
- View migration is idempotent (`CREATE VIEW IF NOT EXISTS`).

## Implementation

Delegated end-to-end against a locked WilyKit→Lion-O interface:
- **WilyKit** (SQLite/Storage) — view migration + `getAgentTaskStats` + `getStalestSpecialist`.
- **Lion-O** (Copilot SDK & Orchestration) — ToolDeps wiring, orchestrator pass-through, `squad_agents` + `squad_task_status` rendering, formatting helpers.