### PR TITLE
feat: require JWT auth on all API endpoints when Supabase is enabled (#162)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ web-dist/
 docs/node_modules
 docs/.vitepress/dist
 docs/.vitepress/cache
+data/

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -98,7 +98,10 @@ export async function startApiServer(): Promise<void> {
     });
   });
 
-  // Skills read endpoints — public (no auth required; read-only local filesystem)
+  // Apply auth middleware — all routes below require a valid JWT
+  api.use(requireAuth);
+
+  // Skills read endpoints
   api.get("/skills", (_req: Request, res: Response) => {
     try {
       const skills = listSkills();
@@ -130,7 +133,7 @@ export async function startApiServer(): Promise<void> {
     }
   });
 
-  // Inbox read endpoints — public (nav badge needs count without auth timing issues)
+  // Inbox read endpoints
   api.get("/inbox/count", (_req: Request, res: Response) => {
     try {
       const count = countInboxEntries();
@@ -151,12 +154,12 @@ export async function startApiServer(): Promise<void> {
     }
   });
 
-  // Status endpoint — public (non-sensitive version/uptime info)
+  // Status endpoint
   api.get("/status", (_req: Request, res: Response) => {
     res.json({ version: IO_VERSION, uptime: process.uptime() });
   });
 
-  // Notifications read endpoint — public (local-only app, nav badge needs data without auth race)
+  // Notifications endpoint
   api.get("/notifications", (_req: Request, res: Response) => {
     try {
       const unreadOnly = _req.query.unread === "true";
@@ -188,7 +191,7 @@ export async function startApiServer(): Promise<void> {
     }
   });
 
-  // SSE events — public (AppNav subscribes on load before auth resolves)
+  // SSE events endpoint
   api.get("/events", (req: Request, res: Response) => {
     res.setHeader("Content-Type", "text/event-stream");
     res.setHeader("Cache-Control", "no-cache");
@@ -201,9 +204,6 @@ export async function startApiServer(): Promise<void> {
       sseConnections.delete(res);
     });
   });
-
-  // Apply auth middleware to all subsequent routes
-  api.use(requireAuth);
 
   // Install a skill from pasted SKILL.md content (issue #117)
   api.post("/skills/paste", (req: Request, res: Response) => {

--- a/web/src/components/AppNav.vue
+++ b/web/src/components/AppNav.vue
@@ -157,6 +157,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRoute, useRouter, RouterLink } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
 import { apiFetch, authenticatedUrl } from '../lib/api'
+import { getSupabase } from '../lib/supabase'
 
 const route = useRoute()
 const router = useRouter()
@@ -238,8 +239,17 @@ onMounted(async () => {
     }
   } catch { /* best effort */ }
 
-  notificationSource = new EventSource(authenticatedUrl('/api/events'))
-  notificationSource.onmessage = (e) => {
+  connectSSE()
+})
+
+function connectSSE(retries = 0) {
+  notificationSource?.close()
+  notificationSource = null
+
+  const es = new EventSource(authenticatedUrl('/api/events'))
+  notificationSource = es
+
+  es.onmessage = (e) => {
     try {
       const data = JSON.parse(e.data) as { type?: string }
       if (data.type === 'notification' && route.name !== 'notifications') {
@@ -247,7 +257,23 @@ onMounted(async () => {
       }
     } catch { /* ignore */ }
   }
-})
+
+  es.onerror = async () => {
+    es.close()
+    if (notificationSource === es) {
+      notificationSource = null
+    }
+    if (retries >= 3) return // give up after 3 retries
+
+    // Refresh token before reconnecting so the new URL carries a valid JWT
+    try {
+      const supabase = await getSupabase()
+      if (supabase) await supabase.auth.refreshSession()
+    } catch { /* best effort */ }
+
+    setTimeout(() => connectSSE(retries + 1), 2000 * (retries + 1))
+  }
+}
 
 onUnmounted(() => {
   notificationSource?.close()


### PR DESCRIPTION
Fixes #162

## Problem
The API had several endpoints placed before `requireAuth` that could be called without a valid JWT when Supabase auth was enabled.

## Changes

### Server (src/api/server.ts)
- Move `requireAuth` middleware before ALL endpoints except `/health` and `/auth/config`
- Skills, inbox, status, notifications, and SSE events all now require valid JWT
- Write endpoints (POST/DELETE) were already behind auth — no change there

### Frontend (web/src/components/AppNav.vue)
- SSE EventSource now reconnects with token refresh on auth failure
- 3 retries with increasing backoff (2s, 4s, 6s) before giving up
- Properly cleans up stale connections before reconnecting

### Existing safeguard (from PR #165, unchanged)
- `apiFetch` retries once with `refreshSession()` before signing out on 401

## How it works together
1. Page loads → AppNav calls /status, /notifications → may get 401 (expired JWT)
2. `apiFetch` catches 401 → refreshes Supabase session → retries with new token → 200
3. SSE /events → may get 401 → `onerror` fires → refreshes token → reconnects
4. No session loss cascade

TSC clean, 72/72 tests pass.