### PR TITLE
Show lead/QA icons in squad roster (#89)

### DIFF
--- a/web/src/views/SquadsView.vue
+++ b/web/src/views/SquadsView.vue
@@ -131,6 +131,8 @@
               >
                 <div class="flex-1 min-w-0">
                   <span class="text-sm font-medium text-gray-100">{{ agent.character_name }}</span>
+                  <span v-if="agent.is_lead" title="Team Lead" class="text-xs">👑</span>
+                  <span v-if="agent.is_qa" title="QA / Veto Power" class="text-xs">🛡️</span>
                   <span class="text-xs text-gray-500 ml-2">{{ agent.role_title }}</span>
                 </div>
                 <span :class="[
@@ -255,6 +257,8 @@ interface SquadAgent {
   status: string
   currentTaskId?: string | null
   currentTask?: string | null
+  is_lead?: number
+  is_qa?: number
 }
 
 const UNIVERSE_NAMES: Record<string, string> = {


### PR DESCRIPTION
Closes #89.

Displays 👑 next to the team lead and 🛡️ next to QA agents in the squad roster. Data was already served by the API — pure frontend change.

Single file: web/src/views/SquadsView.vue.