### PR TITLE
fix(web): defer AppNav API calls until auth is initialized

### DIFF
--- a/web/src/components/AppNav.vue
+++ b/web/src/components/AppNav.vue
@@ -356,6 +356,14 @@ onMounted(async () => {
     if (stored !== null) collapsed.value = stored === 'true'
   } catch { /* ignore */ }
 
+  // Wait for auth to be fully initialized before making API calls.
+  // AppNav mounts before the router guard finishes auth.init(), so
+  // without this guard, requests fire with no token and get 401s.
+  await auth.init()
+
+  // Skip authenticated API calls when on the login page
+  if (auth.authEnabled && !auth.user) return
+
   try {
     const res = await apiFetch('/api/status')
     if (res.ok) {


### PR DESCRIPTION
Closes #195

## Problem
AppNav mounts before the router guard finishes `auth.init()`, so `/api/status` and `/api/feed/count` fire with no token → 401. The 401-retry in `apiFetch` then triggers a second `/feed/count` call.

## Fix
Add `await auth.init()` + user-check at the top of `onMounted`:
- Defers all API calls and SSE until auth state is settled
- Skips authenticated calls entirely on the login page (no user)
- Eliminates both the timing 401s and the duplicate `/count` call

## Changed
- `web/src/components/AppNav.vue` — +8 lines