### PR TITLE
feat: dedicated Inbox view in the IO UI (#228)

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -15,6 +15,7 @@ import { listSchedules, getSchedule, deleteSchedule, setScheduleEnabled } from "
 import { listIoSchedules, getIoSchedule, deleteIoSchedule, setIoScheduleEnabled } from "../store/io-schedules.js";
 import { getScheduleRuns } from "../store/schedule-runs.js";
 import { createFeedEntry, listFeedEntries, countUnreadFeedEntries, markFeedEntryRead, markAllFeedEntriesRead, deleteFeedEntry, markFeedEntriesRead, deleteFeedEntries, type FeedEntryType } from "../store/feed.js";
+import { listInboxEntries, countInboxEntries, deleteInboxEntry } from "../store/inbox.js";
 import { listPages, readPage } from "../wiki/fs.js";
 import { runScheduleNow } from "../copilot/scheduler.js";
 import { runIoScheduleNow } from "../copilot/io-scheduler.js";
@@ -387,6 +388,48 @@ export async function startApiServer(): Promise<void> {
       res.json({ deleted: true });
     } catch (e) {
       console.error("Error deleting feed entry:", e);
+      res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
+    }
+  });
+
+
+  // Inbox endpoints
+  api.get("/inbox/count", (_req: Request, res: Response) => {
+    try {
+      const count = countInboxEntries();
+      res.json({ count });
+    } catch (e) {
+      console.error("Error counting inbox entries:", e);
+      res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
+    }
+  });
+
+  api.get("/inbox", (_req: Request, res: Response) => {
+    try {
+      const entries = listInboxEntries();
+      res.json({ entries });
+    } catch (e) {
+      console.error("Error listing inbox entries:", e);
+      res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
+    }
+  });
+
+  api.delete("/inbox/:id", (req: Request, res: Response) => {
+    const raw = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+    const id = Number.parseInt(raw, 10);
+    if (Number.isNaN(id)) {
+      res.status(400).json({ error: "Invalid id" });
+      return;
+    }
+    try {
+      const deleted = deleteInboxEntry(id);
+      if (!deleted) {
+        res.status(404).json({ error: "Inbox entry not found" });
+        return;
+      }
+      res.status(204).send();
+    } catch (e) {
+      console.error("Error deleting inbox entry:", e);
       res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
     }
   });

--- a/web/src/components/AppNav.vue
+++ b/web/src/components/AppNav.vue
@@ -53,7 +53,7 @@
                 : 'text-txt-secondary hover:text-txt-primary hover:bg-surface-3/40'
             ]"
             :title="collapsed ? item.label : undefined"
-            @click="item.name === 'feed' ? onFeedClick() : undefined"
+            @click="item.name === 'feed' ? onFeedClick() : item.name === 'inbox' ? onInboxClick() : undefined"
           >
             <!-- Active indicator bar -->
             <span
@@ -72,6 +72,14 @@
               :class="collapsed ? 'top-0 right-0' : 'top-0.5 right-1'"
             >
               {{ unreadCount > 99 ? '99+' : unreadCount }}
+            </span>
+            <!-- Inbox unread badge -->
+            <span
+              v-if="item.name === 'inbox' && inboxCount > 0"
+              class="absolute flex items-center justify-center bg-accent text-surface-1 text-[9px] font-bold rounded-full min-w-[16px] h-[16px] px-0.5 ring-2 ring-surface-1"
+              :class="collapsed ? 'top-0 right-0' : 'top-0.5 right-1'"
+            >
+              {{ inboxCount > 99 ? '99+' : inboxCount }}
             </span>
           </RouterLink>
         </li>
@@ -178,7 +186,7 @@
     :to="item.to"
     class="relative flex-1 flex flex-col items-center justify-center gap-0.5 py-2 px-1 min-w-0 transition-colors duration-150 touch-manipulation select-none"
     :class="isActive(item.name) ? 'text-accent' : 'text-txt-muted'"
-    @click="item.name === 'feed' ? onFeedClick() : undefined"
+    @click="item.name === 'feed' ? onFeedClick() : item.name === 'inbox' ? onInboxClick() : undefined"
     :aria-label="item.label"
   >
     <!-- Active top accent line -->
@@ -190,6 +198,10 @@
         v-if="item.name === 'feed' && unreadCount > 0"
         class="absolute -top-1 -right-1.5 min-w-[14px] h-[14px] flex items-center justify-center bg-red-500 text-white text-[7px] font-bold rounded-full px-0.5 ring-1 ring-surface-0"
       >{{ unreadCount > 9 ? '9+' : unreadCount }}</span>
