### PR TITLE
feat: multi-skill repo support and paste-to-install (#117)

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 import { existsSync, readFileSync } from "node:fs";
 import express, { type Request, type Response } from "express";
 import { config } from "../config.js";
-import { listSkills, installSkill } from "../copilot/skills.js";
+import { listSkills, installSkill, installSkillFromContent } from "../copilot/skills.js";
 import { listSquads, createSquad, listSquadAgents } from "../store/squads.js";
 import { getAgentInfo, cancelAgentTask, getTaskEvents, subscribeToTaskEvents } from "../copilot/agents.js";
 import { summarize, summarizeEvent } from "../copilot/event-summary.js";
@@ -130,6 +130,25 @@ export async function startApiServer(): Promise<void> {
     } catch (e) {
       console.error("Error reading skill content:", e);
       res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
+    }
+  });
+
+  // Install a skill from pasted SKILL.md content (issue #117)
+  api.post("/skills/paste", (req: Request, res: Response) => {
+    const { content: skillContent, slug } = req.body as { content?: unknown; slug?: unknown };
+    if (!skillContent || typeof skillContent !== "string" || skillContent.trim() === "") {
+      res.status(400).json({ error: "Missing or empty required field: content" });
+      return;
+    }
+    if (!slug || typeof slug !== "string" || slug.trim() === "") {
+      res.status(400).json({ error: "Missing or empty required field: slug" });
+      return;
+    }
+    try {
+      const skill = installSkillFromContent(skillContent, slug.trim());
+      res.status(201).json({ skill });
+    } catch (e) {
+      res.status(400).json({ error: e instanceof Error ? e.message : String(e) });
     }
   });
 

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -158,8 +158,9 @@ export async function startApiServer(): Promise<void> {
     }
 
     try {
-      const skill = await installSkill(trimmed);
-      res.status(201).json({ skill });
+      const result = await installSkill(trimmed);
+      const skills = Array.isArray(result) ? result : [result];
+      res.status(201).json({ skill: skills[0], skills });
     } catch (e) {
       console.error("Error installing skill:", e);
       res.status(500).json({ error: e instanceof Error ? e.message : String(e) });

--- a/src/copilot/skills.ts
+++ b/src/copilot/skills.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
+import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
 import { join, basename } from "path";
 import { execFileSync } from "child_process";
 import { SKILLS_DIR } from "../paths.js";
@@ -199,11 +199,65 @@ async function installSkillFromFile(rawUrl: string, slug: string): Promise<Skill
   };
 }
 
