### PR TITLE
feat: add GitHub repo link in nav footer (#120)

### DIFF
--- a/web/src/components/AppNav.vue
+++ b/web/src/components/AppNav.vue
@@ -56,7 +56,11 @@
         <template v-if="auth.authEnabled && auth.user">
           <div class="flex items-center justify-between mb-2">
             <p class="text-xs text-gray-500 truncate">{{ auth.user.email }}</p>
-            <span v-if="version" class="text-[10px] text-gray-600 shrink-0 ml-2">v{{ version }}</span>
+            <span class="flex items-center gap-1 shrink-0 ml-2">
+              <span v-if="version" class="text-[10px] text-gray-600">v{{ version }}</span>
+              <span v-if="version" class="text-[10px] text-gray-600">·</span>
+              <a href="https://github.com/michaeljolley/io" target="_blank" rel="noopener" class="text-[10px] text-gray-600 hover:text-gray-400 transition-colors">GitHub</a>
+            </span>
           </div>
           <button
             @click="handleSignOut"
@@ -65,18 +69,29 @@
             Sign out
           </button>
         </template>
-        <span v-else-if="version" class="text-[10px] text-gray-600">v{{ version }}</span>
+        <span v-else class="flex items-center gap-1">
+          <span v-if="version" class="text-[10px] text-gray-600">v{{ version }}</span>
+          <span v-if="version" class="text-[10px] text-gray-600">·</span>
+          <a href="https://github.com/michaeljolley/io" target="_blank" rel="noopener" class="text-[10px] text-gray-600 hover:text-gray-400 transition-colors">GitHub</a>
+        </span>
       </template>
       <template v-else>
-        <!-- Collapsed: sign-out icon only when auth active -->
-        <button
-          v-if="auth.authEnabled && auth.user"
-          @click="handleSignOut"
-          class="w-full flex justify-center p-1 text-gray-500 hover:text-white hover:bg-gray-800 rounded transition-colors"
-          title="Sign out"
-        >
-          <span class="text-sm">↩</span>
-        </button>
+        <!-- Collapsed: sign-out icon + GitHub icon -->
+        <div class="flex flex-col items-center gap-1">
+          <a href="https://github.com/michaeljolley/io" target="_blank" rel="noopener" class="text-gray-600 hover:text-gray-400 transition-colors" title="GitHub">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.868-.013-1.703-2.782.604-3.369-1.342-3.369-1.342-.454-1.154-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.741 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+            </svg>
+          </a>
+          <button
+            v-if="auth.authEnabled && auth.user"
+            @click="handleSignOut"
+            class="flex justify-center p-1 text-gray-500 hover:text-white hover:bg-gray-800 rounded transition-colors"
+            title="Sign out"
+          >
+            <span class="text-sm">↩</span>
+          </button>
+        </div>
       </template>
     </div>
   </nav>


### PR DESCRIPTION
Closes #120

Adds a link to https://github.com/michaeljolley/io in the AppNav footer. Shows as text link when expanded, SVG icon when collapsed. Opens in new tab.