### PR TITLE
fix: resolve 401 errors on page load and session loss on refresh

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -73,7 +73,11 @@ export async function startApiServer(): Promise<void> {
   app.use((_req: Request, res: Response, next) => {
     res.setHeader("Access-Control-Allow-Origin", "*");
     res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
-    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+    if (_req.method === "OPTIONS") {
+      res.sendStatus(204);
+      return;
+    }
     next();
   });
 
@@ -147,12 +151,59 @@ export async function startApiServer(): Promise<void> {
     }
   });
 
-  // Apply auth middleware to all subsequent routes
-  api.use(requireAuth);
-
+  // Status endpoint — public (non-sensitive version/uptime info)
   api.get("/status", (_req: Request, res: Response) => {
     res.json({ version: IO_VERSION, uptime: process.uptime() });
   });
+
+  // Notifications read endpoint — public (local-only app, nav badge needs data without auth race)
+  api.get("/notifications", (_req: Request, res: Response) => {
+    try {
+      const unreadOnly = _req.query.unread === "true";
+      const rows = unreadOnly
+        ? listUnreadNotifications()
+        : (() => {
+            const rawLimit = _req.query.limit;
+            const parsed = typeof rawLimit === "string" ? Number.parseInt(rawLimit, 10) : NaN;
+            const limit = Number.isFinite(parsed) && parsed > 0 ? Math.min(parsed, 200) : 50;
+            return listRecentNotifications(limit);
+          })();
+      const unreadCount = countUnreadNotifications();
+      const notifications = rows.map(({ id, title, text, created_at, read_at, source_type, source_ref }) => {
+        let source: { type: string; [key: string]: unknown } = { type: source_type };
+        if (source_ref) {
+          try {
+            const parsed = JSON.parse(source_ref) as Record<string, unknown>;
+            source = { type: source_type, ...parsed };
+          } catch {
+            // source_ref is not valid JSON — fall back to type-only
+          }
+        }
+        return { id, title, text, created_at, read_at, source };
+      });
+      res.json({ notifications, unreadCount });
+    } catch (e) {
+      console.error("Error listing notifications:", e);
+      res.status(500).json({ error: "Failed to list notifications" });
+    }
+  });
+
+  // SSE events — public (AppNav subscribes on load before auth resolves)
+  api.get("/events", (req: Request, res: Response) => {
+    res.setHeader("Content-Type", "text/event-stream");
+    res.setHeader("Cache-Control", "no-cache");
+    res.setHeader("Connection", "keep-alive");
+    res.flushHeaders();
+
+    sseConnections.add(res);
+
+    req.on("close", () => {
+      sseConnections.delete(res);
+    });
+  });
+
+  // Apply auth middleware to all subsequent routes
+  api.use(requireAuth);
 
   // Install a skill from pasted SKILL.md content (issue #117)
   api.post("/skills/paste", (req: Request, res: Response) => {
@@ -596,38 +647,6 @@ export async function startApiServer(): Promise<void> {
     }
   });
 
-  // Notifications endpoints
-  api.get("/notifications", (_req: Request, res: Response) => {
-    try {
-      const unreadOnly = _req.query.unread === "true";
-      const rows = unreadOnly
-        ? listUnreadNotifications()
-        : (() => {
-            const rawLimit = _req.query.limit;
-            const parsed = typeof rawLimit === "string" ? Number.parseInt(rawLimit, 10) : NaN;
-            const limit = Number.isFinite(parsed) && parsed > 0 ? Math.min(parsed, 200) : 50;
-            return listRecentNotifications(limit);
-          })();
-      const unreadCount = countUnreadNotifications();
-      const notifications = rows.map(({ id, title, text, created_at, read_at, source_type, source_ref }) => {
-        let source: { type: string; [key: string]: unknown } = { type: source_type };
-        if (source_ref) {
-          try {
-            const parsed = JSON.parse(source_ref) as Record<string, unknown>;
-            source = { type: source_type, ...parsed };
-          } catch {
-            // source_ref is not valid JSON — fall back to type-only
-          }
-        }
-        return { id, title, text, created_at, read_at, source };
-      });
-      res.json({ notifications, unreadCount });
-    } catch (e) {
-      console.error("Error listing notifications:", e);
-      res.status(500).json({ error: "Failed to list notifications" });
-    }
-  });
-
   api.post("/notifications/read-all", (_req: Request, res: Response) => {
     try {
       const marked = markAllNotificationsRead();
@@ -688,19 +707,6 @@ export async function startApiServer(): Promise<void> {
     });
 
     res.json({ response: fullResponse });
-  });
-
-  api.get("/events", (req: Request, res: Response) => {
-    res.setHeader("Content-Type", "text/event-stream");
-    res.setHeader("Cache-Control", "no-cache");
-    res.setHeader("Connection", "keep-alive");
-    res.flushHeaders();
-
-    sseConnections.add(res);
-
-    req.on("close", () => {
-      sseConnections.delete(res);
-    });
   });
 
   // Wiki endpoints (issue #105)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,5 @@
 import { useAuthStore } from '../stores/auth'
+import { getSupabase } from './supabase'
 
 /**
  * Wrapper around fetch() that injects the Supabase Bearer token
@@ -15,8 +16,22 @@ export async function apiFetch(input: string, init?: RequestInit): Promise<Respo
 
   const res = await fetch(input, { ...init, headers })
 
-  // If we get a 401, sign out so the router guard redirects to login
+  // On 401, try to refresh the Supabase session before giving up.
+  // This handles the race where the access token expires during a background
+  // token-refresh — Supabase would have auto-refreshed, but the in-flight
+  // request already got a 401.  One retry is enough; we never loop.
   if (res.status === 401 && auth.authEnabled) {
+    const supabase = await getSupabase()
+    if (supabase) {
+      const { data } = await supabase.auth.refreshSession()
+      if (data.session) {
+        // Retry the original request with the fresh token
+        const retryHeaders = new Headers(init?.headers)
+        retryHeaders.set('Authorization', `Bearer ${data.session.access_token}`)
+        return fetch(input, { ...init, headers: retryHeaders })
+      }
+    }
+    // Refresh failed — session is truly gone, sign out
     await auth.signOut()
   }
 


### PR DESCRIPTION
## Problem
Two related auth bugs:

1. **401 on authenticated endpoints** — `/status`, `/notifications`, `/events` return 401 on page load because AppNav calls them before Supabase finishes token refresh
2. **Session lost on refresh** — The 401 triggers `signOut()` in `apiFetch`, wiping the session before auto-refresh completes

## Root Cause
Race condition: on page refresh, the Supabase SDK restores a (possibly expired) access token from localStorage. AppNav's `onMounted` fires API calls immediately. If the token is expired, `requireAuth` returns 401, and `apiFetch` aggressively calls `signOut()` — destroying the session before Supabase's background refresh can replace the expired token.

## Fix (two-pronged)

### Server (src/api/server.ts)
- Move `/status`, `/notifications` GET, `/events` SSE before `requireAuth` — same pattern as skills/inbox reads. These are read-only endpoints in a local-only app, no multi-tenant security concern.
- Add `Authorization` to CORS `Access-Control-Allow-Headers`
- Handle OPTIONS preflight with 204

### Frontend (web/src/lib/api.ts)
- On 401, attempt `supabase.auth.refreshSession()` first
- If refresh succeeds, retry the request with the new token (one retry only)
- Only call `signOut()` if refresh fails (session truly expired)

## Write endpoints remain auth-protected
`POST /notifications/read-all`, `POST /notifications/:id/read`, and all other mutation endpoints stay behind `requireAuth`.

TSC clean, 72/72 tests pass.