### PR TITLE
Schedule execution history table + daily pruning (#86)

### DIFF
--- a/src/copilot/io-scheduler.ts
+++ b/src/copilot/io-scheduler.ts
@@ -15,6 +15,7 @@ import {
 import { sendToOrchestrator } from "./orchestrator.js";
 import { nextRun } from "./cron.js";
 import { notifyBackground } from "../notify.js";
+import { startScheduleRun, completeScheduleRun, failScheduleRun } from "../store/schedule-runs.js";
 
 const TICK_MS = 30_000;
 
@@ -47,6 +48,11 @@ async function fireSchedule(schedule: IoSchedule): Promise<void> {
   console.log(
     `[io] io-scheduler: firing schedule "${schedule.name}" (next run: ${nextIso ?? "never"})`,
   );
+  const run = startScheduleRun({
+    schedule_type: "io",
+    schedule_id: schedule.id,
+    schedule_name: schedule.name,
+  });
   try {
     let buffer = "";
     await sendToOrchestrator(
@@ -63,11 +69,16 @@ async function fireSchedule(schedule: IoSchedule): Promise<void> {
             },
             title: `IO schedule: ${schedule.name}`,
             text: buffer.trim(),
+          }).then((notifyResult) => {
+            completeScheduleRun(run.id, notifyResult.id);
+          }).catch((err) => {
+            failScheduleRun(run.id, err instanceof Error ? err.message : String(err));
           });
         }
       },
     );
   } catch (err) {
+    failScheduleRun(run.id, err instanceof Error ? err.message : String(err));
     console.error(
       `[io] io-scheduler: failed to dispatch schedule ${schedule.id}:`,
       err instanceof Error ? err.message : err,

--- a/src/copilot/scheduler.ts
+++ b/src/copilot/scheduler.ts
@@ -16,6 +16,7 @@ import { getSquad } from "../store/squads.js";
 import { delegateToAgent } from "./agents.js";
 import { nextRun } from "./cron.js";
 import { notifyBackground } from "../notify.js";
+import { startScheduleRun, completeScheduleRun, failScheduleRun } from "../store/schedule-runs.js";
 
 const TICK_MS = 30_000;
 
@@ -79,6 +80,12 @@ async function fireSchedule(schedule: SquadSchedule): Promise<void> {
     schedule,
   );
   console.log(`[io] scheduler: firing schedule "${schedule.name}" for squad "${squad.slug}" (next run: ${nextIso ?? "never"})`);
+  const run = startScheduleRun({
+    schedule_type: "squad",
+    schedule_id: schedule.id,
+    schedule_name: schedule.name,
+    squad_slug: squad.slug,
+  });
   try {
     await delegateToAgent(squad.slug, prompt, (_taskId, result) => {
       void notifyBackground({
@@ -90,9 +97,14 @@ async function fireSchedule(schedule: SquadSchedule): Promise<void> {
         },
         title: `${squad.name}: ${schedule.name}`,
         text: result,
+      }).then((notifyResult) => {
+        completeScheduleRun(run.id, notifyResult.id);
+      }).catch((err) => {
+        failScheduleRun(run.id, err instanceof Error ? err.message : String(err));
       });
     });
   } catch (err) {
+    failScheduleRun(run.id, err instanceof Error ? err.message : String(err));
     console.error(`[io] scheduler: failed to delegate stand-up for schedule ${schedule.id}:`, err instanceof Error ? err.message : err);
   } finally {
     inFlight.delete(schedule.id);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -3,6 +3,8 @@ import { initOrchestrator, sendToOrchestrator, shutdownOrchestrator } from "./co
 import { startApiServer, setMessageHandler as setApiHandler, broadcastToSSE, broadcastNotificationToSSE } from "./api/server.js";
 import { createBot, startBot, stopBot, sendProactiveMessage, sendBackgroundNotification, setMessageHandler as setTelegramHandler } from "./telegram/bot.js";
 import { setTelegramSender, setTuiSender, setSseBroadcaster } from "./notify.js";
+import { pruneOldScheduleRuns } from "./store/schedule-runs.js";
+import { pruneOldNotifications } from "./store/notifications.js";
 import { printBackgroundNotification } from "./tui/index.js";
 import { getDb, closeDb } from "./store/db.js";
 import { clearStaleTasks } from "./store/tasks.js";
@@ -155,6 +157,31 @@ export async function startDaemon(): Promise<void> {
   setSseBroadcaster((p) => broadcastNotificationToSSE(p));
   setTuiSender((opts) => printBackgroundNotification(opts));
   setTelegramSender((opts) => sendBackgroundNotification(opts));
+
+  // Daily cleanup — prune schedule runs and notifications older than 30 days
+  const PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1000;
+  const PRUNE_RETENTION_DAYS = 30;
+  const pruneTimer = setInterval(() => {
+    try {
+      const runsDeleted = pruneOldScheduleRuns(PRUNE_RETENTION_DAYS);
+      const notificationsDeleted = pruneOldNotifications(PRUNE_RETENTION_DAYS);
+      if (runsDeleted > 0 || notificationsDeleted > 0) {
+        console.log(`[prune] Cleaned up ${runsDeleted} schedule runs and ${notificationsDeleted} notifications older than ${PRUNE_RETENTION_DAYS} days`);
+      }
+    } catch (err) {
+      console.error("[prune] Error during cleanup:", err);
+    }
+  }, PRUNE_INTERVAL_MS);
+  pruneTimer.unref();
+
+  // Run once on startup after a brief delay
+  const pruneStartup = setTimeout(() => {
+    try {
+      pruneOldScheduleRuns(PRUNE_RETENTION_DAYS);
+      pruneOldNotifications(PRUNE_RETENTION_DAYS);
+    } catch { /* best effort */ }
+  }, 5000);
+  (pruneStartup as unknown as { unref?: () => void }).unref?.();
 
   console.log("[io] IO is fully operational.");
 

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -148,6 +148,19 @@ GROUP BY agent_slug`,
       read_at DATETIME
     )`,
     `CREATE INDEX IF NOT EXISTS idx_bg_notifications_unread ON background_notifications(read_at, created_at)`,
+    `CREATE TABLE IF NOT EXISTS schedule_runs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      schedule_type TEXT NOT NULL,
+      schedule_id INTEGER NOT NULL,
+      schedule_name TEXT NOT NULL,
+      squad_slug TEXT,
+      status TEXT NOT NULL DEFAULT 'running',
+      error_text TEXT,
+      notification_id INTEGER,
+      started_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      completed_at DATETIME
+    )`,
+    `CREATE INDEX IF NOT EXISTS idx_schedule_runs_lookup ON schedule_runs(schedule_type, schedule_id, started_at)`,
   ];
 
   for (const migration of migrations) {

--- a/src/store/schedule-runs.ts
+++ b/src/store/schedule-runs.ts
@@ -1,0 +1,87 @@
+import { getDb } from "./db.js";
+
+export interface ScheduleRun {
+  id: number;
+  schedule_type: string;
+  schedule_id: number;
+  schedule_name: string;
+  squad_slug: string | null;
+  status: string;
+  error_text: string | null;
+  notification_id: number | null;
+  started_at: string;
+  completed_at: string | null;
+}
+
+/** Create a new run in 'running' status. Returns the row. */
+export function startScheduleRun(input: {
+  schedule_type: string;
+  schedule_id: number;
+  schedule_name: string;
+  squad_slug?: string;
+}): ScheduleRun {
+  const db = getDb();
+  const info = db
+    .prepare(
+      `INSERT INTO schedule_runs (schedule_type, schedule_id, schedule_name, squad_slug)
+       VALUES (?, ?, ?, ?)`,
+    )
+    .run(
+      input.schedule_type,
+      input.schedule_id,
+      input.schedule_name,
+      input.squad_slug ?? null,
+    );
+  return db
+    .prepare("SELECT * FROM schedule_runs WHERE id = ?")
+    .get(info.lastInsertRowid) as ScheduleRun;
+}
+
+/** Mark a run complete (success). Optionally link a notification_id. */
+export function completeScheduleRun(id: number, notificationId?: number): void {
+  getDb()
+    .prepare(
+      `UPDATE schedule_runs
+       SET status = 'done', completed_at = CURRENT_TIMESTAMP, notification_id = ?
+       WHERE id = ?`,
+    )
+    .run(notificationId ?? null, id);
+}
+
+/** Mark a run failed with an error message. */
+export function failScheduleRun(id: number, errorText: string): void {
+  getDb()
+    .prepare(
+      `UPDATE schedule_runs
+       SET status = 'failed', completed_at = CURRENT_TIMESTAMP, error_text = ?
+       WHERE id = ?`,
+    )
+    .run(errorText, id);
+}
+
+/** Get last N runs for a specific schedule. Newest first. */
+export function getScheduleRuns(
+  scheduleType: string,
+  scheduleId: number,
+  limit = 10,
+): ScheduleRun[] {
+  return getDb()
+    .prepare(
+      `SELECT * FROM schedule_runs
+       WHERE schedule_type = ? AND schedule_id = ?
+       ORDER BY started_at DESC
+       LIMIT ?`,
+    )
+    .all(scheduleType, scheduleId, limit) as ScheduleRun[];
+}
+
+/** Prune runs older than the given number of days. Returns rows deleted. */
+export function pruneOldScheduleRuns(olderThanDays: number): number {
+  const info = getDb()
+    .prepare(
+      `DELETE FROM schedule_runs
+       WHERE started_at < datetime('now', '-' || ? || ' days')`,
+    )
+    .run(olderThanDays);
+  return info.changes;
+}


### PR DESCRIPTION
Closes #86.

New `schedule_runs` table records every schedule fire with status, timing, and a link to the `background_notifications` row. Both schedulers (IO + squad) create a run record before dispatch and mark it done/failed on completion. Daily timer prunes runs and notifications older than 30 days.

Fan-out: WilyKit (store + migration) → Lion-O (scheduler wiring + daemon pruning timer).