### PR TITLE
feat: use LLM to generate real character rosters for custom universes (#216)

### DIFF
--- a/src/copilot/tools.ts
+++ b/src/copilot/tools.ts
@@ -4,7 +4,7 @@ import { execSync, execFileSync } from "child_process";
 import { readFileSync, writeFileSync, readdirSync, statSync, existsSync, mkdirSync } from "fs";
 import { join, dirname, resolve, sep } from "path";
 import { homedir } from "os";
-import { UNIVERSES, getOrCreateUniverse } from "./universes.js";
+import { UNIVERSES, getOrCreateUniverse, generateUniverseRoster } from "./universes.js";
 import { createFeedEntry } from "../store/feed.js";
 import { validateCron, nextRun } from "./cron.js";
 import {
@@ -427,6 +427,9 @@ export function createTools(deps: ToolDeps) {
     }),
     handler: async ({ slug, name, project_path, universe }) => {
       try {
+        if (universe) {
+          await generateUniverseRoster(universe);
+        }
         deps.createSquad(slug, name, project_path, universe);
         const squad = deps.getSquad(slug);
         const universeName = squad?.universe ? getOrCreateUniverse(squad.universe).name : "random";

--- a/src/copilot/universes.ts
+++ b/src/copilot/universes.ts
@@ -449,6 +449,71 @@ export function getOrCreateUniverse(input: string): Universe {
   return custom;
 }
 
+
+
+/**
+ * Generate a universe roster using the LLM for unknown universes.
+ * Falls back to archetype characters if the LLM call fails.
+ * For known/well-known universes, returns them directly without an LLM call.
+ */
+export async function generateUniverseRoster(input: string): Promise<Universe> {
+  // First try synchronous resolution
+  const existing = getOrCreateUniverse(input);
+  // If it resolved to something other than archetypes, use it
+  const isArchetype = existing.characters[0]?.name === "Commander";
+  if (!isArchetype) return existing;
+
+  // Use LLM to generate real characters for the unknown universe
+  let session: { sendAndWait: (opts: { prompt: string }, timeout: number) => Promise<{ data: { content: string } } | undefined>; destroy: () => Promise<void> } | undefined;
+  try {
+    const { getClient } = await import("./client.js");
+    const { approveAll } = await import("@github/copilot-sdk");
+    const client = await getClient();
+    session = await client.createSession({
+      systemMessage: { mode: "replace", content: "You are a pop-culture expert. Generate character rosters for fictional universes. Respond ONLY with valid JSON, no markdown fencing." },
+      onPermissionRequest: approveAll,
+    });
+
+    const prompt = `Generate a roster of 8 characters from the universe "${input}". For each character provide their canonical name and a one-sentence personality description suitable for a software engineering team role.
+
+Return ONLY a JSON object with this exact shape:
+{"name":"<Universe Display Name>","tagline":"<iconic catchphrase or tagline>","characters":[{"name":"<Character Name>","personality":"<1-sentence personality description>"}]}
+
+Use well-known, iconic characters from this universe. The personality should reflect the actual character's traits.`;
+
+    const response = await session.sendAndWait({ prompt }, 30_000);
+    const rawContent = response?.data?.content ?? "";
+    const jsonStr = rawContent.replace(/```json?\n?/g, "").replace(/```/g, "").trim();
+    const parsed = JSON.parse(jsonStr);
+
+    if (parsed?.characters?.length > 0) {
+      const slug = slugify(input);
+      const universe: Universe = {
+        id: slug,
+        name: parsed.name || input,
+        tagline: parsed.tagline || `Welcome to ${input}.`,
+        characters: parsed.characters.slice(0, 8).map((c: { name: unknown; personality: unknown }) => ({
+          name: String(c.name),
+          personality: String(c.personality),
+        })),
+      };
+
+      // Replace the archetype entry with the real one
+      const idx = UNIVERSES.findIndex((u) => u.id === slug);
+      if (idx >= 0) UNIVERSES.splice(idx, 1);
+      UNIVERSES.push(universe);
+      return universe;
+    }
+  } catch (err) {
+    console.error(`[io] Failed to generate universe roster for "${input}":`, err);
+  } finally {
+    try { await session?.destroy(); } catch { /* best-effort cleanup */ }
+  }
+
+  // LLM failed — return the archetype fallback (already registered)
+  return existing;
+}
+
 /**
  * Get a universe by ID.
  */


### PR DESCRIPTION
## Summary

When `squad_create` receives an unknown universe name (not in built-in or well-known lists), the system now uses the Copilot SDK to ask the LLM for 8 real canonical characters with accurate personalities, rather than falling back to generic archetypes.

### How it works

1. `generateUniverseRoster(input)` is called in the `squad_create` handler before `createSquad()`
2. If the universe resolves to a known roster → returns immediately (no LLM call)
3. If it resolved to archetypes → fires a one-shot LLM prompt asking for 8 real characters
4. Parses the JSON response, validates it, and registers it in the UNIVERSES array
5. If the LLM fails (timeout, parse error, network) → gracefully degrades to archetype fallback

### Examples

- `universe: "he-man"` → He-Man, Teela, Man-At-Arms, Orko, Skeletor, She-Ra, Battle Cat, Sorceress
- `universe: "futurama"` → Fry, Leela, Bender, Professor Farnsworth, Amy, Zoidberg, Hermes, Nibbler

### Technical details

- Dynamic `import("./client.js")` avoids circular deps (universes.ts doesn't statically import client)
- Session destroyed in `finally` block to prevent leaks
- LLM timeout: 30s (generous for a simple JSON generation task)
- All 131 tests pass, tsc clean

Closes #216