### PR TITLE
fix: re-register custom universe on addSquadAgent after daemon restart (#215)

### DIFF
--- a/src/store/squads.ts
+++ b/src/store/squads.ts
@@ -121,6 +121,9 @@ export function addSquadAgent(
       .run(universeId, squadSlug);
   }
 
+  // Ensure universe is registered in runtime array (handles restart for custom universes)
+  getOrCreateUniverse(universeId);
+
   const existingAgents = listSquadAgents(squadSlug);
   const usedNames = existingAgents.map((a) => a.character_name);
   const character = nextCharacter(universeId, usedNames);


### PR DESCRIPTION
## Summary

One-line fix: calls `getOrCreateUniverse(universeId)` before `nextCharacter()` in `addSquadAgent` to ensure custom/well-known universes are re-registered in the runtime UNIVERSES array after a daemon restart.

**Root cause:** Custom universe rosters are stored in a runtime array that's lost on restart. The universe ID is persisted in SQLite, but `nextCharacter()` → `getUniverse()` couldn't find it in the empty runtime array.

**Fix:** `getOrCreateUniverse()` handles the re-registration (well-known lookup or archetype generation), making the universe available for `nextCharacter()`.

131/131 tests pass.

Closes #215