### PR TITLE
docs: update testing documentation for accuracy (#167)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,7 @@ npm run build
 | `npm run dev` | Run daemon in watch mode (auto-restart on changes) |
 | `npm run daemon` | Run the daemon directly |
 | `npm run tui` | Run the TUI directly |
+| `npm test` | Run the test suite (Node.js built-in test runner via tsx) |
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -313,7 +313,12 @@ npm run tui
 
 # Run the daemon directly
 npm run daemon
+
+# Run the test suite
+npm test
 ```
+
+Tests use the Node.js built-in test runner with [tsx](https://github.com/privatenumber/tsx) for TypeScript support. Test files live alongside source files as `*.test.ts`.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed development guidelines.
 

--- a/docs/architecture/squads.md
+++ b/docs/architecture/squads.md
@@ -64,7 +64,7 @@ Decisions are stored in the `squad_decisions` table and summarized when building
 
 ```
 - [2025-05-06T10:30:00Z] Use bcrypt for password hashing instead of argon2 (Project already has bcrypt as a dependency)
-- [2025-05-06T11:15:00Z] Adopt Vitest over Jest for new test files (Aligns with existing project tooling)
+- [2025-05-06T11:15:00Z] Use Node.js built-in test runner (node --test) with tsx for new test files — not Vitest or Jest (zero extra dependencies, native ESM support)
 ```
 
 The `getDecisionsSummary()` function formats the last 20 decisions into the agent's system prompt, providing an audit trail and enabling consistent decisions over time.


### PR DESCRIPTION
Fixes #167

## Changes
- README.md: Add testing section with `npm test` and runner description
- CONTRIBUTING.md: Add `npm test` to Available Scripts table
- docs/architecture/squads.md: Correct 'Adopt Vitest' decision log entry to actual runner (Node.js built-in test runner with tsx)

All test documentation now accurately reflects the actual test setup: `node --import tsx --test 'src/**/*.test.ts'`