### PR TITLE
feat(web): add skill discovery resource links (#144)

### DIFF
--- a/web/src/views/SkillsView.vue
+++ b/web/src/views/SkillsView.vue
@@ -58,6 +58,29 @@
     <div v-else class="flex-1 overflow-y-auto p-6">
       <h2 class="text-2xl font-bold mb-6">Skills</h2>
 
+      <!-- Discover Skills links -->
+      <div class="flex items-center gap-4 mb-6">
+        <span class="text-xs text-gray-500 uppercase tracking-wide shrink-0">Discover</span>
+        <a
+          href="https://github.com/github/awesome-copilot"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-200 transition-colors"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="w-4 h-4 fill-current" aria-hidden="true"><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"/></svg>
+          awesome-copilot
+        </a>
+        <a
+          href="https://skills.sh"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-200 transition-colors"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="w-4 h-4 fill-current" aria-hidden="true"><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8c0 .93.16 1.82.46 2.65L5 8.5V7H3.5l-.07.01A6.492 6.492 0 0 0 1.5 8Zm6.5 6.5c.93 0 1.82-.17 2.65-.47L8.5 11H7v2.5c.17.01.33.01.5.01Zm-5.3-1.7c.56.4 1.19.7 1.87.88L5 11H3.5c.34.66.79 1.25 1.2 1.8ZM8.5 1.5V4H10l2.5 2.5c.02-.16.03-.33.03-.5A6.5 6.5 0 0 0 8.5 1.5Zm-1 0A6.5 6.5 0 0 0 1.97 6H3.5L6 3.5V1.53c-.51.1-1 .26-1.5.46V1.5ZM11 8.5l-2.5 2.5H10l1.88-1.88A6.47 6.47 0 0 0 11 8.5ZM6 6v4h4V6H6Z"/></svg>
+          skills.sh
+        </a>
+      </div>
+
       <!-- Install form with URL / Paste tabs -->
       <div class="mb-6 max-w-2xl">
         <!-- Tab switcher -->


### PR DESCRIPTION
Closes #144

Adds 'Discover' row with links to awesome-copilot (GitHub) and skills.sh above the skills install form. SVG icons, new-tab links.