### PR TITLE
feat(web): smooth-scroll to bottom of chat (#181)

### DIFF
--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -186,21 +186,21 @@ function handleScroll() {
   isScrolledUp.value = el.scrollTop + el.clientHeight < el.scrollHeight - 100
 }
 
-function scrollToBottom() {
+function scrollToBottom(smooth = true) {
   nextTick(() => {
     if (messagesEl.value) {
-      messagesEl.value.scrollTop = messagesEl.value.scrollHeight
+      messagesEl.value.scrollTo({ top: messagesEl.value.scrollHeight, behavior: smooth ? 'smooth' : 'instant' })
     }
   })
 }
 
 onMounted(() => {
-  scrollToBottom()
+  scrollToBottom(false)
 })
 
 // Scroll to bottom when navigating back to the chat tab
 watch(() => route.name, (name) => {
-  if (name === 'chat') scrollToBottom()
+  if (name === 'chat') scrollToBottom(false)
 })
 
 watch(() => store.messages.length, () => {


### PR DESCRIPTION
Closes #181

Changes scroll-to-bottom behavior to use smooth scrolling animation. Initial load remains instant to avoid visual distraction on mount.

## Changes
- `scrollToBottom(smooth = true)` — added `smooth` parameter (default `true`)
- Uses `el.scrollTo({ top: el.scrollHeight, behavior: smooth ? "smooth" : "instant" })`
- `onMounted` and route-change calls use `scrollToBottom(false)` — instant, no animation on navigation
- Button click and new-message watcher use default `smooth = true`

## Validation
- `npx tsc --noEmit` ✅
- `vite build` ✅