### PR TITLE
Scroll-to-bottom button in chat when scrolled up (#82)

### DIFF
--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="flex flex-col h-full">
+  <div class="flex flex-col h-full relative">
     <!-- Message history -->
-    <div ref="messagesEl" class="flex-1 overflow-y-auto p-6 space-y-4">
+    <div ref="messagesEl" class="flex-1 overflow-y-auto p-6 space-y-4" @scroll="handleScroll">
       <div v-if="store.messages.length === 0" class="text-gray-600 text-sm text-center mt-12">
         Send a message to start chatting with IO
       </div>
@@ -34,6 +34,18 @@
         </div>
       </div>
     </div>
+
+    <!-- Scroll to bottom button -->
+    <button
+      v-if="isScrolledUp"
+      @click="scrollToBottom"
+      class="absolute bottom-20 right-8 bg-gray-700 hover:bg-gray-600 text-gray-200 rounded-full p-2 shadow-lg transition-all z-10"
+      title="Scroll to bottom"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+      </svg>
+    </button>
 
     <!-- Input bar -->
     <div class="border-t border-gray-800 p-4">
@@ -78,6 +90,7 @@ const store = useChatStore()
 const input = ref('')
 const stopping = ref(false)
 const messagesEl = ref<HTMLElement | null>(null)
+const isScrolledUp = ref(false)
 
 async function stopOrchestrator() {
   if (stopping.value) return
@@ -95,6 +108,13 @@ const isStreaming = computed(() =>
   store.messages.some((m) => m.streaming)
 )
 
+function handleScroll() {
+  const el = messagesEl.value
+  if (!el) return
+  // Consider "at bottom" if within 100px of the end
+  isScrolledUp.value = el.scrollTop + el.clientHeight < el.scrollHeight - 100
+}
+
 function scrollToBottom() {
   nextTick(() => {
     if (messagesEl.value) {
@@ -103,7 +123,10 @@ function scrollToBottom() {
   })
 }
 
-watch(() => store.messages.length, scrollToBottom)
+// Only auto-scroll on incoming messages when user hasn't scrolled up
+watch(() => store.messages.length, () => {
+  if (!isScrolledUp.value) scrollToBottom()
+})
 
 async function sendMessage() {
   const text = input.value.trim()
@@ -115,6 +138,7 @@ async function sendMessage() {
   store.addMessage({ id: crypto.randomUUID(), role: 'user', content: text })
   store.addMessage({ id: crypto.randomUUID(), role: 'assistant', content: '', streaming: true })
 
+  // Always scroll when user sends — they want to see the response
   scrollToBottom()
 
   // Open SSE stream for real-time deltas


### PR DESCRIPTION
Closes #82.

Floating chevron-down button appears when the user scrolls up in chat. Auto-scroll on new messages is suppressed while scrolled up. Sending a message always scrolls to bottom.

Single file: web/src/views/ChatView.vue.