### PR TITLE
fix: render multi-turn TUI responses as separate message bubbles (#219)

### DIFF
--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -279,15 +279,24 @@ export async function startTui(): Promise<void> {
         }
 
         if (done) {
+          // Finalize the current message as its own line, then reset state
+          // so the next message in a multi-turn response starts a fresh bubble.
           clearLine();
-          process.stdout.write(accumulated + "\n");
-          rl.prompt();
+          if (accumulated) {
+            process.stdout.write(accumulated + "\n");
+          }
+          accumulated = "";
+          firstChunk = true;
         } else {
           accumulated += text;
           clearLine();
           process.stdout.write(accumulated);
         }
       });
+      // Restore the prompt once the handler promise fully resolves (i.e. after
+      // all turns are done), rather than inside the done callback so that
+      // multi-turn responses don't render a premature prompt between messages.
+      rl.prompt();
     } catch (err) {
       clearLine();
       console.error(


### PR DESCRIPTION
Fixes #219

Each message segment in a multi-turn response now renders as its own entry in the TUI rather than appending to a single growing bubble.

## What changed

In `src/tui/index.ts`, the `done=true` callback path previously called `rl.prompt()` inline, which meant:
- The prompt fired prematurely between messages
- `accumulated` was never reset, so subsequent messages appended to the previous content

**Fix:**
- When `done=true` fires, finalize and print the current bubble, then reset `accumulated` and `firstChunk` for the next message
- Move `rl.prompt()` to after `await messageHandler()` resolves — runs once, after all turns are complete

Single-message responses are unaffected: one `done=true` call prints the bubble, promise resolves, prompt fires. Multi-turn responses now print each message as its own line.