### PR TITLE
feat(web): structured frontmatter display for skills (#142)

### DIFF
--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -81,6 +81,48 @@ function renderTable(tableLines: string[]): string {
   return `<div class="overflow-x-auto my-2"><table class="border-collapse w-full text-sm"><thead><tr class="border-b border-gray-700">${thCells}</tr></thead><tbody>${tbodyRows}</tbody></table></div>`
 }
 
+
+/**
+ * Extract YAML frontmatter from a markdown string.
+ * Detects content between opening `---` and closing `---` fences at the start of the file.
+ * Parses simple `key: value` pairs — no full YAML library needed for SKILL.md files.
+ * Handles quoted values (single or double quotes) and empty values.
+ */
+export function extractFrontmatter(md: string): { frontmatter: Record<string, string> | null; body: string } {
+  if (!md.startsWith('---\n') && md !== '---') {
+    return { frontmatter: null, body: md }
+  }
+  // Find the closing fence: a `---` on its own line after the opening
+  const closeIdx = md.indexOf('\n---\n', 3)
+  const closeIdxEof = md.indexOf('\n---', 3)
+  const end = (closeIdx !== -1) ? closeIdx : (closeIdxEof !== -1 && md.slice(closeIdxEof).trimEnd() === '---' ? closeIdxEof : -1)
+  if (end === -1) return { frontmatter: null, body: md }
+
+  const yamlBlock = md.slice(4, end) // everything between the two fences
+  const body = (closeIdx !== -1) ? md.slice(closeIdx + 5) : ''
+
+  const frontmatter: Record<string, string> = {}
+  for (const line of yamlBlock.split('\n')) {
+    const m = line.match(/^([^:]+):\s*(.*)$/)
+    if (!m) continue
+    const key = m[1].trim()
+    let value = m[2].trim()
+    // Strip surrounding quotes
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1)
+    }
+    frontmatter[key] = value
+  }
+
+  return {
+    frontmatter: Object.keys(frontmatter).length > 0 ? frontmatter : null,
+    body,
+  }
+}
+
 export function renderMarkdown(md: string): string {
   if (!md) return ''
 

--- a/web/src/views/SkillsView.vue
+++ b/web/src/views/SkillsView.vue
@@ -20,11 +20,38 @@
       <div v-else-if="contentError" class="flex-1 p-6">
         <p class="text-sm text-red-400">{{ contentError }}</p>
       </div>
-      <div
-        v-else
-        class="flex-1 overflow-y-auto p-6 skill-content text-sm text-gray-300 leading-relaxed"
-        v-html="renderedContent"
-      ></div>
+      <div v-else class="flex-1 overflow-y-auto p-6 skill-content text-sm text-gray-300 leading-relaxed">
+        <!-- Frontmatter info card -->
+        <div v-if="parsedFrontmatter" class="mb-6 bg-gray-900 border border-gray-700 rounded-lg p-4">
+          <div v-if="parsedFrontmatter.name" class="mb-2">
+            <p class="text-xs text-gray-500 uppercase tracking-wide">Name</p>
+            <p class="text-base font-semibold text-gray-100">{{ parsedFrontmatter.name }}</p>
+          </div>
+          <div v-if="parsedFrontmatter.description" class="mb-2">
+            <p class="text-xs text-gray-500 uppercase tracking-wide">Description</p>
+            <p class="text-sm text-gray-300">{{ parsedFrontmatter.description }}</p>
+          </div>
+          <div class="flex flex-wrap gap-6 mt-2">
+            <div v-if="parsedFrontmatter.version">
+              <p class="text-xs text-gray-500 uppercase tracking-wide">Version</p>
+              <p class="text-sm text-gray-300 font-mono">{{ parsedFrontmatter.version }}</p>
+            </div>
+            <div v-if="parsedFrontmatter.author">
+              <p class="text-xs text-gray-500 uppercase tracking-wide">Author</p>
+              <p class="text-sm text-gray-300">{{ parsedFrontmatter.author }}</p>
+            </div>
+          </div>
+          <!-- Remaining frontmatter fields -->
+          <dl v-if="remainingFrontmatterFields.length > 0" class="mt-3 pt-3 border-t border-gray-800 grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 items-baseline">
+            <template v-for="[key, val] in remainingFrontmatterFields" :key="key">
+              <dt class="text-xs text-gray-500 whitespace-nowrap">{{ key }}</dt>
+              <dd class="text-xs text-gray-400 font-mono">{{ val }}</dd>
+            </template>
+          </dl>
+        </div>
+        <!-- Markdown body -->
+        <div v-html="renderedBody"></div>
+      </div>
     </div>
 
     <!-- Skills list -->
@@ -171,7 +198,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { apiFetch } from '../lib/api'
-import { renderMarkdown } from '../lib/markdown'
+import { renderMarkdown, extractFrontmatter } from '../lib/markdown'
 
 interface Skill {
   name: string
@@ -201,7 +228,15 @@ const skillContent = ref<string>('')
 const contentLoading = ref(false)
 const contentError = ref<string | null>(null)
 
-const renderedContent = computed(() => renderMarkdown(skillContent.value))
+const skillData = computed(() => extractFrontmatter(skillContent.value))
+const parsedFrontmatter = computed(() => skillData.value.frontmatter)
+const renderedBody = computed(() => renderMarkdown(skillData.value.body))
+
+const PROMINENT_KEYS = ['name', 'description', 'version', 'author'] as const
+const remainingFrontmatterFields = computed(() => {
+  if (!parsedFrontmatter.value) return []
+  return Object.entries(parsedFrontmatter.value).filter(([k]) => !(PROMINENT_KEYS as readonly string[]).includes(k))
+})
 
 const searchQuery = ref<string>('')
 


### PR DESCRIPTION
Closes #142

- Adds extractFrontmatter() to shared markdown lib — parses YAML frontmatter into key-value pairs
- SkillsView renders frontmatter as a styled info card (name, description, version, author) above the markdown body
- Remaining frontmatter fields shown in a compact grid