### PR TITLE
feat: delete skills from web UI (#140)

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 import { existsSync, readFileSync } from "node:fs";
 import express, { type Request, type Response } from "express";
 import { config } from "../config.js";
-import { listSkills, installSkill, installSkillFromContent } from "../copilot/skills.js";
+import { listSkills, installSkill, installSkillFromContent, removeSkill } from "../copilot/skills.js";
 import { listSquads, createSquad, listSquadAgents } from "../store/squads.js";
 import { getAgentInfo, cancelAgentTask, getTaskEvents, subscribeToTaskEvents } from "../copilot/agents.js";
 import { summarize, summarizeEvent } from "../copilot/event-summary.js";
@@ -181,6 +181,26 @@ export async function startApiServer(): Promise<void> {
       res.status(201).json({ skill: skills[0], skills });
     } catch (e) {
       console.error("Error installing skill:", e);
+      res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
+    }
+  });
+
+  // Delete an installed skill by slug (issue #140)
+  api.delete("/skills/:slug", (req: Request, res: Response) => {
+    const slug = Array.isArray(req.params.slug) ? req.params.slug[0] : req.params.slug;
+    if (!slug || slug.includes("..") || slug.includes("/") || slug.includes("\\")) {
+      res.status(400).json({ error: "Invalid skill slug" });
+      return;
+    }
+    try {
+      const deleted = removeSkill(slug);
+      if (!deleted) {
+        res.status(404).json({ error: "Skill not found" });
+        return;
+      }
+      res.json({ deleted: true });
+    } catch (e) {
+      console.error("Error deleting skill:", e);
       res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
     }
   });

--- a/web/src/views/SkillsView.vue
+++ b/web/src/views/SkillsView.vue
@@ -134,10 +134,15 @@
           class="bg-gray-800 border border-gray-700 rounded-lg p-4 hover:border-blue-500 transition-colors cursor-pointer"
         >
           <div class="flex justify-between items-start mb-2">
-            <div>
+            <div class="min-w-0">
               <h3 class="font-bold text-gray-100">{{ skill.name }}</h3>
               <p class="text-sm text-gray-500">{{ skill.slug }}</p>
             </div>
+            <button
+              @click.stop="deleteSkill(skill)"
+              class="shrink-0 ml-2 text-gray-600 hover:text-red-400 transition-colors text-sm p-1 rounded hover:bg-gray-700"
+              title="Delete skill"
+            >🗑️</button>
           </div>
           <p class="text-sm text-gray-400 mb-3">{{ skill.description }}</p>
           <p class="text-xs text-gray-500">{{ skill.path }}</p>
@@ -298,6 +303,23 @@ async function installPaste(): Promise<void> {
     installError.value = e instanceof Error ? e.message : 'Install failed'
   } finally {
     pasting.value = false
+  }
+}
+
+async function deleteSkill(skill: Skill): Promise<void> {
+  if (!confirm(`Delete skill "${skill.name}"? This cannot be undone.`)) return
+  try {
+    const res = await apiFetch(`/api/skills/${encodeURIComponent(skill.slug)}`, { method: 'DELETE' })
+    if (res.ok) {
+      skills.value = skills.value.filter(s => s.slug !== skill.slug)
+      installSuccess.value = `✓ Deleted: ${skill.name}`
+      setTimeout(() => { installSuccess.value = null }, 3000)
+    } else {
+      const body = await res.json().catch(() => ({})) as { error?: string }
+      installError.value = body.error ?? (res.status === 404 ? 'Skill not found' : `Delete failed (HTTP ${res.status})`)
+    }
+  } catch (e) {
+    installError.value = e instanceof Error ? e.message : 'Delete failed'
   }
 }
 


### PR DESCRIPTION
Closes #140

- Adds DELETE /api/skills/:slug API endpoint (auth-protected, path traversal safe)
- Adds delete button to skill cards with confirmation dialog
- Optimistic local removal on success