### PR TITLE
Fix: activity panel fallback for tasks after daemon restart (#66)

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -244,7 +244,28 @@ export async function startApiServer(): Promise<void> {
     const taskId = Array.isArray(req.params.taskId) ? req.params.taskId[0] : req.params.taskId;
     try {
       const events = getTaskEvents(taskId);
-      const activity = summarize(events);
+      let activity = summarize(events);
+
+      // Fallback: when in-memory events are gone (e.g. daemon restart),
+      // build a minimal entry from the persisted task result so the UI
+      // doesn't show "no activity" for tasks that actually ran. (#66)
+      if (activity.length === 0) {
+        const task = getTask(taskId);
+        if (task?.result) {
+          activity = [{
+            ts: task.completed_at ? new Date(task.completed_at).getTime() : Date.now(),
+            kind: "outcome" as const,
+            icon: task.status === "failed" ? "\u274c" : task.status === "done" ? "\u2705" : "\ud83d\udccb",
+            summary: task.status === "failed"
+              ? "Task failed (activity log unavailable after restart)"
+              : "Task completed (activity log unavailable after restart)",
+            rawType: "task.result.fallback",
+            detail: task.result,
+            raw: { result: task.result, status: task.status },
+          }];
+        }
+      }
+
       res.json({ taskId, activity });
     } catch (e) {
       console.error("Error building task activity:", e);


### PR DESCRIPTION
Closes #66.

## Problem
Task events are stored in-memory only. After a daemon restart, the activity panel showed 'no activity' for tasks that had data in SQLite.

## Fix
When in-memory events are empty, the `GET /tasks/:taskId/activity` endpoint now falls back to a synthetic `ActivityEntry` built from the persisted `result` field in the `agent_tasks` table. The entry is clearly labelled as `(activity log unavailable after restart)` and uses `kind: 'outcome'` with the appropriate status icon.

## Scope
Single-file change: `src/api/server.ts`. No frontend changes needed — the UI already handles the activity array correctly.