### PR TITLE
fix: display notification timestamps in local timezone (#106)

### DIFF
--- a/web/src/views/NotificationsView.vue
+++ b/web/src/views/NotificationsView.vue
@@ -67,7 +67,11 @@ const loading = ref(true)
 const expanded = ref(new Set<number>())
 
 function formatTime(ts: string) {
-  try { return new Date(ts).toLocaleString() } catch { return ts }
+  try {
+    // SQLite CURRENT_TIMESTAMP is UTC without Z — normalize to ISO 8601 UTC
+    const normalized = ts.includes('T') || ts.endsWith('Z') ? ts : ts.replace(' ', 'T') + 'Z'
+    return new Date(normalized).toLocaleString()
+  } catch { return ts }
 }
 
 function toggleExpand(id: number) {

--- a/web/src/views/SchedulesView.vue
+++ b/web/src/views/SchedulesView.vue
@@ -348,7 +348,9 @@ const historyLoading = ref(new Set<string>())
 const promptExpanded = ref(new Set<string>())
 
 function formatDate(iso: string): string {
-  return new Date(iso).toLocaleString()
+  // SQLite CURRENT_TIMESTAMP is UTC without Z — normalize to ISO 8601 UTC
+  const normalized = iso.includes('T') || iso.endsWith('Z') ? iso : iso.replace(' ', 'T') + 'Z'
+  return new Date(normalized).toLocaleString()
 }
 
 function runIcon(status: string): string {


### PR DESCRIPTION
Closes #106

SQLite CURRENT_TIMESTAMP stores UTC without Z suffix. Normalizes timestamps to ISO 8601 UTC before parsing so toLocaleString() correctly converts to local timezone. Fixed in NotificationsView and SchedulesView.