### PR TITLE
fix: resolve IO_VERSION from package.json reliably across install contexts (#163)

### DIFF
--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,6 +1,7 @@
 import { homedir } from "os";
-import { join } from "path";
-import { createRequire } from "module";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { readFileSync } from "fs";
 
 export const IO_HOME = join(homedir(), ".io");
 export const CONFIG_PATH = join(IO_HOME, "config.json");
@@ -10,6 +11,15 @@ export const SKILLS_DIR = join(IO_HOME, "skills");
 export const SESSIONS_DIR = join(IO_HOME, "sessions");
 export const LOGS_DIR = join(IO_HOME, "logs");
 
-const require = createRequire(import.meta.url);
-const pkg = require("../package.json") as { version: string };
-export const IO_VERSION: string = pkg.version;
+function resolveVersion(): string {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  for (const rel of ["..", join("..", "..")]) {
+    try {
+      const pkg = JSON.parse(readFileSync(join(__dirname, rel, "package.json"), "utf-8"));
+      if (pkg.version) return pkg.version;
+    } catch { /* try next */ }
+  }
+  return "0.0.0";
+}
+
+export const IO_VERSION: string = resolveVersion();


### PR DESCRIPTION
Fixes #163

## Problem
`IO_VERSION` used `createRequire(import.meta.url)` to read `../package.json`, which can fail when the package is installed globally or in non-standard locations, resulting in an empty version string in the UI.

## Solution
Replaced `createRequire` with `fileURLToPath` + `readFileSync` and a fallback chain:
1. Try `../package.json` relative to compiled file (covers `dist/` → project root)
2. Try `../../package.json` (covers nested install locations)
3. Fall back to `0.0.0` if neither resolves

TSC clean, 72/72 tests pass.