### PR TITLE
feat: route squad task results to inbox + TUI inbox commands

### DIFF
--- a/src/copilot/scheduler.ts
+++ b/src/copilot/scheduler.ts
@@ -17,6 +17,8 @@ import { delegateToAgent } from "./agents.js";
 import { nextRun } from "./cron.js";
 import { notifyBackground } from "../notify.js";
 import { startScheduleRun, completeScheduleRun, failScheduleRun } from "../store/schedule-runs.js";
+import { createInboxEntry } from "../store/inbox.js";
+import { shouldRouteToInbox } from "./tools.js";
 
 const TICK_MS = 30_000;
 
@@ -88,20 +90,26 @@ async function fireSchedule(schedule: SquadSchedule): Promise<void> {
   });
   try {
     await delegateToAgent(squad.slug, prompt, (_taskId, result) => {
-      void notifyBackground({
-        source: {
-          type: "squad-schedule",
-          scheduleId: schedule.id,
-          squadSlug: squad.slug,
-          scheduleName: schedule.name,
-        },
-        title: `${squad.name}: ${schedule.name}`,
-        text: result,
-      }).then((notifyResult) => {
-        completeScheduleRun(run.id, notifyResult.id);
-      }).catch((err) => {
-        failScheduleRun(run.id, err instanceof Error ? err.message : String(err));
-      });
+      if (shouldRouteToInbox(prompt)) {
+        createInboxEntry(`[${squad.slug}] ${schedule.name}`, result);
+        console.error(`[io] Schedule ${schedule.id} result routed to inbox`);
+        completeScheduleRun(run.id, 0);
+      } else {
+        void notifyBackground({
+          source: {
+            type: "squad-schedule",
+            scheduleId: schedule.id,
+            squadSlug: squad.slug,
+            scheduleName: schedule.name,
+          },
+          title: `${squad.name}: ${schedule.name}`,
+          text: result,
+        }).then((notifyResult) => {
+          completeScheduleRun(run.id, notifyResult.id);
+        }).catch((err) => {
+          failScheduleRun(run.id, err instanceof Error ? err.message : String(err));
+        });
+      }
     });
   } catch (err) {
     failScheduleRun(run.id, err instanceof Error ? err.message : String(err));

--- a/src/copilot/tools.ts
+++ b/src/copilot/tools.ts
@@ -5,6 +5,7 @@ import { readFileSync, writeFileSync, readdirSync, statSync, existsSync, mkdirSy
 import { join, dirname, resolve, sep } from "path";
 import { homedir } from "os";
 import { UNIVERSES } from "./universes.js";
+import { createInboxEntry } from "../store/inbox.js";
 import { validateCron, nextRun } from "./cron.js";
 import {
   createIoSchedule,
@@ -352,6 +353,19 @@ export interface ToolDeps {
   checkForUpdate: () => Promise<{ updateAvailable: boolean; current: string; latest: string }>;
 }
 
+
+export function shouldRouteToInbox(taskDescription: string): boolean {
+  const lower = taskDescription.toLowerCase();
+  return (
+    lower.includes("io inbox") ||
+    lower.includes("io-inbox") ||
+    lower.includes("send to inbox") ||
+    lower.includes("to the inbox") ||
+    lower.includes("result: \"io-inbox\"") ||
+    lower.includes("not github or telegram") ||
+    lower.includes("not telegram")
+  );
+}
 export function createTools(deps: ToolDeps) {
   const wikiRead = defineTool("wiki_read", {
     description: "Read a page from IO's knowledge base wiki. Path is relative to the wiki root (e.g., 'pages/preferences/editor.md').",
@@ -514,6 +528,10 @@ export function createTools(deps: ToolDeps) {
       try {
         const taskId = await deps.delegateToAgent(slug, task, (id, result) => {
           console.error(`[io] Agent task ${id} completed for squad ${slug}`);
+          if (shouldRouteToInbox(task)) {
+            createInboxEntry(`[${slug}] Task result`, result);
+            console.error(`[io] Task ${id} result routed to inbox`);
+          }
         }, agent);
         const agentLabel = agent ? `agent "${agent}" in squad "${slug}"` : `squad "${slug}"`;
         const warningPrefix = coverage.warning

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -2,6 +2,11 @@ import { createInterface, type Interface } from "readline";
 import { listRecentTasks, getTask } from "../store/tasks.js";
 import { getTaskEvents } from "../copilot/agents.js";
 import { summarize } from "../copilot/event-summary.js";
+import {
+  listInboxEntries,
+  deleteInboxEntry,
+  countInboxEntries,
+} from "../store/inbox.js";
 
 export type TuiMessageHandler = (
   text: string,
@@ -22,6 +27,9 @@ Type a message to chat. Commands:
   /status              — show status
   /activity [id|N]     — show summarized activity for a task (default: most recent)
   /verbose             — toggle verbose mode (raw event detail in /activity)
+  /inbox               — list inbox entries
+  /inbox delete <id>   — delete an inbox entry by ID
+  /inbox clear         — delete all inbox entries
   /quit                — exit
 `;
 
@@ -141,6 +149,25 @@ function renderActivity(taskIdArg: string | undefined): void {
   }
 }
 
+function renderInbox(): void {
+  const entries = listInboxEntries();
+  if (entries.length === 0) {
+    console.log("\u2705 Inbox is empty.");
+    return;
+  }
+  console.log(`\u2705 Inbox (${entries.length} ${entries.length === 1 ? "entry" : "entries"})`);
+  console.log("\u2500".repeat(60));
+  for (const entry of entries) {
+    const ts = new Date(entry.created_at).toLocaleString();
+    console.log(`[${entry.id}] ${entry.title} \u2014 ${ts}`);
+    const preview = entry.body.length > 200 ? entry.body.slice(0, 200) + "\u2026" : entry.body;
+    for (const line of preview.split(/\r?\n/)) {
+      console.log(`    ${line}`);
+    }
+    console.log("");
+  }
+}
+
 function clearLine(): void {
   process.stdout.write("\r\x1b[K");
 }
@@ -174,7 +201,11 @@ export async function startTui(): Promise<void> {
     }
 
     if (trimmed === "/status") {
+      const inboxCount = countInboxEntries();
       console.log(`[io] Uptime: ${Math.floor(process.uptime())}s`);
+      if (inboxCount > 0) {
+        console.log(`[io] \u2705 Inbox: ${inboxCount} ${inboxCount === 1 ? "entry" : "entries"}`);
+      }
       rl.prompt();
       return;
     }
@@ -190,6 +221,38 @@ export async function startTui(): Promise<void> {
       const arg = trimmed.slice("/activity".length).trim() || undefined;
       try { renderActivity(arg); } catch (err) {
         console.error(`[io] /activity failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      rl.prompt();
+      return;
+    }
+
+    if (trimmed === "/inbox" || trimmed.startsWith("/inbox ")) {
+      const sub = trimmed.slice("/inbox".length).trim();
+      try {
+        if (sub === "" ) {
+          renderInbox();
+        } else if (sub === "clear") {
+          const entries = listInboxEntries();
+          let deleted = 0;
+          for (const entry of entries) {
+            if (deleteInboxEntry(entry.id)) deleted++;
+          }
+          console.log(`[io] Cleared ${deleted} inbox ${deleted === 1 ? "entry" : "entries"}.`);
+        } else if (sub.startsWith("delete ")) {
+          const rawId = sub.slice("delete ".length).trim();
+          const id = Number.parseInt(rawId, 10);
+          if (Number.isNaN(id)) {
+            console.log(`[io] Invalid ID: "${rawId}". Usage: /inbox delete <id>`);
+          } else if (deleteInboxEntry(id)) {
+            console.log(`[io] Deleted inbox entry #${id}.`);
+          } else {
+            console.log(`[io] Inbox entry #${id} not found.`);
+          }
+        } else {
+          console.log(`[io] Unknown inbox subcommand: "${sub}". Try /inbox, /inbox delete <id>, or /inbox clear.`);
+        }
+      } catch (err) {
+        console.error(`[io] /inbox failed: ${err instanceof Error ? err.message : String(err)}`);
       }
       rl.prompt();
       return;


### PR DESCRIPTION
Related to #153

## Inbox Routing
When a squad task description contains an inbox routing hint (e.g., 'send to IO inbox', 'not GitHub or Telegram'), the task result is automatically written to the `inbox_entries` SQLite table on completion.

### Detection hints:
- 'io inbox', 'io-inbox', 'send to inbox', 'to the inbox'
- 'not github or telegram', 'not telegram'

### Changes:
- `src/copilot/tools.ts`: `shouldRouteToInbox()` helper + inbox write in squad_delegate onComplete
- `src/copilot/scheduler.ts`: inbox-first routing for scheduled tasks with hints

## TUI Inbox Commands
- `/inbox` — list all inbox entries with title, timestamp, body preview
- `/inbox delete <id>` — delete a specific entry
- `/inbox clear` — delete all entries
- `/status` now shows inbox count when > 0
- Updated welcome banner