### PR TITLE
Notification bell with SSE-driven unread count (#85)

### DIFF
--- a/web/src/components/AppNav.vue
+++ b/web/src/components/AppNav.vue
@@ -45,6 +45,22 @@
         </li>
         <li>
           <RouterLink
+            to="/notifications"
+            class="block px-4 py-2 rounded hover:bg-gray-800 transition-colors relative"
+            :class="{ 'bg-blue-900 text-blue-300': route.name === 'notifications' }"
+            @click="onNotificationsClick"
+          >
+            🔔 Notifications
+            <span
+              v-if="unreadCount > 0"
+              class="absolute top-1 right-2 bg-red-500 text-white text-[10px] font-bold rounded-full min-w-[18px] h-[18px] flex items-center justify-center px-1"
+            >
+              {{ unreadCount > 99 ? '99+' : unreadCount }}
+            </span>
+          </RouterLink>
+        </li>
+        <li>
+          <RouterLink
             to="/activity"
             class="block px-4 py-2 rounded hover:bg-gray-800 transition-colors"
             :class="{ 'bg-blue-900 text-blue-300': route.name === 'activity' }"
@@ -68,15 +84,52 @@
 </template>
 
 <script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
 import { useRoute, useRouter, RouterLink } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
+import { apiFetch, authenticatedUrl } from '../lib/api'
 
 const route = useRoute()
 const router = useRouter()
 const auth = useAuthStore()
 
+const unreadCount = ref(0)
+let notificationSource: EventSource | null = null
+
 async function handleSignOut() {
   await auth.signOut()
   router.push('/login')
 }
+
+function onNotificationsClick() {
+  // Clear badge immediately when the user navigates to notifications
+  unreadCount.value = 0
+}
+
+onMounted(async () => {
+  // Fetch initial unread count
+  try {
+    const res = await apiFetch('/api/notifications?unread=true&limit=1')
+    if (res.ok) {
+      const data = (await res.json()) as { unreadCount?: number }
+      unreadCount.value = data.unreadCount ?? 0
+    }
+  } catch { /* best effort */ }
+
+  // Listen for new notifications via the shared SSE events stream
+  notificationSource = new EventSource(authenticatedUrl('/api/events'))
+  notificationSource.onmessage = (e) => {
+    try {
+      const data = JSON.parse(e.data) as { type?: string }
+      if (data.type === 'notification' && route.name !== 'notifications') {
+        unreadCount.value++
+      }
+    } catch { /* ignore */ }
+  }
+})
+
+onUnmounted(() => {
+  notificationSource?.close()
+  notificationSource = null
+})
 </script>

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -4,6 +4,7 @@ import SkillsView from '../views/SkillsView.vue'
 import SquadsView from '../views/SquadsView.vue'
 import AgentActivityView from '../views/AgentActivityView.vue'
 import SchedulesView from '../views/SchedulesView.vue'
+import NotificationsView from '../views/NotificationsView.vue'
 import LoginView from '../views/LoginView.vue'
 import { useAuthStore } from '../stores/auth'
 
@@ -44,6 +45,11 @@ const router = createRouter({
       path: '/schedules',
       name: 'schedules',
       component: SchedulesView,
+    },
+    {
+      path: '/notifications',
+      name: 'notifications',
+      component: NotificationsView,
     },
   ],
 })

--- a/web/src/views/NotificationsView.vue
+++ b/web/src/views/NotificationsView.vue
@@ -1,0 +1,109 @@
+<template>
+  <div class="flex flex-col h-full p-6">
+    <div class="flex justify-between items-center mb-4">
+      <h2 class="text-xl font-bold text-gray-100">Notifications</h2>
+      <button
+        v-if="notifications.length > 0"
+        @click="markAllRead"
+        class="text-sm text-blue-400 hover:text-blue-300 transition-colors"
+      >
+        Mark all as read
+      </button>
+    </div>
+
+    <div v-if="loading" class="text-gray-400 text-center py-8">Loading...</div>
+    <div v-else-if="notifications.length === 0" class="text-gray-500 text-center py-8">
+      No notifications yet
+    </div>
+    <ul v-else class="space-y-2 overflow-y-auto flex-1">
+      <li
+        v-for="n in notifications"
+        :key="n.id"
+        class="bg-gray-800 border rounded-lg p-4 cursor-pointer transition-colors"
+        :class="n.read_at ? 'border-gray-700 opacity-60' : 'border-blue-700'"
+        @click="toggleExpand(n.id)"
+      >
+        <div class="flex justify-between items-start gap-2">
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 mb-1">
+              <span v-if="!n.read_at" class="w-2 h-2 bg-blue-400 rounded-full shrink-0"></span>
+              <span class="text-sm font-medium text-gray-100 truncate">{{ n.title }}</span>
+              <span class="text-xs text-gray-500">{{ n.source?.type }}</span>
+            </div>
+            <p class="text-xs text-gray-500">{{ formatTime(n.created_at) }}</p>
+          </div>
+          <button
+            v-if="!n.read_at"
+            @click.stop="markRead(n.id)"
+            class="text-xs text-gray-400 hover:text-white shrink-0"
+            title="Mark as read"
+          >
+            ✓
+          </button>
+        </div>
+        <div v-if="expanded.has(n.id)" class="mt-3 text-sm text-gray-300 whitespace-pre-wrap bg-gray-900 rounded p-3 border border-gray-700">
+          {{ n.text }}
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { apiFetch } from '../lib/api'
+
+interface Notification {
+  id: number
+  title: string
+  text: string
+  source: { type: string; [k: string]: unknown }
+  created_at: string
+  read_at: string | null
+}
+
+const notifications = ref<Notification[]>([])
+const loading = ref(true)
+const expanded = ref(new Set<number>())
+
+function formatTime(ts: string) {
+  try { return new Date(ts).toLocaleString() } catch { return ts }
+}
+
+function toggleExpand(id: number) {
+  const next = new Set(expanded.value)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  expanded.value = next
+}
+
+async function loadNotifications() {
+  try {
+    const res = await apiFetch('/api/notifications?limit=100')
+    if (res.ok) {
+      const data = (await res.json()) as { notifications: Notification[] }
+      notifications.value = data.notifications ?? []
+    }
+  } catch { /* best effort */ }
+  loading.value = false
+}
+
+async function markRead(id: number) {
+  try {
+    await apiFetch(`/api/notifications/${id}/read`, { method: 'POST' })
+    const n = notifications.value.find(x => x.id === id)
+    if (n) n.read_at = new Date().toISOString()
+  } catch { /* best effort */ }
+}
+
+async function markAllRead() {
+  try {
+    await apiFetch('/api/notifications/read-all', { method: 'POST' })
+    for (const n of notifications.value) {
+      if (!n.read_at) n.read_at = new Date().toISOString()
+    }
+  } catch { /* best effort */ }
+}
+
+onMounted(loadNotifications)
+</script>


### PR DESCRIPTION
Closes #85.

Adds a 🔔 Notifications nav link with a real-time unread badge driven by SSE notification events. New NotificationsView at /notifications shows all notifications with expand/collapse, mark-read, and mark-all-read. Consumes the endpoints from PR #83.

Files: AppNav.vue, NotificationsView.vue (new), router.