+      <span
+        v-if="item.name === 'inbox' && inboxCount > 0"
+        class="absolute -top-1 -right-1.5 min-w-[14px] h-[14px] flex items-center justify-center bg-accent text-surface-1 text-[7px] font-bold rounded-full px-0.5 ring-1 ring-surface-0"
+      >{{ inboxCount > 9 ? '9+' : inboxCount }}</span>
     </span>
     <span class="text-[9px] leading-tight font-medium truncate max-w-full px-0.5">{{ item.label }}</span>
   </RouterLink>
@@ -210,6 +222,7 @@ const auth = useAuthStore()
 
 const version = ref('')
 const unreadCount = ref(0)
+const inboxCount = ref(0)
 const collapsed = ref(false)
 let notificationSource: EventSource | null = null
 
@@ -230,6 +243,7 @@ const navItems = [
   { to: '/wiki',          name: 'wiki',          icon: '<path d="M10 16c-.46.6-1.18 1-2 1H3.5A1.5 1.5 0 0 1 2 15.5v-11C2 3.67 2.67 3 3.5 3H8c.82 0 1.54.4 2 1 .46-.6 1.18-1 2-1h4.5c.83 0 1.5.67 1.5 1.5v11c0 .83-.67 1.5-1.5 1.5H12a2.5 2.5 0 0 1-2-1ZM3 4.5v11c0 .28.22.5.5.5H8c.83 0 1.5-.67 1.5-1.5v-9C9.5 4.67 8.83 4 8 4H3.5a.5.5 0 0 0-.5.5Zm7.5 10c0 .83.67 1.5 1.5 1.5h4.5a.5.5 0 0 0 .5-.5v-11a.5.5 0 0 0-.5-.5H12c-.83 0-1.5.67-1.5 1.5v9Z"/>', label: 'Wiki' },
   { to: '/schedules',     name: 'schedules',     icon: '<path d="M7 11a1 1 0 1 0 0-2 1 1 0 0 0 0 2Zm1 2a1 1 0 1 1-2 0 1 1 0 0 1 2 0Zm2-2a1 1 0 1 0 0-2 1 1 0 0 0 0 2Zm1 2a1 1 0 1 1-2 0 1 1 0 0 1 2 0Zm2-2a1 1 0 1 0 0-2 1 1 0 0 0 0 2Zm4-5.5A2.5 2.5 0 0 0 14.5 3h-9A2.5 2.5 0 0 0 3 5.5v9A2.5 2.5 0 0 0 5.5 17h9a2.5 2.5 0 0 0 2.5-2.5v-9ZM4 7h12v7.5c0 .83-.67 1.5-1.5 1.5h-9A1.5 1.5 0 0 1 4 14.5V7Zm1.5-3h9c.83 0 1.5.67 1.5 1.5V6H4v-.5C4 4.67 4.67 4 5.5 4Z"/>', label: 'Schedules' },
   { to: '/activity',      name: 'activity',      icon: '<path d="M16.52 9c.26 0 .48-.2.48-.46V8.5A6.5 6.5 0 0 0 10.5 2h-.04a.47.47 0 0 0-.46.48V8.5c0 .28.22.5.5.5h6.02ZM11 3.02A5.5 5.5 0 0 1 15.98 8H11V3.02ZM8 9V5.1A5 5 0 0 0 9 15v1a6 6 0 0 1-.5-11.98c.28-.02.5.2.5.48V9a1 1 0 0 0 1 1h4.5c.28 0 .5.22.48.5a6 6 0 0 1-.06.5H10a2 2 0 0 1-2-2Zm9 1a1 1 0 0 0-1 1v7a1 1 0 1 0 2 0v-7a1 1 0 0 0-1-1Zm-3 2a1 1 0 0 0-1 1v5a1 1 0 1 0 2 0v-5a1 1 0 0 0-1-1Zm-4 3a1 1 0 1 1 2 0v3a1 1 0 1 1-2 0v-3Z"/>', label: 'Activity' },
+  { to: '/inbox',        name: 'inbox',         icon: '<path d="M2 6.25A2.25 2.25 0 0 1 4.25 4h11.5A2.25 2.25 0 0 1 18 6.25v7.5A2.25 2.25 0 0 1 15.75 16H4.25A2.25 2.25 0 0 1 2 13.75v-7.5Zm2.25-1a1 1 0 0 0-1 1v.388l6.75 4.5 6.75-4.5V6.25a1 1 0 0 0-1-1H4.25Zm12.5 2.834-6.294 4.196a.75.75 0 0 1-.812 0L3.25 8.084v5.666a1 1 0 0 0 1 1h11.5a1 1 0 0 0 1-1V8.084Z"/>', label: 'Inbox' },
 ]
 
 const userInitial = computed(() => {
@@ -258,6 +272,10 @@ async function handleSignOut() {
 
 function onFeedClick() {
   unreadCount.value = 0
+}
+
+function onInboxClick() {
+  inboxCount.value = 0
 }
 
 onMounted(async () => {
@@ -291,6 +309,14 @@ onMounted(async () => {
     if (res.ok) {
       const data = (await res.json()) as { count?: number }
       unreadCount.value = data.count ?? 0
+    }
+  } catch { /* best effort */ }
+
+  try {
+    const res = await apiFetch('/api/inbox/count')
+    if (res.ok) {
+      const data = (await res.json()) as { count?: number }
+      inboxCount.value = data.count ?? 0
     }
   } catch { /* best effort */ }
 

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -5,6 +5,7 @@ import SquadsView from '../views/SquadsView.vue'
 import AgentActivityView from '../views/AgentActivityView.vue'
 import SchedulesView from '../views/SchedulesView.vue'
 import FeedView from '../views/FeedView.vue'
+import InboxView from '../views/InboxView.vue'
 import WikiView from '../views/WikiView.vue'
 import LoginView from '../views/LoginView.vue'
 import { useAuthStore } from '../stores/auth'
@@ -58,11 +59,12 @@ const router = createRouter({
       component: FeedView,
     },
     {
-      path: '/notifications',
-      redirect: '/feed',
+      path: '/inbox',
+      name: 'inbox',
+      component: InboxView,
     },
     {
-      path: '/inbox',
+      path: '/notifications',
       redirect: '/feed',
     },
   ],

--- a/web/src/views/InboxView.vue
+++ b/web/src/views/InboxView.vue
@@ -1,0 +1,142 @@
+<template>
+  <div class="flex flex-col h-full p-3 sm:p-6">
+    <!-- Header -->
+    <div class="flex justify-between items-center mb-6">
+      <div>
+        <h2 class="text-xl font-bold text-txt-primary tracking-tight">Inbox</h2>
+        <p class="text-xs text-txt-muted mt-0.5">Messages delivered to you</p>
+      </div>
+    </div>
+
+    <!-- Error -->
+    <div v-if="error" class="flex items-center gap-2 bg-red-500/10 text-red-400 border border-red-500/20 p-3 rounded-lg mb-4 text-sm">
+      <span>⚠</span> {{ error }}
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading && entries.length === 0" class="flex-1 flex items-center justify-center">
+      <div class="flex items-center gap-3 text-txt-muted text-sm">
+        <div class="w-1.5 h-1.5 rounded-full bg-accent animate-pulse"></div>
+        Loading…
+      </div>
+    </div>
+
+    <!-- Empty state -->
+    <div v-else-if="!loading && entries.length === 0" class="flex-1 flex flex-col items-center justify-center">
+      <div class="w-14 h-14 rounded-xl bg-surface-2 border border-edge flex items-center justify-center mb-4">
+        <svg viewBox="0 0 20 20" fill="currentColor" class="w-7 h-7 text-txt-muted" aria-hidden="true">
+          <path d="M2 6.25A2.25 2.25 0 0 1 4.25 4h11.5A2.25 2.25 0 0 1 18 6.25v7.5A2.25 2.25 0 0 1 15.75 16H4.25A2.25 2.25 0 0 1 2 13.75v-7.5Zm2.25-1a1 1 0 0 0-1 1v.388l6.75 4.5 6.75-4.5V6.25a1 1 0 0 0-1-1H4.25Zm12.5 2.834-6.294 4.196a.75.75 0 0 1-.812 0L3.25 8.084v5.666a1 1 0 0 0 1 1h11.5a1 1 0 0 0 1-1V8.084Z"/>
+        </svg>
+      </div>
+      <p class="text-txt-muted text-sm font-medium">Inbox is empty</p>
+      <p class="text-txt-muted/60 text-xs mt-1">New messages will appear here</p>
+    </div>
+
+    <!-- Entry list -->
+    <ul v-else class="space-y-3 overflow-y-auto flex-1">
+      <li
+        v-for="entry in entries"
+        :key="entry.id"
+        class="bg-surface-2/40 border border-edge rounded-xl p-4 hover:border-edge-bright transition-all duration-150 group"
+      >
+        <div class="flex justify-between items-start gap-3">
+          <h3 class="text-sm font-semibold text-txt-primary leading-snug">{{ entry.title }}</h3>
+          <div class="flex items-center gap-2 shrink-0">
+            <span class="text-[10px] text-txt-muted font-mono">{{ formatDate(entry.created_at) }}</span>
+            <button
+              @click="deleteEntry(entry.id)"
+              :disabled="deletingIds.has(entry.id)"
+              class="opacity-0 group-hover:opacity-100 transition-opacity text-txt-muted hover:text-red-400 disabled:opacity-30"
+              title="Delete"
+              aria-label="Delete entry"
+            >
+              <svg viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4" aria-hidden="true">
+                <path fill-rule="evenodd" d="M8.75 1A2.75 2.75 0 0 0 6 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 1 0 .23 1.482l.149-.022.841 10.518A2.75 2.75 0 0 0 7.596 19h4.807a2.75 2.75 0 0 0 2.742-2.53l.841-10.52.149.023a.75.75 0 0 0 .23-1.482A41.03 41.03 0 0 0 14 4.193V3.75A2.75 2.75 0 0 0 11.25 1h-2.5ZM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4ZM8.58 7.72a.75.75 0 0 0-1.5.06l.3 7.5a.75.75 0 1 0 1.5-.06l-.3-7.5Zm4.34.06a.75.75 0 1 0-1.5-.06l-.3 7.5a.75.75 0 1 0 1.5.06l.3-7.5Z" clip-rule="evenodd"/>
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="mt-2 text-sm text-txt-secondary wiki-content prose-sm"
+          v-html="renderMarkdown(entry.body)"
+        ></div>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+import { apiFetch } from '../lib/api'
+import { renderMarkdown } from '../lib/markdown'
+
+const INBOX_LAST_SEEN_KEY = 'inbox-last-seen-id'
+
+interface InboxEntry {
+  id: number
+  title: string
+  body: string
+  created_at: string
+}
+
+const entries = ref<InboxEntry[]>([])
+const loading = ref(false)
+const error = ref<string | null>(null)
+const deletingIds = ref<Set<number>>(new Set())
+let pollTimer: ReturnType<typeof setInterval> | null = null
+
+const formatDate = (value: string) => {
+  if (!value) return ''
+  const iso = value.includes('T') ? value : value.replace(' ', 'T') + 'Z'
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return value
+  return d.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false })
+}
+
+const markSeen = (list: InboxEntry[]) => {
+  if (list.length === 0) return
+  const maxId = Math.max(...list.map(e => e.id))
+  try { localStorage.setItem(INBOX_LAST_SEEN_KEY, String(maxId)) } catch { /* ignore */ }
+}
+
+const fetchEntries = async (initial = false) => {
+  if (initial) loading.value = true
+  error.value = null
+  try {
+    const res = await apiFetch('/api/inbox')
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const data = (await res.json()) as { entries: InboxEntry[] }
+    entries.value = data.entries ?? []
+    markSeen(entries.value)
+  } catch (e) {
+    if (initial) error.value = e instanceof Error ? e.message : 'Failed to load inbox'
+  } finally {
+    if (initial) loading.value = false
+  }
+}
+
+const deleteEntry = async (id: number) => {
+  if (deletingIds.value.has(id)) return
+  deletingIds.value = new Set(deletingIds.value).add(id)
+  try {
+    const res = await apiFetch(`/api/inbox/${encodeURIComponent(id)}`, { method: 'DELETE' })
+    if (!res.ok && res.status !== 204) throw new Error(`HTTP ${res.status}`)
+    entries.value = entries.value.filter(e => e.id !== id)
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to delete entry'
+  } finally {
+    const next = new Set(deletingIds.value)
+    next.delete(id)
+    deletingIds.value = next
+  }
+}
+
+onMounted(() => {
+  fetchEntries(true)
+  pollTimer = setInterval(() => fetchEntries(), 10_000)
+})
+
+onUnmounted(() => {
+  if (pollTimer) clearInterval(pollTimer)
+})
+</script>


### PR DESCRIPTION
Fixes #228

Adds a dedicated Inbox tab to the IO web UI:
- Full markdown rendering of inbox entries (using existing renderMarkdown)
- Newest-first ordering with live polling (10s interval)
- Unread badge on nav tab (localStorage-based last-seen tracking, key: `inbox-last-seen-id`)
- Delete individual entries (hover to reveal trash icon)
- Date formatting consistent with other views

API endpoints used: `GET /api/inbox`, `GET /api/inbox/count`, `DELETE /api/inbox/:id`

No schema changes — uses existing inbox_entries table.