### PR TITLE
fix(web): auth state not persisted across page refreshes

### DIFF
--- a/web/src/lib/supabase.ts
+++ b/web/src/lib/supabase.ts
@@ -5,9 +5,16 @@ let authConfig: { authEnabled: boolean; supabaseUrl: string | null; supabaseAnon
 
 export async function getAuthConfig() {
   if (authConfig) return authConfig
-  const res = await fetch('/api/auth/config')
-  authConfig = await res.json()
-  return authConfig!
+  try {
+    const res = await fetch('/api/auth/config')
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const config = await res.json() as { authEnabled: boolean; supabaseUrl: string | null; supabaseAnonKey: string | null }
+    authConfig = config  // Only cache on success
+    return authConfig
+  } catch {
+    // Return a safe default but don't cache — next call will retry
+    return { authEnabled: false, supabaseUrl: null, supabaseAnonKey: null }
+  }
 }
 
 export async function getSupabase(): Promise<SupabaseClient | null> {
@@ -16,6 +23,12 @@ export async function getSupabase(): Promise<SupabaseClient | null> {
   if (!config.authEnabled || !config.supabaseUrl || !config.supabaseAnonKey) {
     return null
   }
-  supabaseClient = createClient(config.supabaseUrl, config.supabaseAnonKey)
+  supabaseClient = createClient(config.supabaseUrl, config.supabaseAnonKey, {
+    auth: {
+      persistSession: true,
+      autoRefreshToken: true,
+      detectSessionInUrl: true,
+    },
+  })
   return supabaseClient
 }

--- a/web/src/stores/auth.ts
+++ b/web/src/stores/auth.ts
@@ -50,7 +50,11 @@ export const useAuthStore = defineStore('auth', () => {
   async function init() {
     if (initialized.value) return
     if (!initPromise) {
-      initPromise = doInit()
+      initPromise = doInit().catch(() => {
+        // Allow retry on next navigation if init failed (e.g. network error
+        // during config fetch before the API server was ready)
+        initPromise = null
+      })
     }
     return initPromise
   }


### PR DESCRIPTION
Fixes #157. Three root causes fixed: (1) getAuthConfig only caches on success — API-not-ready on cold start no longer permanently disables auth; (2) explicit persistSession/autoRefreshToken/detectSessionInUrl in createClient; (3) initPromise cleared on doInit error so next navigation retries instead of hanging on a poisoned promise.