### PR TITLE
fix(web): resilient token retrieval prevents sporadic auth failures (#188)

### DIFF
--- a/web/src/components/AppNav.vue
+++ b/web/src/components/AppNav.vue
@@ -252,11 +252,11 @@ onMounted(async () => {
   connectSSE()
 })
 
-function connectSSE(retries = 0) {
+async function connectSSE(retries = 0) {
   notificationSource?.close()
   notificationSource = null
 
-  const es = new EventSource(authenticatedUrl('/api/events'))
+  const es = new EventSource(await authenticatedUrl('/api/events'))
   notificationSource = es
 
   es.onmessage = (e) => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -7,7 +7,7 @@ import { getSupabase } from './supabase'
  */
 export async function apiFetch(input: string, init?: RequestInit): Promise<Response> {
   const auth = useAuthStore()
-  const token = auth.getAccessToken()
+  const token = await auth.getAccessToken()
 
   const headers = new Headers(init?.headers)
   if (token) {
@@ -23,16 +23,19 @@ export async function apiFetch(input: string, init?: RequestInit): Promise<Respo
   if (res.status === 401 && auth.authEnabled) {
     const supabase = await getSupabase()
     if (supabase) {
-      const { data } = await supabase.auth.refreshSession()
+      const { data, error } = await supabase.auth.refreshSession()
       if (data.session) {
         // Retry the original request with the fresh token
         const retryHeaders = new Headers(init?.headers)
         retryHeaders.set('Authorization', `Bearer ${data.session.access_token}`)
         return fetch(input, { ...init, headers: retryHeaders })
       }
+      // Only sign out when refresh explicitly returns no session with no error.
+      // If there was a network error, don't nuke the session — it may recover.
+      if (!error) {
+        await auth.signOut()
+      }
     }
-    // Refresh failed — session is truly gone, sign out
-    await auth.signOut()
   }
 
   return res
@@ -42,9 +45,9 @@ export async function apiFetch(input: string, init?: RequestInit): Promise<Respo
  * Build an EventSource URL with the access token as a query param.
  * The server can read `req.query.token` for SSE endpoints.
  */
-export function authenticatedUrl(path: string): string {
+export async function authenticatedUrl(path: string): Promise<string> {
   const auth = useAuthStore()
-  const token = auth.getAccessToken()
+  const token = await auth.getAccessToken()
   if (!token) return path
   const sep = path.includes('?') ? '&' : '?'
   return `${path}${sep}token=${encodeURIComponent(token)}`

--- a/web/src/stores/auth.ts
+++ b/web/src/stores/auth.ts
@@ -82,7 +82,16 @@ export const useAuthStore = defineStore('auth', () => {
     session.value = null
   }
 
-  function getAccessToken(): string | null {
+  async function getAccessToken(): Promise<string | null> {
+    if (!authEnabled.value) return null
+    const supabase = await getSupabase()
+    if (!supabase) return session.value?.access_token ?? null
+    const { data } = await supabase.auth.getSession()
+    if (data.session) {
+      session.value = data.session
+      user.value = data.session.user
+      return data.session.access_token
+    }
     return session.value?.access_token ?? null
   }
 

--- a/web/src/views/AgentActivityView.vue
+++ b/web/src/views/AgentActivityView.vue
@@ -574,11 +574,11 @@ const scheduleActivityRefresh = (taskId: string) => {
   }, 250)
 }
 
-const startActivityStream = (taskId: string) => {
+const startActivityStream = async (taskId: string) => {
   stopActivityStream()
   loadActivity(taskId, { initial: true })
   try {
-    activityEventSource = new EventSource(authenticatedUrl(`/api/tasks/${encodeURIComponent(taskId)}/events`))
+    activityEventSource = new EventSource(await authenticatedUrl(`/api/tasks/${encodeURIComponent(taskId)}/events`))
     activityEventSource.onmessage = () => {
       scheduleActivityRefresh(taskId)
     }

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -238,7 +238,7 @@ async function sendMessage() {
 
   scrollToBottom()
 
-  const evtSource = new EventSource(authenticatedUrl('/api/events'))
+  const evtSource = new EventSource(await authenticatedUrl('/api/events'))
   evtSource.onmessage = (e) => {
     try {
       const data = JSON.parse(e.data) as { type: 'delta' | 'done'; text: string }

--- a/web/src/views/SquadsView.vue
+++ b/web/src/views/SquadsView.vue
@@ -446,7 +446,7 @@ const scrollPreviewToBottom = () => {
   })
 }
 
-const openPreview = (agent: SquadAgent) => {
+const openPreview = async (agent: SquadAgent) => {
   if (!agent.currentTaskId) return
   closePreview()
   previewAgent.value = agent
@@ -455,7 +455,7 @@ const openPreview = (agent: SquadAgent) => {
   previewConnected.value = false
   previewSummaryMode.value = true
 
-  const url = authenticatedUrl(`/api/tasks/${encodeURIComponent(agent.currentTaskId)}/events`)
+  const url = await authenticatedUrl(`/api/tasks/${encodeURIComponent(agent.currentTaskId)}/events`)
   const es = new EventSource(url)
   previewSource = es
 


### PR DESCRIPTION
Closes #188

## Root Cause
getAccessToken() read from a cached Pinia ref that could hold a stale expired token if Supabase's background auto-refresh silently failed.

## Fix
- getAccessToken() now calls supabase.auth.getSession() to always fetch the latest token from Supabase's internal state, updating cached refs as a side-effect
- apiFetch retry on 401 only signs out when refresh explicitly returns no session (not on network errors)
- authenticatedUrl() is now async to support the async token fetch
- All four call sites updated to await authenticatedUrl()