### PR TITLE
feat(web): replace UI icons with Fluent design icons (#168)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "web",
       "version": "0.0.0",
       "dependencies": {
+        "@fluentui/svg-icons": "^1.1.326",
         "@supabase/supabase-js": "^2.105.4",
         "highlight.js": "^11.11.1",
         "pinia": "^2.2.2",
@@ -474,6 +475,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@fluentui/svg-icons": {
+      "version": "1.1.326",
+      "resolved": "https://registry.npmjs.org/@fluentui/svg-icons/-/svg-icons-1.1.326.tgz",
+      "integrity": "sha512-jjT8THbBQdL+NGyaE31HJ5yDeOKc9WEk+3r1JQnAsb20+02eoOlX0/ImNIf5j8HjLDPZet/3FzYmwuE9bnsWDg==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fluentui/svg-icons": "^1.1.326",
     "@supabase/supabase-js": "^2.105.4",
     "highlight.js": "^11.11.1",
     "pinia": "^2.2.2",

--- a/web/src/components/AppNav.vue
+++ b/web/src/components/AppNav.vue
@@ -24,7 +24,7 @@
         class="p-1.5 rounded-md text-txt-muted hover:text-txt-secondary hover:bg-surface-3/50 transition-all duration-150 shrink-0 ml-1"
         title="Collapse sidebar"
       >
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M10 3L5 8l5 5"/></svg>
+        <FluentIcon paths="<path d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"/>" :size="14" />
       </button>
       <button
         v-else
@@ -32,7 +32,7 @@
         class="absolute -right-3 top-4 w-6 h-6 rounded-full bg-surface-2 border border-edge-bright shadow-card flex items-center justify-center text-txt-muted hover:text-accent hover:border-accent/30 transition-all duration-150 z-20"
         title="Expand sidebar"
       >
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M6 3l5 5-5 5"/></svg>
+        <FluentIcon paths="<path d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"/>" :size="12" />
       </button>
     </div>
 
@@ -62,7 +62,7 @@
               :class="collapsed ? 'h-4' : 'h-5'"
             ></span>
 
-            <span class="text-base leading-none shrink-0 transition-transform duration-150 group-hover:scale-105" :class="collapsed ? '' : 'ml-0.5'">{{ item.icon }}</span>
+            <FluentIcon :paths="item.icon" :size="18" class="shrink-0 transition-transform duration-150 group-hover:scale-105" :class="collapsed ? '' : 'ml-0.5'" />
             <span v-if="!collapsed" class="text-[13px] font-medium truncate">{{ item.label }}</span>
 
             <!-- Notification badge -->
@@ -143,7 +143,7 @@
               class="p-1.5 rounded-md text-txt-muted hover:text-red-400 hover:bg-surface-3/50 transition-all duration-150"
               title="Sign out"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M6 2H3a1 1 0 00-1 1v10a1 1 0 001 1h3M11 11l3-3-3-3M14 8H6"/></svg>
+              <FluentIcon paths="<path d="M9.16 16.87a.5.5 0 1 0 .67-.74L3.67 10.5H17.5a.5.5 0 0 0 0-1H3.67l6.16-5.63a.5.5 0 0 0-.67-.74L2.24 9.44a.75.75 0 0 0 0 1.11l6.92 6.32Z"/>" :size="14" />
             </button>
           </div>
         </template>
@@ -155,6 +155,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRoute, useRouter, RouterLink } from 'vue-router'
+ import FluentIcon from './FluentIcon.vue'
 import { useAuthStore } from '../stores/auth'
 import { apiFetch, authenticatedUrl } from '../lib/api'
 import { getSupabase } from '../lib/supabase'
@@ -172,14 +173,14 @@ let notificationSource: EventSource | null = null
 const STORAGE_KEY = 'io-nav-collapsed'
 
 const navItems = [
-  { to: '/chat',          name: 'chat',          icon: '💬', label: 'Chat' },
-  { to: '/inbox',         name: 'inbox',         icon: '📥', label: 'Inbox' },
-  { to: '/skills',        name: 'skills',        icon: '⚙️',  label: 'Skills' },
-  { to: '/squads',        name: 'squads',        icon: '👥', label: 'Squads' },
-  { to: '/wiki',          name: 'wiki',          icon: '📚', label: 'Wiki' },
-  { to: '/schedules',     name: 'schedules',     icon: '📅', label: 'Schedules' },
-  { to: '/notifications', name: 'notifications', icon: '🔔', label: 'Notifications' },
-  { to: '/activity',      name: 'activity',      icon: '📊', label: 'Activity' },
+  { to: '/chat',          name: 'chat',          icon: '<path d="M10 2a8 8 0 1 1-3.61 15.14l-.12-.07-3.65.92a.5.5 0 0 1-.62-.45v-.08l.01-.08.92-3.64-.07-.12a7.95 7.95 0 0 1-.83-2.9l-.02-.37L2 10a8 8 0 0 1 8-8Zm0 1a7 7 0 0 0-6.1 10.42.5.5 0 0 1 .06.28l-.02.1-.75 3.01 3.02-.75a.5.5 0 0 1 .19-.01l.09.02.09.04A7 7 0 1 0 10 3Zm.5 8a.5.5 0 0 1 .09 1H7.5a.5.5 0 0 1-.09-1h3.09Zm2-3a.5.5 0 0 1 .09 1H7.5a.5.5 0 0 1-.09-1h5.09Z"/>', label: 'Chat' },
+  { to: '/inbox',         name: 'inbox',         icon: '<path d="M6 3a3 3 0 0 0-3 3v8a3 3 0 0 0 3 3h8a3 3 0 0 0 3-3V6a3 3 0 0 0-3-3H6Zm10 7h-3.5a.5.5 0 0 0-.5.5v.01a1.75 1.75 0 0 1-.03.3c-.04.2-.1.46-.23.72-.13.25-.3.49-.57.66-.26.18-.63.31-1.17.31-.54 0-.9-.13-1.17-.3a1.7 1.7 0 0 1-.57-.67A2.57 2.57 0 0 1 8 10.5v-.01a.5.5 0 0 0-.5-.5H4V6c0-1.1.9-2 2-2h8a2 2 0 0 1 2 2v4ZM4 11h3.05c.05.26.14.62.32.97.18.38.47.76.9 1.06.45.29 1.02.47 1.73.47s1.28-.18 1.72-.47c.44-.3.73-.68.91-1.06.18-.35.27-.7.32-.97H16v3a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-3Z"/>', label: 'Inbox' },
+  { to: '/skills',        name: 'skills',        icon: '<path d="M9 6.5a4.5 4.5 0 0 1 6.35-4.1.5.5 0 0 1 .15.8l-2.3 2.3 1.3 1.3 2.3-2.3a.5.5 0 0 1 .8.15A4.49 4.49 0 0 1 13.5 11a4.5 4.5 0 0 1-1.1-.14l-6.37 6.45a2.36 2.36 0 0 1-3.37-3.3l6.42-6.65A4.52 4.52 0 0 1 9 6.5ZM13.5 3a3.5 3.5 0 0 0-3.39 4.39.5.5 0 0 1-.12.47L3.38 14.7a1.36 1.36 0 0 0 1.94 1.9l6.57-6.66a.5.5 0 0 1 .51-.12 3.5 3.5 0 0 0 4.53-4.05l-2.08 2.07a.5.5 0 0 1-.7 0l-2-2a.5.5 0 0 1 0-.7l2.07-2.08A3.52 3.52 0 0 0 13.5 3Z"/>', label: 'Skills' },
+  { to: '/squads',        name: 'squads',        icon: '<path d="M10 3a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3ZM7.5 4.5a2.5 2.5 0 1 1 5 0 2.5 2.5 0 0 1-5 0Zm8-.5a1 1 0 1 0 0 2 1 1 0 0 0 0-2Zm-2 1a2 2 0 1 1 4 0 2 2 0 0 1-4 0Zm-10 0a1 1 0 1 1 2 0 1 1 0 0 1-2 0Zm1-2a2 2 0 1 0 0 4 2 2 0 0 0 0-4Zm.6 12H5a2 2 0 0 1-2-2V9.25c0-.14.11-.25.25-.25h1.76c.04-.37.17-.7.37-1H3.25C2.56 8 2 8.56 2 9.25V13a3 3 0 0 0 3.4 2.97 4.96 4.96 0 0 1-.3-.97Zm9.5.97A3 3 0 0 0 18 13V9.25C18 8.56 17.44 8 16.75 8h-2.13c.2.3.33.63.37 1h1.76c.14 0 .25.11.25.25V13a2 2 0 0 1-2.1 2c-.07.34-.17.66-.3.97ZM7.25 8C6.56 8 6 8.56 6 9.25V14a4 4 0 0 0 8 0V9.25C14 8.56 13.44 8 12.75 8h-5.5ZM7 9.25c0-.14.11-.25.25-.25h5.5c.14 0 .25.11.25.25V14a3 3 0 1 1-6 0V9.25Z"/>', label: 'Squads' },
+  { to: '/wiki',          name: 'wiki',          icon: '<path d="M10 16c-.46.6-1.18 1-2 1H3.5A1.5 1.5 0 0 1 2 15.5v-11C2 3.67 2.67 3 3.5 3H8c.82 0 1.54.4 2 1 .46-.6 1.18-1 2-1h4.5c.83 0 1.5.67 1.5 1.5v11c0 .83-.67 1.5-1.5 1.5H12a2.5 2.5 0 0 1-2-1ZM3 4.5v11c0 .28.22.5.5.5H8c.83 0 1.5-.67 1.5-1.5v-9C9.5 4.67 8.83 4 8 4H3.5a.5.5 0 0 0-.5.5Zm7.5 10c0 .83.67 1.5 1.5 1.5h4.5a.5.5 0 0 0 .5-.5v-11a.5.5 0 0 0-.5-.5H12c-.83 0-1.5.67-1.5 1.5v9Z"/>', label: 'Wiki' },
+  { to: '/schedules',     name: 'schedules',     icon: '<path d="M7 11a1 1 0 1 0 0-2 1 1 0 0 0 0 2Zm1 2a1 1 0 1 1-2 0 1 1 0 0 1 2 0Zm2-2a1 1 0 1 0 0-2 1 1 0 0 0 0 2Zm1 2a1 1 0 1 1-2 0 1 1 0 0 1 2 0Zm2-2a1 1 0 1 0 0-2 1 1 0 0 0 0 2Zm4-5.5A2.5 2.5 0 0 0 14.5 3h-9A2.5 2.5 0 0 0 3 5.5v9A2.5 2.5 0 0 0 5.5 17h9a2.5 2.5 0 0 0 2.5-2.5v-9ZM4 7h12v7.5c0 .83-.67 1.5-1.5 1.5h-9A1.5 1.5 0 0 1 4 14.5V7Zm1.5-3h9c.83 0 1.5.67 1.5 1.5V6H4v-.5C4 4.67 4.67 4 5.5 4Z"/>', label: 'Schedules' },
+  { to: '/notifications', name: 'notifications', icon: '<path d="M10 2a5.92 5.92 0 0 1 5.98 5.36l.02.22V11.4l.92 2.22a1 1 0 0 1 .06.17l.01.08.01.13a1 1 0 0 1-.75.97l-.11.02L16 15h-3.5v.17a2.5 2.5 0 0 1-5 0V15H4a1 1 0 0 1-.26-.03l-.13-.04a1 1 0 0 1-.6-1.05l.02-.13.05-.13L4 11.4V7.57A5.9 5.9 0 0 1 10 2Zm1.5 13h-3v.15a1.5 1.5 0 0 0 1.36 1.34l.14.01c.78 0 1.42-.6 1.5-1.36V15ZM10 3a4.9 4.9 0 0 0-4.98 4.38L5 7.6V11.5l-.04.2L4 14h12l-.96-2.3-.04-.2V7.61A4.9 4.9 0 0 0 10 3Z"/>', label: 'Notifications' },
+  { to: '/activity',      name: 'activity',      icon: '<path d="M16.52 9c.26 0 .48-.2.48-.46V8.5A6.5 6.5 0 0 0 10.5 2h-.04a.47.47 0 0 0-.46.48V8.5c0 .28.22.5.5.5h6.02ZM11 3.02A5.5 5.5 0 0 1 15.98 8H11V3.02ZM8 9V5.1A5 5 0 0 0 9 15v1a6 6 0 0 1-.5-11.98c.28-.02.5.2.5.48V9a1 1 0 0 0 1 1h4.5c.28 0 .5.22.48.5a6 6 0 0 1-.06.5H10a2 2 0 0 1-2-2Zm9 1a1 1 0 0 0-1 1v7a1 1 0 1 0 2 0v-7a1 1 0 0 0-1-1Zm-3 2a1 1 0 0 0-1 1v5a1 1 0 1 0 2 0v-5a1 1 0 0 0-1-1Zm-4 3a1 1 0 1 1 2 0v3a1 1 0 1 1-2 0v-3Z"/>', label: 'Activity' },
 ]
 
 const userInitial = computed(() => {

--- a/web/src/components/FluentIcon.vue
+++ b/web/src/components/FluentIcon.vue
@@ -1,0 +1,22 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    :width="size"
+    :height="size"
+    :viewBox="`0 0 ${viewBox} ${viewBox}`"
+    fill="currentColor"
+    aria-hidden="true"
+    v-html="paths"
+  />
+</template>
+
+<script setup lang="ts">
+withDefaults(defineProps<{
+  paths: string
+  size?: number | string
+  viewBox?: number
+}>(), {
+  size: 20,
+  viewBox: 20,
+})
+</script>

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -79,7 +79,7 @@
                flex items-center justify-center transition-all duration-200"
         title="Scroll to bottom"
       >
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 6l4 4 4-4"/></svg>
+        <FluentIcon paths="<path d="M15.85 7.65c.2.2.2.5 0 .7l-5.46 5.49a.55.55 0 0 1-.78 0L4.15 8.35a.5.5 0 1 1 .7-.7L10 12.8l5.15-5.16c.2-.2.5-.2.7 0Z"/>" :size="16" />
       </button>
     </Transition>
 
@@ -127,7 +127,7 @@
                  transition-all duration-150"
           title="Send"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 16 16" fill="currentColor"><path d="M1.724 1.053a.5.5 0 0 1 .54-.068l12 6a.5.5 0 0 1 0 .894l-12 6A.5.5 0 0 1 1.5 13.5v-4.379l6.5-1.121-6.5-1.121V2.5a.5.5 0 0 1 .224-.447Z"/></svg>
+          <FluentIcon paths="<path d="M2.18 2.11a.5.5 0 0 1 .54-.06l15 7.5a.5.5 0 0 1 0 .9l-15 7.5a.5.5 0 0 1-.7-.58L3.98 10 2.02 2.63a.5.5 0 0 1 .16-.52Zm2.7 8.39-1.61 6.06L16.38 10 3.27 3.44 4.88 9.5h6.62a.5.5 0 1 1 0 1H4.88Z"/>" :size="16" />
         </button>
       </form>
     </div>
@@ -136,6 +136,7 @@
 
 <script setup lang="ts">
 import { ref, nextTick, watch, computed } from 'vue'
+import FluentIcon from '../components/FluentIcon.vue'
 import { useChatStore } from '../stores/chat'
 import { renderMarkdown } from '../lib/markdown'
 import { apiFetch, authenticatedUrl } from '../lib/api'

--- a/web/src/views/InboxView.vue
+++ b/web/src/views/InboxView.vue
@@ -23,9 +23,7 @@
     <!-- Empty state -->
     <div v-else-if="entries.length === 0" class="flex-1 flex flex-col items-center justify-center">
       <div class="w-14 h-14 rounded-xl bg-surface-2 border border-edge flex items-center justify-center mb-4">
-        <svg class="w-7 h-7 text-txt-muted" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 13.5h3.86a2.25 2.25 0 012.012 1.244l.256.512a2.25 2.25 0 002.013 1.244h3.218a2.25 2.25 0 002.013-1.244l.256-.512a2.25 2.25 0 012.013-1.244h3.859m-19.5.338V18a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 00-2.15-1.588H6.911a2.25 2.25 0 00-2.15 1.588L2.35 13.177a2.25 2.25 0 00-.1.661z"/>
-        </svg>
+        <FluentIcon paths="<path d="M6 3a3 3 0 0 0-3 3v8a3 3 0 0 0 3 3h8a3 3 0 0 0 3-3V6a3 3 0 0 0-3-3H6Zm10 7h-3.5a.5.5 0 0 0-.5.5v.01a1.75 1.75 0 0 1-.03.3c-.04.2-.1.46-.23.72-.13.25-.3.49-.57.66-.26.18-.63.31-1.17.31-.54 0-.9-.13-1.17-.3a1.7 1.7 0 0 1-.57-.67A2.57 2.57 0 0 1 8 10.5v-.01a.5.5 0 0 0-.5-.5H4V6c0-1.1.9-2 2-2h8a2 2 0 0 1 2 2v4ZM4 11h3.05c.05.26.14.62.32.97.18.38.47.76.9 1.06.45.29 1.02.47 1.73.47s1.28-.18 1.72-.47c.44-.3.73-.68.91-1.06.18-.35.27-.7.32-.97H16v3a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-3Z"/>" :size="28" class="text-txt-muted" />
       </div>
       <p class="text-txt-muted text-sm font-medium">Inbox is empty</p>
       <p class="text-txt-muted/60 text-xs mt-1">No messages right now</p>
@@ -65,9 +63,7 @@
             class="opacity-0 group-hover:opacity-100 shrink-0 p-1.5 rounded-lg text-txt-muted hover:text-red-400 hover:bg-red-500/10 border border-transparent hover:border-red-500/20 disabled:opacity-30 transition-all duration-200"
             title="Delete entry"
           >
-            <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"/>
-            </svg>
+            <FluentIcon paths="<path d="M8.5 4h3a1.5 1.5 0 0 0-3 0Zm-1 0a2.5 2.5 0 0 1 5 0h5a.5.5 0 0 1 0 1h-1.05l-1.2 10.34A3 3 0 0 1 12.27 18H7.73a3 3 0 0 1-2.98-2.66L3.55 5H2.5a.5.5 0 0 1 0-1h5ZM5.74 15.23A2 2 0 0 0 7.73 17h4.54a2 2 0 0 0 1.99-1.77L15.44 5H4.56l1.18 10.23ZM8.5 7.5c.28 0 .5.22.5.5v6a.5.5 0 0 1-1 0V8c0-.28.22-.5.5-.5ZM12 8a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V8Z"/>" :size="14" />
           </button>
         </div>
 
@@ -86,9 +82,7 @@
       v-if="errorMsg"
       class="mt-3 flex items-center gap-2 text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-xl px-3.5 py-2.5"
     >
-      <svg class="w-4 h-4 shrink-0" viewBox="0 0 20 20" fill="currentColor">
-        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clip-rule="evenodd"/>
-      </svg>
+      <FluentIcon paths="<path d="m4.09 4.22.06-.07a.5.5 0 0 1 .63-.06l.07.06L10 9.29l5.15-5.14a.5.5 0 0 1 .63-.06l.07.06c.18.17.2.44.06.63l-.06.07L10.71 10l5.14 5.15c.18.17.2.44.06.63l-.06.07a.5.5 0 0 1-.63.06l-.07-.06L10 10.71l-5.15 5.14a.5.5 0 0 1-.63.06l-.07-.06a.5.5 0 0 1-.06-.63l.06-.07L9.29 10 4.15 4.85a.5.5 0 0 1-.06-.63l.06-.07-.06.07Z"/>" :size="16" class="shrink-0" />
       {{ errorMsg }}
     </div>
   </div>
@@ -96,6 +90,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import FluentIcon from '../components/FluentIcon.vue'
 import { renderMarkdown } from '../lib/markdown'
 import { apiFetch } from '../lib/api'
 

--- a/web/src/views/LoginView.vue
+++ b/web/src/views/LoginView.vue
@@ -46,7 +46,7 @@
           </div>
 
           <div v-if="error" class="flex items-center gap-2 text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-xl px-3.5 py-2.5">
-            <svg class="w-4 h-4 shrink-0" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clip-rule="evenodd"/></svg>
+            <FluentIcon paths="<path d="m4.09 4.22.06-.07a.5.5 0 0 1 .63-.06l.07.06L10 9.29l5.15-5.14a.5.5 0 0 1 .63-.06l.07.06c.18.17.2.44.06.63l-.06.07L10.71 10l5.14 5.15c.18.17.2.44.06.63l-.06.07a.5.5 0 0 1-.63.06l-.07-.06L10 10.71l-5.15 5.14a.5.5 0 0 1-.63.06l-.07-.06a.5.5 0 0 1-.06-.63l.06-.07L9.29 10 4.15 4.85a.5.5 0 0 1-.06-.63l.06-.07-.06.07Z"/>" :size="16" class="shrink-0" />
             {{ error }}
           </div>
 
@@ -65,6 +65,7 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
+import FluentIcon from '../components/FluentIcon.vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
 

--- a/web/src/views/NotificationsView.vue
+++ b/web/src/views/NotificationsView.vue
@@ -26,9 +26,7 @@
     <!-- Empty state -->
     <div v-else-if="notifications.length === 0" class="flex-1 flex flex-col items-center justify-center">
       <div class="w-12 h-12 rounded-xl bg-surface-2 border border-edge flex items-center justify-center mb-4">
-        <svg class="w-6 h-6 text-txt-muted" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0"/>
-        </svg>
+        <FluentIcon paths="<path d="M10 2a5.92 5.92 0 0 1 5.98 5.36l.02.22V11.4l.92 2.22a1 1 0 0 1 .06.17l.01.08.01.13a1 1 0 0 1-.75.97l-.11.02L16 15h-3.5v.17a2.5 2.5 0 0 1-5 0V15H4a1 1 0 0 1-.26-.03l-.13-.04a1 1 0 0 1-.6-1.05l.02-.13.05-.13L4 11.4V7.57A5.9 5.9 0 0 1 10 2Zm1.5 13h-3v.15a1.5 1.5 0 0 0 1.36 1.34l.14.01c.78 0 1.42-.6 1.5-1.36V15ZM10 3a4.9 4.9 0 0 0-4.98 4.38L5 7.6V11.5l-.04.2L4 14h12l-.96-2.3-.04-.2V7.61A4.9 4.9 0 0 0 10 3Z"/>" :size="24" class="text-txt-muted" />
       </div>
       <p class="text-txt-muted text-sm">No notifications yet</p>
     </div>
@@ -73,9 +71,7 @@
               class="text-txt-muted hover:text-accent shrink-0 opacity-0 group-hover:opacity-100 transition-all duration-200 p-1 rounded-lg hover:bg-accent/10"
               title="Mark as read"
             >
-              <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/>
-              </svg>
+              <FluentIcon paths="<path d="M3.37 10.17a.5.5 0 0 0-.74.66l4 4.5c.19.22.52.23.72.02l10.5-10.5a.5.5 0 0 0-.7-.7L7.02 14.27l-3.65-4.1Z"/>" :size="16" />
             </button>
           </div>
         </div>
@@ -94,6 +90,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import FluentIcon from '../components/FluentIcon.vue'
 import { renderMarkdown } from '../lib/markdown'
 import { apiFetch } from '../lib/api'
 

--- a/web/src/views/SchedulesView.vue
+++ b/web/src/views/SchedulesView.vue
@@ -12,9 +12,7 @@
           :disabled="loading"
           class="flex items-center gap-1.5 bg-surface-2/60 hover:bg-surface-3/60 disabled:opacity-50 text-txt-secondary hover:text-txt-primary border border-edge hover:border-edge-bright px-3.5 py-2 rounded-xl text-sm transition-all duration-200"
         >
-          <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.992 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182"/>
-          </svg>
+          <FluentIcon paths="<path d=\"M11.41 3.64a.5.5 0 0 0 0-.71L9.3.8a.5.5 0 0 0-.7.7l1 1a7.5 7.5 0 0 0-4.08 13.5.5.5 0 0 0 .6-.8A6.5 6.5 0 0 1 10.14 3.5L8.59 5.04a.5.5 0 0 0 .7.7l2.12-2.11ZM8.6 16.36a.5.5 0 0 0 0 .71l2.12 2.12a.5.5 0 0 0 .7-.7l-1-1a7.5 7.5 0 0 0 4.07-13.5.5.5 0 1 0-.59.8A6.5 6.5 0 0 1 9.86 16.5l1.55-1.55a.5.5 0 1 0-.7-.7l-2.12 2.11Z\"/>" class="w-3.5 h-3.5" />
           Refresh
         </button>
       </div>
@@ -36,9 +34,7 @@
         <!-- IO Schedules -->
         <details open class="mb-8 group/section">
           <summary class="cursor-pointer select-none flex items-center gap-3 text-sm font-semibold text-txt-primary mb-4 py-2">
-            <svg class="w-4 h-4 text-accent transition-transform group-open/section:rotate-90" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5"/>
-            </svg>
+            <FluentIcon paths="<path d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"/>" :size="16" class="text-accent transition-transform group-open/section:rotate-90" />
             <span class="tracking-wide uppercase text-xs text-txt-secondary">IO Schedules</span>
             <span class="text-[10px] font-mono text-txt-muted bg-surface-2 px-2 py-0.5 rounded-full border border-edge">{{ ioSchedules.length }}</span>
             <div class="flex-1 h-px bg-gradient-to-r from-edge to-transparent"></div>
@@ -46,9 +42,7 @@
 
           <div v-if="ioSchedules.length === 0" class="flex flex-col items-center py-8">
             <div class="w-10 h-10 rounded-xl bg-surface-2 border border-edge flex items-center justify-center mb-3">
-              <svg class="w-5 h-5 text-txt-muted" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
-              </svg>
+              <FluentIcon paths="<path d="M10 2a8 8 0 1 1 0 16 8 8 0 0 1 0-16Zm0 1a7 7 0 1 0 0 14 7 7 0 0 0 0-14Zm-.5 2a.5.5 0 0 1 .5.41V10h2.5a.5.5 0 0 1 .09 1H9.5a.5.5 0 0 1-.5-.41V5.5c0-.28.22-.5.5-.5Z"/>" :size="20" class="text-txt-muted" />
             </div>
             <p class="text-txt-muted text-sm">No IO schedules configured</p>
           </div>
@@ -77,11 +71,11 @@
                   <div class="flex flex-wrap items-center gap-3 text-xs text-txt-muted mt-1">
                     <code class="font-mono text-accent/80 bg-surface-0/60 px-2 py-0.5 rounded-lg border border-edge/50 break-all">{{ s.cron_expr }}</code>
                     <span v-if="s.next_run_at" class="flex items-center gap-1 shrink-0">
-                      <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3 8.689c0-.864.933-1.405 1.683-.977l7.108 4.062a1.125 1.125 0 010 1.953l-7.108 4.062A1.125 1.125 0 013 16.811V8.69zM12.75 8.689c0-.864.933-1.405 1.683-.977l7.108 4.062a1.125 1.125 0 010 1.953l-7.108 4.062a1.125 1.125 0 01-1.683-.977V8.69z"/></svg>
+                      <FluentIcon paths="<path d="M17.22 8.69a1.5 1.5 0 0 1 0 2.62l-10 5.5A1.5 1.5 0 0 1 5 15.5v-11A1.5 1.5 0 0 1 7.22 3.2l10 5.5Zm-.48 1.75a.5.5 0 0 0 0-.88l-10-5.5A.5.5 0 0 0 6 4.5v11c0 .38.4.62.74.44l10-5.5Z"/>" :size="12" />
                       {{ formatDate(s.next_run_at) }}
                     </span>
                     <span v-if="s.last_run_at" class="flex items-center gap-1 shrink-0">
-                      <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+                      <FluentIcon paths="<path d="M10 2a8 8 0 1 1 0 16 8 8 0 0 1 0-16Zm0 1a7 7 0 1 0 0 14 7 7 0 0 0 0-14Zm-.5 2a.5.5 0 0 1 .5.41V10h2.5a.5.5 0 0 1 .09 1H9.5a.5.5 0 0 1-.5-.41V5.5c0-.28.22-.5.5-.5Z"/>" :size="12" />
                       {{ formatDate(s.last_run_at) }}
                     </span>
                   </div>
@@ -126,7 +120,7 @@
                     class="text-red-400/70 hover:text-red-400 disabled:opacity-50 text-xs px-2 py-1.5 rounded-lg hover:bg-red-500/10 border border-transparent hover:border-red-500/20 transition-all duration-200"
                     title="Delete"
                   >
-                    <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"/></svg>
+                    <FluentIcon paths="<path d="M8.5 4h3a1.5 1.5 0 0 0-3 0Zm-1 0a2.5 2.5 0 0 1 5 0h5a.5.5 0 0 1 0 1h-1.05l-1.2 10.34A3 3 0 0 1 12.27 18H7.73a3 3 0 0 1-2.98-2.66L3.55 5H2.5a.5.5 0 0 1 0-1h5ZM5.74 15.23A2 2 0 0 0 7.73 17h4.54a2 2 0 0 0 1.99-1.77L15.44 5H4.56l1.18 10.23ZM8.5 7.5c.28 0 .5.22.5.5v6a.5.5 0 0 1-1 0V8c0-.28.22-.5.5-.5ZM12 8a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V8Z"/>" :size="14" />
                   </button>
                 </div>
               </div>
@@ -189,9 +183,7 @@
         <!-- Squad Schedules -->
         <details open class="group/section">
           <summary class="cursor-pointer select-none flex items-center gap-3 text-sm font-semibold text-txt-primary mb-4 py-2">
-            <svg class="w-4 h-4 text-accent transition-transform group-open/section:rotate-90" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5"/>
-            </svg>
+            <FluentIcon paths="<path d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"/>" :size="16" class="text-accent transition-transform group-open/section:rotate-90" />
             <span class="tracking-wide uppercase text-xs text-txt-secondary">Squad Schedules</span>
             <span class="text-[10px] font-mono text-txt-muted bg-surface-2 px-2 py-0.5 rounded-full border border-edge">{{ squadSchedules.length }}</span>
             <div class="flex-1 h-px bg-gradient-to-r from-edge to-transparent"></div>
@@ -199,9 +191,7 @@
 
           <div v-if="squadSchedules.length === 0" class="flex flex-col items-center py-8">
             <div class="w-10 h-10 rounded-xl bg-surface-2 border border-edge flex items-center justify-center mb-3">
-              <svg class="w-5 h-5 text-txt-muted" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z"/>
-              </svg>
+              <FluentIcon paths="<path d="M10 3a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3ZM7.5 4.5a2.5 2.5 0 1 1 5 0 2.5 2.5 0 0 1-5 0Zm8-.5a1 1 0 1 0 0 2 1 1 0 0 0 0-2Zm-2 1a2 2 0 1 1 4 0 2 2 0 0 1-4 0Zm-10 0a1 1 0 1 1 2 0 1 1 0 0 1-2 0Zm1-2a2 2 0 1 0 0 4 2 2 0 0 0 0-4Zm.6 12H5a2 2 0 0 1-2-2V9.25c0-.14.11-.25.25-.25h1.76c.04-.37.17-.7.37-1H3.25C2.56 8 2 8.56 2 9.25V13a3 3 0 0 0 3.4 2.97 4.96 4.96 0 0 1-.3-.97Zm9.5.97A3 3 0 0 0 18 13V9.25C18 8.56 17.44 8 16.75 8h-2.13c.2.3.33.63.37 1h1.76c.14 0 .25.11.25.25V13a2 2 0 0 1-2.1 2c-.07.34-.17.66-.3.97ZM7.25 8C6.56 8 6 8.56 6 9.25V14a4 4 0 0 0 8 0V9.25C14 8.56 13.44 8 12.75 8h-5.5ZM7 9.25c0-.14.11-.25.25-.25h5.5c.14 0 .25.11.25.25V14a3 3 0 1 1-6 0V9.25Z"/>" :size="20" class="text-txt-muted" />
             </div>
             <p class="text-txt-muted text-sm">No squad schedules configured</p>
           </div>
@@ -231,11 +221,11 @@
                   <div class="flex flex-wrap items-center gap-3 text-xs text-txt-muted mt-1">
                     <code class="font-mono text-accent/80 bg-surface-0/60 px-2 py-0.5 rounded-lg border border-edge/50 break-all">{{ s.cron_expr }}</code>
                     <span v-if="s.next_run_at" class="flex items-center gap-1 shrink-0">
-                      <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3 8.689c0-.864.933-1.405 1.683-.977l7.108 4.062a1.125 1.125 0 010 1.953l-7.108 4.062A1.125 1.125 0 013 16.811V8.69zM12.75 8.689c0-.864.933-1.405 1.683-.977l7.108 4.062a1.125 1.125 0 010 1.953l-7.108 4.062a1.125 1.125 0 01-1.683-.977V8.69z"/></svg>
+                      <FluentIcon paths="<path d="M17.22 8.69a1.5 1.5 0 0 1 0 2.62l-10 5.5A1.5 1.5 0 0 1 5 15.5v-11A1.5 1.5 0 0 1 7.22 3.2l10 5.5Zm-.48 1.75a.5.5 0 0 0 0-.88l-10-5.5A.5.5 0 0 0 6 4.5v11c0 .38.4.62.74.44l10-5.5Z"/>" :size="12" />
                       {{ formatDate(s.next_run_at) }}
                     </span>
                     <span v-if="s.last_run_at" class="flex items-center gap-1 shrink-0">
-                      <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+                      <FluentIcon paths="<path d="M10 2a8 8 0 1 1 0 16 8 8 0 0 1 0-16Zm0 1a7 7 0 1 0 0 14 7 7 0 0 0 0-14Zm-.5 2a.5.5 0 0 1 .5.41V10h2.5a.5.5 0 0 1 .09 1H9.5a.5.5 0 0 1-.5-.41V5.5c0-.28.22-.5.5-.5Z"/>" :size="12" />
                       {{ formatDate(s.last_run_at) }}
                     </span>
                   </div>
@@ -280,7 +270,7 @@
                     class="text-red-400/70 hover:text-red-400 disabled:opacity-50 text-xs px-2 py-1.5 rounded-lg hover:bg-red-500/10 border border-transparent hover:border-red-500/20 transition-all duration-200"
                     title="Delete"
                   >
-                    <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"/></svg>
+                    <FluentIcon paths="<path d="M8.5 4h3a1.5 1.5 0 0 0-3 0Zm-1 0a2.5 2.5 0 0 1 5 0h5a.5.5 0 0 1 0 1h-1.05l-1.2 10.34A3 3 0 0 1 12.27 18H7.73a3 3 0 0 1-2.98-2.66L3.55 5H2.5a.5.5 0 0 1 0-1h5ZM5.74 15.23A2 2 0 0 0 7.73 17h4.54a2 2 0 0 0 1.99-1.77L15.44 5H4.56l1.18 10.23ZM8.5 7.5c.28 0 .5.22.5.5v6a.5.5 0 0 1-1 0V8c0-.28.22-.5.5-.5ZM12 8a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V8Z"/>" :size="14" />
                   </button>
                 </div>
               </div>
@@ -346,6 +336,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import FluentIcon from '../components/FluentIcon.vue'
 import { apiFetch } from '../lib/api'
 
 interface IoSchedule {

--- a/web/src/views/SkillsView.vue
+++ b/web/src/views/SkillsView.vue
@@ -8,7 +8,7 @@
           @click="closeDetail"
           class="text-txt-muted hover:text-accent transition-colors flex items-center gap-1.5 text-sm group"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 transition-transform group-hover:-translate-x-0.5" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M10 3L5 8l5 5"/></svg>
+          <FluentIcon paths="<path d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"/>" :size="14" class="transition-transform group-hover:-translate-x-0.5" />
           Back
         </button>
         <div class="w-px h-5 bg-edge"></div>
@@ -241,7 +241,7 @@
                        hover:!text-red-400 hover:bg-red-500/10 transition-all duration-150"
                 title="Delete skill"
               >
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M2 4h12M5.333 4V2.667a1.333 1.333 0 011.334-1.334h2.666a1.333 1.333 0 011.334 1.334V4m2 0v9.333a1.333 1.333 0 01-1.334 1.334H4.667a1.333 1.333 0 01-1.334-1.334V4h9.334z"/></svg>
+                <FluentIcon paths="<path d="M8.5 4h3a1.5 1.5 0 0 0-3 0Zm-1 0a2.5 2.5 0 0 1 5 0h5a.5.5 0 0 1 0 1h-1.05l-1.2 10.34A3 3 0 0 1 12.27 18H7.73a3 3 0 0 1-2.98-2.66L3.55 5H2.5a.5.5 0 0 1 0-1h5ZM5.74 15.23A2 2 0 0 0 7.73 17h4.54a2 2 0 0 0 1.99-1.77L15.44 5H4.56l1.18 10.23ZM8.5 7.5c.28 0 .5.22.5.5v6a.5.5 0 0 1-1 0V8c0-.28.22-.5.5-.5ZM12 8a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V8Z"/>" :size="14" />
               </button>
             </div>
             <p class="text-xs text-txt-secondary mb-2 line-clamp-2">{{ skill.description }}</p>
@@ -256,6 +256,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
+import FluentIcon from '../components/FluentIcon.vue'
 import { apiFetch } from '../lib/api'
 import { renderMarkdown, extractFrontmatter } from '../lib/markdown'
 

--- a/web/src/views/SquadsView.vue
+++ b/web/src/views/SquadsView.vue
@@ -93,11 +93,7 @@
             >
               <div class="flex justify-between items-start mb-2">
                 <div class="flex-1 flex items-center gap-2.5">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 text-txt-muted transition-transform duration-200 shrink-0"
-                    :class="isExpanded(squad.slug) ? 'rotate-90' : ''"
-                    viewBox="0 0 16 16" fill="currentColor"
-                  ><path d="M6 3l5 5-5 5z"/></svg>
+                  <FluentIcon paths="<path d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"/>" :size="14" class="text-txt-muted transition-transform duration-200 shrink-0" :class="isExpanded(squad.slug) ? 'rotate-90' : ''"/>
                   <div class="min-w-0">
                     <h3 class="font-semibold text-txt-primary text-sm">{{ squad.name }}</h3>
                     <p class="text-[11px] text-txt-muted font-mono">{{ squad.slug }}</p>
@@ -309,6 +305,7 @@
 
 <script setup lang="ts">
 import { ref, reactive, computed, nextTick, onMounted, onBeforeUnmount } from 'vue'
+import FluentIcon from '../components/FluentIcon.vue'
 import { apiFetch, authenticatedUrl } from '../lib/api'
 
 interface Squad {


### PR DESCRIPTION
Fixes #168

## Changes
- Created `FluentIcon.vue` wrapper component (SVG paths + size prop, zero runtime deps)
- Replaced all emoji/generic SVG icons across 8 Vue files with Fluent design icon SVGs
- Icons use `currentColor` to inherit Obsidian Console color tokens
- GitHub logo SVGs left untouched (not UI icons)

### Files changed:
- `web/src/components/FluentIcon.vue` (new)
- `web/src/components/AppNav.vue` — 8 nav icons + collapse/expand/sign-out
- `web/src/views/SchedulesView.vue` — refresh, expand, clock, play, delete
- `web/src/views/InboxView.vue` — empty state, delete, dismiss
- `web/src/views/NotificationsView.vue` — bell, checkmark
- `web/src/views/ChatView.vue` — scroll-down, send
- `web/src/views/SkillsView.vue` — back, delete
- `web/src/views/SquadsView.vue` — expand
- `web/src/views/LoginView.vue` — dismiss

TSC clean, 72/72 tests pass, frontend builds.