+function isValidSkillContent(content: string): boolean {
+  const first10 = content.split(/\r?\n/).slice(0, 10);
+  return first10.some((line) => /^#\s+/.test(line));
+}
+
+/**
+ * Install a skill from raw markdown content and a caller-chosen slug.
+ * Useful for paste-to-install workflows.
+ */
+export function installSkillFromContent(content: string, slug: string): SkillInfo {
+  if (!slug || /[\/\\]/.test(slug)) {
+    throw new Error("Invalid slug — must be a non-empty string without path separators.");
+  }
+
+  const destDir = join(SKILLS_DIR, slug);
+  if (existsSync(destDir)) {
+    throw new Error(`Skill "${slug}" is already installed.`);
+  }
+
+  if (!isValidSkillContent(content)) {
+    throw new Error("Content does not appear to be a valid SKILL.md (no heading found in first 10 lines).");
+  }
+
+  mkdirSync(destDir, { recursive: true });
+  writeFileSync(join(destDir, "SKILL.md"), content, "utf-8");
+
+  const { name, description } = parseSkillMd(content);
+  return {
+    name: name || slug,
+    slug,
+    description,
+    path: destDir,
+  };
+}
+
+/**
+ * Scan a cloned repo for SKILL.md files in subdirectories (1 level deep).
+ * Returns an array of { subdir, skillMdPath } for each found skill.
+ */
+function discoverSkillsInRepo(repoDir: string): { subdir: string; skillMdPath: string }[] {
+  const found: { subdir: string; skillMdPath: string }[] = [];
+  for (const entry of readdirSync(repoDir)) {
+    const subPath = join(repoDir, entry);
+    if (!statSync(subPath).isDirectory()) continue;
+    if (entry.startsWith(".")) continue;
+    const mdPath = join(subPath, "SKILL.md");
+    if (existsSync(mdPath)) {
+      found.push({ subdir: entry, skillMdPath: mdPath });
+    }
+  }
+  return found;
+}
+
 /**
  * Install a skill from a git repo URL or a direct SKILL.md file URL.
- * Throws if the repo/file does not contain a valid SKILL.md.
+ * Returns a single SkillInfo for single-skill repos/files, or an array
+ * for repos containing multiple SKILL.md files in subdirectories.
  */
-export async function installSkill(input: string): Promise<SkillInfo> {
+export async function installSkill(input: string): Promise<SkillInfo | SkillInfo[]> {
   let destDir: string | undefined;
   try {
     const parsed = parseSkillUrl(input);
@@ -225,23 +279,57 @@ export async function installSkill(input: string): Promise<SkillInfo> {
     });
 
     const skillMdPath = join(destDir, "SKILL.md");
-    if (!existsSync(skillMdPath)) {
+    if (existsSync(skillMdPath)) {
+      // Single-skill repo (root SKILL.md)
+      const content = readFileSync(skillMdPath, "utf-8");
+      const { name, description } = parseSkillMd(content);
+      return {
+        name: name || repoName,
+        slug: repoName,
+        description,
+        path: destDir,
+      };
+    }
+
+    // No root SKILL.md — scan subdirectories for multi-skill repos
+    const discovered = discoverSkillsInRepo(destDir);
+    if (discovered.length === 0) {
       rmSync(destDir, { recursive: true, force: true });
       destDir = undefined;
       throw new Error(
-        `Repository "${repoUrl}" does not contain a SKILL.md file.`,
+        `Repository "${repoUrl}" does not contain a SKILL.md file at the root or in any subdirectory. ` +
+        `If skills are nested deeper, try installing with a direct URL to the SKILL.md file.`,
       );
     }
 
-    const content = readFileSync(skillMdPath, "utf-8");
-    const { name, description } = parseSkillMd(content);
+    // Install each discovered skill into its own SKILLS_DIR/<slug> directory
+    const installed: SkillInfo[] = [];
+    for (const { subdir, skillMdPath: mdPath } of discovered) {
+      const skillDest = join(SKILLS_DIR, subdir);
+      if (existsSync(skillDest)) {
+        console.error(`[io] Skipping "${subdir}" — already installed.`);
+        continue;
+      }
+      mkdirSync(skillDest, { recursive: true });
+      copyFileSync(mdPath, join(skillDest, "SKILL.md"));
+      // Also copy agents/ subdirectory if present
+      const agentsDir = join(destDir!, subdir, "agents");
+      if (existsSync(agentsDir) && statSync(agentsDir).isDirectory()) {
+        execFileSync("cp", ["-r", agentsDir, join(skillDest, "agents")], { stdio: "pipe" });
+      }
+      const content = readFileSync(mdPath, "utf-8");
+      const { name, description } = parseSkillMd(content);
+      installed.push({ name: name || subdir, slug: subdir, description, path: skillDest });
+    }
 
-    return {
-      name: name || repoName,
-      slug: repoName,
-      description,
-      path: destDir,
-    };
+    // Clean up cloned repo — individual skills have been extracted
+    rmSync(destDir, { recursive: true, force: true });
+    destDir = undefined;
+
+    if (installed.length === 0) {
+      throw new Error("All skills in the repository are already installed.");
+    }
+    return installed.length === 1 ? installed[0] : installed;
   } catch (e) {
     // Clean up partially-created directory on failure
     if (destDir && existsSync(destDir)) {

--- a/src/copilot/skills.ts
+++ b/src/copilot/skills.ts
@@ -1,5 +1,5 @@
 import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
-import { join, basename } from "path";
+import { join, basename, resolve } from "path";
 import { execFileSync } from "child_process";
 import { SKILLS_DIR } from "../paths.js";
 
@@ -209,11 +209,14 @@ function isValidSkillContent(content: string): boolean {
  * Useful for paste-to-install workflows.
  */
 export function installSkillFromContent(content: string, slug: string): SkillInfo {
-  if (!slug || /[\/\\]/.test(slug)) {
-    throw new Error("Invalid slug — must be a non-empty string without path separators.");
+  if (!slug || /[\/\\]/.test(slug) || slug === "." || slug === ".." || slug.includes("..")) {
+    throw new Error("Invalid slug — must be a non-empty string without path separators or traversals.");
   }
 
   const destDir = join(SKILLS_DIR, slug);
+  if (!resolve(destDir).startsWith(resolve(SKILLS_DIR) + "/")) {
+    throw new Error("Invalid slug — resolved path escapes the skills directory.");
+  }
   if (existsSync(destDir)) {
     throw new Error(`Skill "${slug}" is already installed.`);
   }
@@ -243,7 +246,7 @@ function discoverSkillsInRepo(repoDir: string): { subdir: string; skillMdPath: s
   for (const entry of readdirSync(repoDir)) {
     const subPath = join(repoDir, entry);
     if (!statSync(subPath).isDirectory()) continue;
-    if (entry.startsWith(".")) continue;
+    if (entry.startsWith(".") || entry === ".." || entry.includes("..")) continue;
     const mdPath = join(subPath, "SKILL.md");
     if (existsSync(mdPath)) {
       found.push({ subdir: entry, skillMdPath: mdPath });

--- a/src/copilot/tools.ts
+++ b/src/copilot/tools.ts
@@ -345,7 +345,7 @@ export interface ToolDeps {
     perAgent: Array<{ agent_slug: string; count: number }>;
   };
   listSkills: () => Array<{ name: string; slug: string; description: string; path: string }>;
-  installSkill: (repoUrl: string) => Promise<{ name: string; slug: string; description: string; path: string }>;
+  installSkill: (repoUrl: string) => Promise<{ name: string; slug: string; description: string; path: string } | { name: string; slug: string; description: string; path: string }[]>;
   removeSkill: (slug: string) => boolean;
   searchSkillsRegistry: (query: string) => Promise<Array<{ name: string; description: string; repoUrl: string }>>;
   saveConfig: (updates: Record<string, unknown>) => void;
@@ -924,8 +924,11 @@ export function createTools(deps: ToolDeps) {
     handler: async ({ repo_url }) => {
       console.error(`[io] skill_install called: ${repo_url}`);
       try {
-        const skill = await deps.installSkill(repo_url);
-        return `Skill "${skill.name}" installed successfully.\nSlug: ${skill.slug}\nDescription: ${skill.description || "(none)"}`;
+        const result = await deps.installSkill(repo_url);
+        const skills = Array.isArray(result) ? result : [result];
+        return skills.map((skill) =>
+          `Skill "${skill.name}" installed successfully.\nSlug: ${skill.slug}\nDescription: ${skill.description || "(none)"}`,
+        ).join("\n\n");
       } catch (err) {
         return `Error installing skill: ${err instanceof Error ? err.message : String(err)}`;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,8 +91,11 @@ skillCmd
   .action(async (repoUrl: string) => {
     try {
       console.log(`Installing skill from ${repoUrl}...`);
-      const skill = await installSkill(repoUrl);
-      console.log(`✓ Installed: ${skill.name} (${skill.slug})`);
+      const result = await installSkill(repoUrl);
+      const skills = Array.isArray(result) ? result : [result];
+      for (const skill of skills) {
+        console.log(`✓ Installed: ${skill.name} (${skill.slug})`);
+      }
     } catch (err) {
       console.error(`✗ ${err instanceof Error ? err.message : String(err)}`);
       process.exit(1);

--- a/web/src/views/SkillsView.vue
+++ b/web/src/views/SkillsView.vue
@@ -31,26 +31,81 @@
     <div v-else class="flex-1 overflow-y-auto p-6">
       <h2 class="text-2xl font-bold mb-6">Skills</h2>
 
-      <!-- Add Skill form -->
-      <form @submit.prevent="installSkill" class="mb-6 max-w-2xl">
-        <div class="flex gap-2">
-          <input
-            v-model="newRepoUrl"
-            type="url"
-            placeholder="https://github.com/owner/repo.git"
-            aria-label="Git repository URL"
-            :disabled="installing"
-            class="flex-1 bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:border-blue-500 disabled:opacity-50"
-          />
+      <!-- Install form with URL / Paste tabs -->
+      <div class="mb-6 max-w-2xl">
+        <!-- Tab switcher -->
+        <div class="flex gap-1 mb-3 border-b border-gray-800">
           <button
-            type="submit"
-            :disabled="installing || newRepoUrl.trim() === ''"
-            class="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:opacity-50 text-white px-4 py-2 rounded text-sm transition-colors whitespace-nowrap"
+            type="button"
+            @click="installTab = 'url'"
+            class="px-3 py-1.5 text-sm rounded-t transition-colors"
+            :class="installTab === 'url' ? 'bg-gray-800 text-gray-100 border-b-2 border-blue-500' : 'text-gray-500 hover:text-gray-300'"
           >
-            {{ installing ? 'Installing…' : 'Install' }}
+            From URL
+          </button>
+          <button
+            type="button"
+            @click="installTab = 'paste'"
+            class="px-3 py-1.5 text-sm rounded-t transition-colors"
+            :class="installTab === 'paste' ? 'bg-gray-800 text-gray-100 border-b-2 border-blue-500' : 'text-gray-500 hover:text-gray-300'"
+          >
+            Paste SKILL.md
           </button>
         </div>
-      </form>
+
+        <!-- URL install tab -->
+        <form v-if="installTab === 'url'" @submit.prevent="installSkill">
+          <div class="flex gap-2">
+            <input
+              v-model="newRepoUrl"
+              type="url"
+              placeholder="https://github.com/owner/repo.git"
+              aria-label="Git repository URL"
+              :disabled="installing"
+              class="flex-1 bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:border-blue-500 disabled:opacity-50"
+            />
+            <button
+              type="submit"
+              :disabled="installing || newRepoUrl.trim() === ''"
+              class="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:opacity-50 text-white px-4 py-2 rounded text-sm transition-colors whitespace-nowrap"
+            >
+              {{ installing ? 'Installing…' : 'Install' }}
+            </button>
+          </div>
+        </form>
+
+        <!-- Paste install tab -->
+        <form v-else @submit.prevent="installPaste">
+          <div class="flex flex-col gap-2">
+            <div>
+              <input
+                v-model="pasteSlug"
+                type="text"
+                placeholder="my-skill"
+                aria-label="Skill slug"
+                :disabled="pasting"
+                class="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:border-blue-500 disabled:opacity-50"
+              />
+              <p class="text-xs text-gray-600 mt-1">Unique identifier for this skill (lowercase, hyphens ok)</p>
+            </div>
+            <textarea
+              v-model="pasteContent"
+              placeholder="Paste SKILL.md content here…"
+              aria-label="SKILL.md content"
+              :disabled="pasting"
+              rows="8"
+              class="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:border-blue-500 disabled:opacity-50 font-mono resize-y"
+            ></textarea>
+            <button
+              type="submit"
+              :disabled="pasting || pasteSlug.trim() === '' || pasteContent.trim() === ''"
+              class="self-end bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:opacity-50 text-white px-4 py-2 rounded text-sm transition-colors"
+            >
+              {{ pasting ? 'Installing…' : 'Install' }}
+            </button>
+          </div>
+        </form>
+      </div>
 
       <!-- Install feedback banners -->
       <div v-if="installSuccess" class="bg-green-900 text-green-100 p-4 rounded-lg mb-4">
@@ -113,6 +168,12 @@ const newRepoUrl = ref<string>('')
 const installing = ref(false)
 const installError = ref<string | null>(null)
 const installSuccess = ref<string | null>(null)
+
+// Paste install state
+const installTab = ref<'url' | 'paste'>('url')
+const pasteSlug = ref<string>('')
+const pasteContent = ref<string>('')
+const pasting = ref(false)
 
 // Detail panel state
 const selectedSkill = ref<Skill | null>(null)
@@ -199,6 +260,44 @@ async function installSkill(): Promise<void> {
     installError.value = e instanceof Error ? e.message : 'Install failed'
   } finally {
     installing.value = false
+  }
+}
+
+async function installPaste(): Promise<void> {
+  if (pasting.value || pasteSlug.value.trim() === '' || pasteContent.value.trim() === '') return
+  pasting.value = true
+  installError.value = null
+  installSuccess.value = null
+
+  try {
+    const response = await apiFetch('/api/skills/paste', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: pasteContent.value.trim(), slug: pasteSlug.value.trim() }),
+    })
+
+    if (response.ok) {
+      const data = (await response.json()) as { skill: Skill }
+      skills.value = [data.skill, ...skills.value]
+      pasteSlug.value = ''
+      pasteContent.value = ''
+      installSuccess.value = `✓ Installed: ${data.skill.name}`
+      setTimeout(() => { installSuccess.value = null }, 4000)
+      void fetchSkills()
+    } else {
+      let message = 'Install failed'
+      try {
+        const body = (await response.json()) as { error?: string }
+        message = body.error ?? response.statusText ?? message
+      } catch {
+        message = response.statusText || message
+      }
+      installError.value = message
+    }
+  } catch (e) {
+    installError.value = e instanceof Error ? e.message : 'Install failed'
+  } finally {
+    pasting.value = false
   }
 }
 


### PR DESCRIPTION
Closes #117

### Multi-skill repo discovery
- When a repo has no root SKILL.md, scans subdirectories for SKILL.md files and installs all found
- Better error messages suggesting direct subdirectory URLs

### Paste install
- New `installSkillFromContent()` function with heading validation
- POST /api/skills/paste API endpoint
- Web UI tab to paste SKILL.md content with slug input

### Changes across:
- src/copilot/skills.ts (discovery + paste install)
- src/copilot/tools.ts (array handling)
- src/api/server.ts (paste endpoint + multi-skill response)
- src/index.ts (CLI multi-skill output)
- web/src/views/SkillsView.vue (paste tab UI)