### PR TITLE
feat: Squad Instances / Parallel Execution (Phase 1)

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -532,14 +532,21 @@ export async function startApiServer(): Promise<void> {
       const contextSnapshot = buildContextSnapshot(slug);
       const worktreePath = createWorktree(squad.project_path, instanceId, branchName, base_branch ?? "main");
 
-      const instance = createInstance({
-        id: instanceId,
-        masterSquadSlug: slug,
-        issueRef: issue_ref,
-        worktreePath,
-        branchName,
-        contextSnapshot,
-      });
+      let instance;
+      try {
+        instance = createInstance({
+          id: instanceId,
+          masterSquadSlug: slug,
+          issueRef: issue_ref,
+          worktreePath,
+          branchName,
+          contextSnapshot,
+        });
+      } catch (createErr) {
+        // Roll back the worktree if DB insert fails (e.g. max instances exceeded)
+        removeWorktree(squad.project_path, worktreePath);
+        throw createErr;
+      }
 
       updateInstanceStatus(instanceId, "active");
       res.status(201).json({ instance: { ...instance, status: "active" } });

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -4,7 +4,9 @@ import { existsSync, readFileSync } from "node:fs";
 import express, { type Request, type Response } from "express";
 import { config } from "../config.js";
 import { listSkills, installSkill, installSkillFromContent, removeSkill } from "../copilot/skills.js";
-import { listSquads, createSquad, listSquadAgents } from "../store/squads.js";
+import { listSquads, createSquad, listSquadAgents, getSquad } from "../store/squads.js";
+import { createInstance, getInstance, listInstances, updateInstanceStatus, getInstanceDecisions, mergeInstanceDecisions, buildContextSnapshot } from "../store/instances.js";
+import { createWorktree, removeWorktree } from "../store/worktrees.js";
 import { getAgentInfo, cancelAgentTask, getTaskEvents, subscribeToTaskEvents } from "../copilot/agents.js";
 import { summarize, summarizeEvent } from "../copilot/event-summary.js";
 import { abortOrchestrator } from "../copilot/orchestrator.js";
@@ -500,6 +502,114 @@ export async function startApiServer(): Promise<void> {
     } catch (e) {
       console.error("Error listing squad agents:", e);
       res.status(500).json({ error: "Failed to list squad agents" });
+    }
+  });
+
+  // Squad Instances
+  api.get("/squads/:slug/instances", (req: Request, res: Response) => {
+    try {
+      const slug = Array.isArray(req.params.slug) ? req.params.slug[0] : req.params.slug;
+      const includeCompleted = req.query.include_completed === "true";
+      const instances = listInstances(slug, { includeCompleted });
+      res.json({ instances });
+    } catch (e) {
+      console.error("Error listing instances:", e);
+      res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
+    }
+  });
+
+  api.post("/squads/:slug/instances", (req: Request, res: Response) => {
+    try {
+      const slug = Array.isArray(req.params.slug) ? req.params.slug[0] : req.params.slug;
+      const { issue_ref, base_branch } = req.body as { issue_ref?: string; base_branch?: string };
+      const squad = getSquad(slug);
+      if (!squad) { res.status(404).json({ error: "Squad not found" }); return; }
+
+      const sanitizedRef = (issue_ref ?? "task").replace(/[^a-zA-Z0-9_-]/g, "-").toLowerCase();
+      const instanceId = `${slug}--${sanitizedRef}`;
+      const branchName = `${slug}/instance/${sanitizedRef}`;
+
+      const contextSnapshot = buildContextSnapshot(slug);
+      const worktreePath = createWorktree(squad.project_path, instanceId, branchName, base_branch ?? "main");
+
+      const instance = createInstance({
+        id: instanceId,
+        masterSquadSlug: slug,
+        issueRef: issue_ref,
+        worktreePath,
+        branchName,
+        contextSnapshot,
+      });
+
+      updateInstanceStatus(instanceId, "active");
+      res.status(201).json({ instance: { ...instance, status: "active" } });
+    } catch (e) {
+      console.error("Error creating instance:", e);
+      res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
+    }
+  });
+
+  api.get("/squads/:slug/instances/:id", (req: Request, res: Response) => {
+    try {
+      const slug = Array.isArray(req.params.slug) ? req.params.slug[0] : req.params.slug;
+      const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+      const instance = getInstance(id);
+      if (!instance || instance.master_squad_slug !== slug) {
+        res.status(404).json({ error: "Instance not found" }); return;
+      }
+      const decisions = getInstanceDecisions(id);
+      res.json({ instance, decisions });
+    } catch (e) {
+      console.error("Error getting instance:", e);
+      res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
+    }
+  });
+
+  api.post("/squads/:slug/instances/:id/complete", (req: Request, res: Response) => {
+    try {
+      const slug = Array.isArray(req.params.slug) ? req.params.slug[0] : req.params.slug;
+      const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+      const instance = getInstance(id);
+      if (!instance || instance.master_squad_slug !== slug) {
+        res.status(404).json({ error: "Instance not found" }); return;
+      }
+      if (instance.status === "done") {
+        res.json({ message: "Already completed", merged: 0 }); return;
+      }
+
+      updateInstanceStatus(id, "merging");
+      const merged = mergeInstanceDecisions(id, instance.master_squad_slug);
+
+      const squad = getSquad(instance.master_squad_slug);
+      if (squad) {
+        removeWorktree(squad.project_path, instance.worktree_path);
+      }
+
+      updateInstanceStatus(id, "done");
+      res.json({ message: "Instance completed", merged });
+    } catch (e) {
+      console.error("Error completing instance:", e);
+      res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
+    }
+  });
+
+  api.post("/squads/:slug/instances/:id/abort", (req: Request, res: Response) => {
+    try {
+      const slug = Array.isArray(req.params.slug) ? req.params.slug[0] : req.params.slug;
+      const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+      const instance = getInstance(id);
+      if (!instance || instance.master_squad_slug !== slug) {
+        res.status(404).json({ error: "Instance not found" }); return;
+      }
+      if (instance.status === "done" || instance.status === "failed") {
+        res.json({ message: `Already in terminal state: ${instance.status}` }); return;
+      }
+
+      updateInstanceStatus(id, "failed");
+      res.json({ message: "Instance aborted", worktree_path: instance.worktree_path });
+    } catch (e) {
+      console.error("Error aborting instance:", e);
+      res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
     }
   });
 

--- a/src/copilot/orchestrator.ts
+++ b/src/copilot/orchestrator.ts
@@ -37,6 +37,20 @@ import { resetClient } from "./client.js";
 import { delegateToAgent, getActiveAgentTasks, clearAgentInMemorySession } from "./agents.js";
 import { saveConfig } from "../config.js";
 import { checkForUpdate } from "../update.js";
+import {
+  createInstance,
+  getInstance,
+  listInstances,
+  updateInstanceStatus,
+  logInstanceDecision,
+  getInstanceDecisions,
+  mergeInstanceDecisions,
+  deleteInstance,
+  buildContextSnapshot,
+  reconcileInstances,
+  ensureInstanceTables,
+} from "../store/instances.js";
+import { createWorktree, removeWorktree } from "../store/worktrees.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -182,6 +196,19 @@ function getToolDeps() {
     searchSkillsRegistry,
     saveConfig,
     checkForUpdate,
+    // Squad instance deps
+    createInstance,
+    getInstance,
+    listInstances,
+    updateInstanceStatus,
+    logInstanceDecision,
+    getInstanceDecisions,
+    mergeInstanceDecisions,
+    deleteInstance,
+    buildContextSnapshot,
+    reconcileInstances,
+    createWorktree,
+    removeWorktree,
   };
 }
 
@@ -494,6 +521,7 @@ async function processQueue(): Promise<void> {
 export async function initOrchestrator(copilotClient: CopilotClient): Promise<void> {
   client = copilotClient;
 
+  ensureInstanceTables();
   clearStaleTasks();
 
   // Validate the configured model and resolve model tiers

--- a/src/copilot/orchestrator.ts
+++ b/src/copilot/orchestrator.ts
@@ -522,6 +522,10 @@ export async function initOrchestrator(copilotClient: CopilotClient): Promise<vo
   client = copilotClient;
 
   ensureInstanceTables();
+  const reconciledInstances = reconcileInstances();
+  if (reconciledInstances > 0) {
+    console.error(`[orchestrator] Reconciled ${reconciledInstances} stale instance(s) on startup`);
+  }
   clearStaleTasks();
 
   // Validate the configured model and resolve model tiers

--- a/src/copilot/tools.ts
+++ b/src/copilot/tools.ts
@@ -1877,6 +1877,8 @@ export function createTools(deps: ToolDeps) {
       const squad = deps.getSquad(squad_slug);
       if (!squad) return `Squad not found: ${squad_slug}`;
 
+      // Deterministic ID: allows idempotent re-creation if an instance for
+      // the same issue_ref previously completed or failed.
       const sanitizedRef = issue_ref.replace(/[^a-zA-Z0-9_-]/g, "-").toLowerCase();
       const instanceId = `${squad_slug}--${sanitizedRef}`;
       const branchName = `${squad_slug}/instance/${sanitizedRef}`;
@@ -1968,10 +1970,10 @@ export function createTools(deps: ToolDeps) {
 
         const merged = deps.mergeInstanceDecisions(instance_id, instance.master_squad_slug);
 
+        // Clean up worktree — use squad's project_path if available, fall back to stored path
         const squad = deps.getSquad(instance.master_squad_slug);
-        if (squad) {
-          deps.removeWorktree(squad.projectPath, instance.worktree_path);
-        }
+        const projectPath = squad?.projectPath ?? instance.worktree_path.replace(/\/\.io-worktrees\/.*$/, "");
+        deps.removeWorktree(projectPath, instance.worktree_path);
 
         deps.updateInstanceStatus(instance_id, "done");
 

--- a/src/copilot/tools.ts
+++ b/src/copilot/tools.ts
@@ -351,6 +351,19 @@ export interface ToolDeps {
   searchSkillsRegistry: (query: string) => Promise<Array<{ name: string; description: string; repoUrl: string }>>;
   saveConfig: (updates: Record<string, unknown>) => void;
   checkForUpdate: () => Promise<{ updateAvailable: boolean; current: string; latest: string }>;
+  // Squad instance deps
+  createInstance: (input: { id: string; masterSquadSlug: string; issueRef?: string; worktreePath: string; branchName: string; contextSnapshot?: string }) => { id: string; master_squad_slug: string; status: string; worktree_path: string; branch_name: string };
+  getInstance: (id: string) => { id: string; master_squad_slug: string; issue_ref: string | null; worktree_path: string; branch_name: string; status: string; context_snapshot: string | null; created_at: string; completed_at: string | null } | undefined;
+  listInstances: (masterSquadSlug: string, opts?: { includeCompleted?: boolean }) => Array<{ id: string; issue_ref: string | null; status: string; branch_name: string; created_at: string; completed_at: string | null }>;
+  updateInstanceStatus: (id: string, status: string) => void;
+  logInstanceDecision: (instanceId: string, decision: string, context?: string) => void;
+  getInstanceDecisions: (instanceId: string) => Array<{ decision: string; context: string | null; created_at: string; merged_to_master: number }>;
+  mergeInstanceDecisions: (instanceId: string, masterSquadSlug: string) => number;
+  deleteInstance: (id: string) => void;
+  buildContextSnapshot: (masterSquadSlug: string, limit?: number) => string;
+  reconcileInstances: () => number;
+  createWorktree: (projectPath: string, instanceId: string, branchName: string, baseBranch?: string) => string;
+  removeWorktree: (projectPath: string, worktreePath: string) => void;
 }
 
 
@@ -1847,7 +1860,169 @@ export function createTools(deps: ToolDeps) {
     },
   });
 
-  return [wikiRead, wikiWrite, wikiSearch, wikiDelete, wikiList, squadCreate, squadRecall, squadStatus, squadLogDecision, squadDelegate, squadTaskStatus, squadDelete, squadAnalyze, squadAddAgent, squadAgents, squadRemoveAgent, squadResetAgent, squadSetLead, squadSetQA, squadTaskReviews, squadScheduleCreate, squadScheduleList, squadScheduleDelete, squadSchedulePause, squadScheduleResume, squadScheduleRunNow, scheduleCreate, scheduleList, scheduleDelete, schedulePause, scheduleResume, scheduleRunNow, skillList, skillInstall, skillRemove, skillSearch, configUpdate, checkUpdate, shell, fileOps, bash, readFile, viewTool, grepTool, strReplaceEditor, github];
+
+  // ---------------------------------------------------------------------------
+  // Squad Instance tools (#231)
+  // ---------------------------------------------------------------------------
+
+  const squadInstanceCreate = defineTool("squad_instance_create", {
+    description: "Spawn a parallel instance of a squad to work on a separate issue. Creates a git worktree for file isolation and snapshots the squad's current decisions as context.",
+    skipPermission: true,
+    parameters: z.object({
+      squad_slug: z.string().describe("The squad to create an instance of"),
+      issue_ref: z.string().describe("Issue reference or label (e.g. '#231', 'refactor-auth')"),
+      base_branch: z.string().optional().describe("Branch to base the worktree on (default: 'main')"),
+    }),
+    handler: async ({ squad_slug, issue_ref, base_branch }) => {
+      const squad = deps.getSquad(squad_slug);
+      if (!squad) return `Squad not found: ${squad_slug}`;
+
+      const sanitizedRef = issue_ref.replace(/[^a-zA-Z0-9_-]/g, "-").toLowerCase();
+      const instanceId = `${squad_slug}--${sanitizedRef}`;
+      const branchName = `${squad_slug}/instance/${sanitizedRef}`;
+
+      const existing = deps.getInstance(instanceId);
+      if (existing && existing.status !== "done" && existing.status !== "failed") {
+        return `Instance "${instanceId}" already exists (status: ${existing.status})`;
+      }
+
+      try {
+        const contextSnapshot = deps.buildContextSnapshot(squad_slug);
+        const worktreePath = deps.createWorktree(squad.projectPath, instanceId, branchName, base_branch ?? "main");
+
+        deps.createInstance({
+          id: instanceId,
+          masterSquadSlug: squad_slug,
+          issueRef: issue_ref,
+          worktreePath,
+          branchName,
+          contextSnapshot,
+        });
+
+        deps.updateInstanceStatus(instanceId, "active");
+
+        const inherited = JSON.parse(contextSnapshot) as unknown[];
+        return `Instance "${instanceId}" created.\nWorktree: ${worktreePath}\nBranch: ${branchName}\nStatus: active\nContext: ${inherited.length} decisions inherited`;
+      } catch (err) {
+        return `Error creating instance: ${err instanceof Error ? err.message : String(err)}`;
+      }
+    },
+  });
+
+  const squadInstanceList = defineTool("squad_instance_list", {
+    description: "List active (and optionally completed) instances for a squad.",
+    skipPermission: true,
+    parameters: z.object({
+      squad_slug: z.string().describe("Squad slug"),
+      include_completed: z.boolean().optional().describe("Include done/failed instances (default: false)"),
+    }),
+    handler: async ({ squad_slug, include_completed }) => {
+      const instances = deps.listInstances(squad_slug, { includeCompleted: include_completed ?? false });
+      if (instances.length === 0) return `No instances for squad "${squad_slug}".`;
+
+      return instances.map(i =>
+        `- **${i.id}** [${i.status}] — ${i.issue_ref ?? "no issue"} (branch: ${i.branch_name}, created: ${i.created_at})`
+      ).join("\n");
+    },
+  });
+
+  const squadInstanceStatus = defineTool("squad_instance_status", {
+    description: "Get detailed status of a specific squad instance.",
+    skipPermission: true,
+    parameters: z.object({
+      instance_id: z.string().describe("Instance ID (e.g. 'my-squad--issue-42')"),
+    }),
+    handler: async ({ instance_id }) => {
+      const instance = deps.getInstance(instance_id);
+      if (!instance) return `Instance not found: ${instance_id}`;
+
+      const decisions = deps.getInstanceDecisions(instance_id);
+
+      return [
+        `## Instance: ${instance.id}`,
+        `- Squad: ${instance.master_squad_slug}`,
+        `- Issue: ${instance.issue_ref ?? "none"}`,
+        `- Status: ${instance.status}`,
+        `- Branch: ${instance.branch_name}`,
+        `- Worktree: ${instance.worktree_path}`,
+        `- Created: ${instance.created_at}`,
+        instance.completed_at ? `- Completed: ${instance.completed_at}` : null,
+        `- Decisions: ${decisions.length} (${decisions.filter(d => d.merged_to_master).length} merged)`,
+      ].filter(Boolean).join("\n");
+    },
+  });
+
+  const squadInstanceComplete = defineTool("squad_instance_complete", {
+    description: "Complete a squad instance: merge its decisions back to the master squad and clean up the worktree.",
+    skipPermission: true,
+    parameters: z.object({
+      instance_id: z.string().describe("Instance ID to complete"),
+    }),
+    handler: async ({ instance_id }) => {
+      const instance = deps.getInstance(instance_id);
+      if (!instance) return `Instance not found: ${instance_id}`;
+      if (instance.status === "done") return `Instance already completed.`;
+
+      try {
+        deps.updateInstanceStatus(instance_id, "merging");
+
+        const merged = deps.mergeInstanceDecisions(instance_id, instance.master_squad_slug);
+
+        const squad = deps.getSquad(instance.master_squad_slug);
+        if (squad) {
+          deps.removeWorktree(squad.projectPath, instance.worktree_path);
+        }
+
+        deps.updateInstanceStatus(instance_id, "done");
+
+        return `Instance "${instance_id}" completed.\n- ${merged} decision(s) merged to master squad "${instance.master_squad_slug}"\n- Worktree cleaned up`;
+      } catch (err) {
+        return `Error completing instance: ${err instanceof Error ? err.message : String(err)}`;
+      }
+    },
+  });
+
+  const squadInstanceAbort = defineTool("squad_instance_abort", {
+    description: "Abort a squad instance, marking it as failed. Worktree is preserved for debugging.",
+    skipPermission: true,
+    parameters: z.object({
+      instance_id: z.string().describe("Instance ID to abort"),
+    }),
+    handler: async ({ instance_id }) => {
+      const instance = deps.getInstance(instance_id);
+      if (!instance) return `Instance not found: ${instance_id}`;
+      if (instance.status === "done" || instance.status === "failed") {
+        return `Instance already in terminal state: ${instance.status}`;
+      }
+
+      deps.updateInstanceStatus(instance_id, "failed");
+      return `Instance "${instance_id}" aborted. Worktree preserved at: ${instance.worktree_path}\nUse squad_instance_cleanup to remove it.`;
+    },
+  });
+
+  const squadInstanceCleanup = defineTool("squad_instance_cleanup", {
+    description: "Force-remove a failed instance's worktree and delete the instance record.",
+    skipPermission: true,
+    parameters: z.object({
+      instance_id: z.string().describe("Instance ID to clean up"),
+    }),
+    handler: async ({ instance_id }) => {
+      const instance = deps.getInstance(instance_id);
+      if (!instance) return `Instance not found: ${instance_id}`;
+      if (instance.status !== "done" && instance.status !== "failed") {
+        return `Cannot clean up instance in "${instance.status}" state. Abort it first.`;
+      }
+
+      const squad = deps.getSquad(instance.master_squad_slug);
+      if (squad) {
+        deps.removeWorktree(squad.projectPath, instance.worktree_path);
+      }
+
+      deps.deleteInstance(instance_id);
+      return `Instance "${instance_id}" cleaned up and removed.`;
+    },
+  });
+  return [wikiRead, wikiWrite, wikiSearch, wikiDelete, wikiList, squadCreate, squadRecall, squadStatus, squadLogDecision, squadDelegate, squadTaskStatus, squadDelete, squadAnalyze, squadAddAgent, squadAgents, squadRemoveAgent, squadResetAgent, squadSetLead, squadSetQA, squadTaskReviews, squadScheduleCreate, squadScheduleList, squadScheduleDelete, squadSchedulePause, squadScheduleResume, squadScheduleRunNow, scheduleCreate, scheduleList, scheduleDelete, schedulePause, scheduleResume, scheduleRunNow, skillList, skillInstall, skillRemove, skillSearch, configUpdate, checkUpdate, shell, fileOps, bash, readFile, viewTool, grepTool, strReplaceEditor, github, squadInstanceCreate, squadInstanceList, squadInstanceStatus, squadInstanceComplete, squadInstanceAbort, squadInstanceCleanup];
 }
 
 function walkDirectory(dir: string, maxDepth = 3, depth = 0): string[] {

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -199,6 +199,7 @@ GROUP BY agent_slug`,
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP
     )`,
     `ALTER TABLE agent_tasks ADD COLUMN instance_id TEXT`,
+    `CREATE INDEX IF NOT EXISTS idx_instance_decisions_instance ON instance_decisions(instance_id, merged_to_master)`,
   ];
 
   for (const migration of migrations) {

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -179,6 +179,26 @@ GROUP BY agent_slug`,
     )`,
     `CREATE INDEX IF NOT EXISTS idx_unified_feed_type ON unified_feed(type, created_at)`,
     `CREATE INDEX IF NOT EXISTS idx_unified_feed_unread ON unified_feed(read_at, created_at)`,
+    `CREATE TABLE IF NOT EXISTS squad_instances (
+      id TEXT PRIMARY KEY,
+      master_squad_slug TEXT NOT NULL,
+      issue_ref TEXT,
+      worktree_path TEXT NOT NULL,
+      branch_name TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      context_snapshot TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      completed_at DATETIME
+    )`,
+    `CREATE TABLE IF NOT EXISTS instance_decisions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      instance_id TEXT NOT NULL,
+      decision TEXT NOT NULL,
+      context TEXT,
+      merged_to_master INTEGER DEFAULT 0,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )`,
+    `ALTER TABLE agent_tasks ADD COLUMN instance_id TEXT`,
   ];
 
   for (const migration of migrations) {

--- a/src/store/instances.test.ts
+++ b/src/store/instances.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Tests for src/store/instances.ts — squad instances store.
+ *
+ * DB isolation: setDbPathForTests() redirects the SQLite singleton to a
+ * fresh tmp file so these tests never touch ~/.io/io.db.
+ */
+import { before, after, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { setDbPathForTests, closeDb, getDb } from "./db.js";
+import {
+  createInstance,
+  getInstance,
+  listInstances,
+  updateInstanceStatus,
+  logInstanceDecision,
+  getInstanceDecisions,
+  mergeInstanceDecisions,
+  deleteInstance,
+  buildContextSnapshot,
+  reconcileInstances,
+  MAX_CONCURRENT_INSTANCES,
+} from "./instances.js";
+import { logDecision, getDecisions } from "./squads.js";
+
+// ── DB isolation ─────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+before(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "io-instances-test-"));
+  setDbPathForTests(join(tmpDir, "io.db"));
+});
+
+after(() => {
+  closeDb();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  const db = getDb();
+  db.prepare("DELETE FROM instance_decisions").run();
+  db.prepare("DELETE FROM squad_instances").run();
+  db.prepare("DELETE FROM squad_decisions").run();
+  db.prepare("DELETE FROM squads").run();
+  db.prepare("INSERT INTO squads (slug, name, project_path) VALUES (?, ?, ?)").run("test-squad", "Test Squad", "/tmp/test");
+});
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function makeInstance(id: string, slug = "test-squad", status?: string) {
+  const inst = createInstance({
+    id,
+    masterSquadSlug: slug,
+    issueRef: `#${id}`,
+    worktreePath: `/tmp/nonexistent-worktree-${id}`,
+    branchName: `${slug}/instance/${id}`,
+  });
+  if (status && status !== "pending") {
+    updateInstanceStatus(id, status);
+  }
+  return inst;
+}
+
+// ── createInstance ────────────────────────────────────────────────────────────
+
+describe("createInstance", () => {
+  it("creates and returns an instance with correct fields", () => {
+    const inst = createInstance({
+      id: "inst-1",
+      masterSquadSlug: "test-squad",
+      issueRef: "#42",
+      worktreePath: "/tmp/wt/inst-1",
+      branchName: "test-squad/instance/inst-1",
+      contextSnapshot: JSON.stringify([{ decision: "use TypeScript" }]),
+    });
+    assert.equal(inst.id, "inst-1");
+    assert.equal(inst.master_squad_slug, "test-squad");
+    assert.equal(inst.issue_ref, "#42");
+    assert.equal(inst.worktree_path, "/tmp/wt/inst-1");
+    assert.equal(inst.branch_name, "test-squad/instance/inst-1");
+    assert.equal(inst.status, "pending");
+    assert.ok(inst.context_snapshot?.includes("use TypeScript"));
+    assert.equal(inst.completed_at, null);
+    assert.ok(inst.created_at);
+  });
+
+  it("throws when max concurrent instances are exceeded", () => {
+    // Create MAX_CONCURRENT_INSTANCES active instances
+    for (let i = 1; i <= MAX_CONCURRENT_INSTANCES; i++) {
+      createInstance({
+        id: `inst-max-${i}`,
+        masterSquadSlug: "test-squad",
+        worktreePath: `/tmp/wt/inst-max-${i}`,
+        branchName: `test-squad/instance/inst-max-${i}`,
+      });
+    }
+    assert.throws(
+      () =>
+        createInstance({
+          id: "inst-over-limit",
+          masterSquadSlug: "test-squad",
+          worktreePath: "/tmp/wt/inst-over-limit",
+          branchName: "test-squad/instance/inst-over-limit",
+        }),
+      /Max concurrent instances/,
+    );
+  });
+
+  it("does not count done/failed instances toward the limit", () => {
+    for (let i = 1; i <= MAX_CONCURRENT_INSTANCES; i++) {
+      const inst = createInstance({
+        id: `inst-done-${i}`,
+        masterSquadSlug: "test-squad",
+        worktreePath: `/tmp/wt/inst-done-${i}`,
+        branchName: `test-squad/instance/inst-done-${i}`,
+      });
+      updateInstanceStatus(inst.id, "done");
+    }
+    // Should not throw — all prior instances are done
+    assert.doesNotThrow(() =>
+      createInstance({
+        id: "inst-after-done",
+        masterSquadSlug: "test-squad",
+        worktreePath: "/tmp/wt/inst-after-done",
+        branchName: "test-squad/instance/inst-after-done",
+      }),
+    );
+  });
+});
+
+// ── getInstance ───────────────────────────────────────────────────────────────
+
+describe("getInstance", () => {
+  it("returns undefined for non-existent ID", () => {
+    assert.equal(getInstance("no-such-id"), undefined);
+  });
+
+  it("returns the correct instance after create", () => {
+    makeInstance("get-test");
+    const inst = getInstance("get-test");
+    assert.ok(inst);
+    assert.equal(inst.id, "get-test");
+  });
+});
+
+// ── listInstances ─────────────────────────────────────────────────────────────
+
+describe("listInstances", () => {
+  it("filters by slug and excludes done/failed by default", () => {
+    makeInstance("li-active-1");
+    makeInstance("li-active-2");
+    makeInstance("li-done", "test-squad", "done");
+    makeInstance("li-failed", "test-squad", "failed");
+
+    const active = listInstances("test-squad");
+    assert.equal(active.length, 2);
+    assert.ok(active.every((i) => i.status === "pending"));
+  });
+
+  it("includes completed instances when opted in", () => {
+    makeInstance("li-pending");
+    makeInstance("li-done2", "test-squad", "done");
+
+    const all = listInstances("test-squad", { includeCompleted: true });
+    assert.equal(all.length, 2);
+  });
+
+  it("does not include instances from other squads", () => {
+    getDb().prepare("INSERT INTO squads (slug, name, project_path) VALUES (?, ?, ?)").run("other-squad", "Other", "/tmp/other");
+    makeInstance("li-other", "other-squad");
+    makeInstance("li-mine");
+
+    const mine = listInstances("test-squad");
+    assert.equal(mine.length, 1);
+    assert.equal(mine[0].id, "li-mine");
+  });
+});
+
+// ── updateInstanceStatus ──────────────────────────────────────────────────────
+
+describe("updateInstanceStatus", () => {
+  it("sets completed_at for terminal status 'done'", () => {
+    makeInstance("upd-done");
+    updateInstanceStatus("upd-done", "done");
+    const inst = getInstance("upd-done")!;
+    assert.equal(inst.status, "done");
+    assert.ok(inst.completed_at !== null);
+  });
+
+  it("sets completed_at for terminal status 'failed'", () => {
+    makeInstance("upd-failed");
+    updateInstanceStatus("upd-failed", "failed");
+    const inst = getInstance("upd-failed")!;
+    assert.equal(inst.status, "failed");
+    assert.ok(inst.completed_at !== null);
+  });
+
+  it("does not set completed_at for non-terminal status 'active'", () => {
+    makeInstance("upd-active");
+    updateInstanceStatus("upd-active", "active");
+    const inst = getInstance("upd-active")!;
+    assert.equal(inst.status, "active");
+    assert.equal(inst.completed_at, null);
+  });
+});
+
+// ── logInstanceDecision + getInstanceDecisions ────────────────────────────────
+
+describe("logInstanceDecision / getInstanceDecisions", () => {
+  it("round-trips a decision with context", () => {
+    makeInstance("dec-inst");
+    logInstanceDecision("dec-inst", "use Jest for tests", "better DX");
+    const decisions = getInstanceDecisions("dec-inst");
+    assert.equal(decisions.length, 1);
+    assert.equal(decisions[0].decision, "use Jest for tests");
+    assert.equal(decisions[0].context, "better DX");
+    assert.equal(decisions[0].merged_to_master, 0);
+  });
+
+  it("stores null context when not provided", () => {
+    makeInstance("dec-nocontext");
+    logInstanceDecision("dec-nocontext", "some decision");
+    const decisions = getInstanceDecisions("dec-nocontext");
+    assert.equal(decisions[0].context, null);
+  });
+
+  it("returns decisions in ascending created_at order", () => {
+    makeInstance("dec-order");
+    logInstanceDecision("dec-order", "first");
+    logInstanceDecision("dec-order", "second");
+    const decisions = getInstanceDecisions("dec-order");
+    assert.equal(decisions[0].decision, "first");
+    assert.equal(decisions[1].decision, "second");
+  });
+});
+
+// ── mergeInstanceDecisions ────────────────────────────────────────────────────
+
+describe("mergeInstanceDecisions", () => {
+  it("copies decisions to squad_decisions with provenance tag and marks merged", () => {
+    makeInstance("merge-inst");
+    logInstanceDecision("merge-inst", "use SQLite transactions", "performance");
+    logInstanceDecision("merge-inst", "append-only log", "conflict-free");
+
+    const count = mergeInstanceDecisions("merge-inst", "test-squad");
+    assert.equal(count, 2);
+
+    const masterDecisions = getDecisions("test-squad");
+    assert.equal(masterDecisions.length, 2);
+    assert.ok(masterDecisions.some((d) => d.decision === "use SQLite transactions"));
+    assert.ok(masterDecisions.every((d) => d.context?.includes("[from instance: merge-inst]")));
+
+    const instDecisions = getInstanceDecisions("merge-inst");
+    assert.ok(instDecisions.every((d) => d.merged_to_master === 1));
+  });
+
+  it("is idempotent — calling twice does not double-merge", () => {
+    makeInstance("merge-idempotent");
+    logInstanceDecision("merge-idempotent", "idempotent decision");
+
+    mergeInstanceDecisions("merge-idempotent", "test-squad");
+    const second = mergeInstanceDecisions("merge-idempotent", "test-squad");
+    assert.equal(second, 0);
+
+    const masterDecisions = getDecisions("test-squad");
+    assert.equal(masterDecisions.length, 1);
+  });
+
+  it("returns 0 when there are no decisions to merge", () => {
+    makeInstance("merge-empty");
+    const count = mergeInstanceDecisions("merge-empty", "test-squad");
+    assert.equal(count, 0);
+  });
+});
+
+// ── deleteInstance ────────────────────────────────────────────────────────────
+
+describe("deleteInstance", () => {
+  it("removes the instance and its decisions", () => {
+    makeInstance("del-inst");
+    logInstanceDecision("del-inst", "a decision");
+
+    deleteInstance("del-inst");
+
+    assert.equal(getInstance("del-inst"), undefined);
+    assert.deepEqual(getInstanceDecisions("del-inst"), []);
+  });
+
+  it("is safe to call on a non-existent id", () => {
+    assert.doesNotThrow(() => deleteInstance("no-such-instance"));
+  });
+});
+
+// ── buildContextSnapshot ──────────────────────────────────────────────────────
+
+describe("buildContextSnapshot", () => {
+  it("returns a JSON array of recent squad decisions", () => {
+    logDecision("test-squad", "use TypeScript everywhere", "consistency");
+    logDecision("test-squad", "prefer functional style");
+
+    const snapshot = buildContextSnapshot("test-squad");
+    const parsed = JSON.parse(snapshot) as Array<{ decision: string; context: string | null; created_at: string }>;
+
+    assert.ok(Array.isArray(parsed));
+    assert.equal(parsed.length, 2);
+    assert.ok(parsed.some((d) => d.decision === "use TypeScript everywhere"));
+  });
+
+  it("returns an empty JSON array for a squad with no decisions", () => {
+    const snapshot = buildContextSnapshot("test-squad");
+    assert.deepEqual(JSON.parse(snapshot), []);
+  });
+
+  it("respects the limit parameter", () => {
+    for (let i = 0; i < 10; i++) {
+      logDecision("test-squad", `decision ${i}`);
+    }
+    const snapshot = buildContextSnapshot("test-squad", 5);
+    const parsed = JSON.parse(snapshot) as unknown[];
+    assert.equal(parsed.length, 5);
+  });
+});
+
+// ── reconcileInstances ────────────────────────────────────────────────────────
+
+describe("reconcileInstances", () => {
+  it("marks pending/active/merging instances failed when worktree does not exist", () => {
+    // These worktree paths do not exist on disk
+    makeInstance("recon-pending");                        // status: pending
+    makeInstance("recon-active", "test-squad", "active"); // status: active
+    makeInstance("recon-merging", "test-squad", "merging"); // status: merging
+
+    const cleaned = reconcileInstances();
+    assert.equal(cleaned, 3);
+
+    assert.equal(getInstance("recon-pending")!.status, "failed");
+    assert.equal(getInstance("recon-active")!.status, "failed");
+    assert.equal(getInstance("recon-merging")!.status, "failed");
+  });
+
+  it("does not touch already-terminal instances", () => {
+    makeInstance("recon-done", "test-squad", "done");
+    makeInstance("recon-failed", "test-squad", "failed");
+
+    const cleaned = reconcileInstances();
+    assert.equal(cleaned, 0);
+  });
+
+  it("returns 0 when all non-terminal instances have valid worktrees", () => {
+    // Use a path that actually exists (tmpDir was created above)
+    createInstance({
+      id: "recon-exists",
+      masterSquadSlug: "test-squad",
+      worktreePath: tmpDir, // this path exists on disk
+      branchName: "test-squad/instance/recon-exists",
+    });
+
+    const cleaned = reconcileInstances();
+    assert.equal(cleaned, 0);
+    assert.equal(getInstance("recon-exists")!.status, "pending");
+  });
+});

--- a/src/store/instances.ts
+++ b/src/store/instances.ts
@@ -1,0 +1,183 @@
+import { getDb } from "./db.js";
+import { getDecisions } from "./squads.js";
+import { worktreeExists } from "./worktrees.js";
+
+export interface SquadInstance {
+  id: string;
+  master_squad_slug: string;
+  issue_ref: string | null;
+  worktree_path: string;
+  branch_name: string;
+  status: string;
+  context_snapshot: string | null;
+  created_at: string;
+  completed_at: string | null;
+}
+
+export interface InstanceDecision {
+  decision: string;
+  context: string | null;
+  created_at: string;
+  merged_to_master: number;
+}
+
+export function ensureInstanceTables(): void {
+  const db = getDb();
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS squad_instances (
+      id TEXT PRIMARY KEY,
+      master_squad_slug TEXT NOT NULL,
+      issue_ref TEXT,
+      worktree_path TEXT NOT NULL,
+      branch_name TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      context_snapshot TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      completed_at DATETIME
+    );
+
+    CREATE TABLE IF NOT EXISTS instance_decisions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      instance_id TEXT NOT NULL,
+      decision TEXT NOT NULL,
+      context TEXT,
+      merged_to_master INTEGER DEFAULT 0,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+}
+
+export function createInstance(input: {
+  id: string;
+  masterSquadSlug: string;
+  issueRef?: string;
+  worktreePath: string;
+  branchName: string;
+  contextSnapshot?: string;
+}): SquadInstance {
+  const db = getDb();
+  db.prepare(
+    `INSERT INTO squad_instances (id, master_squad_slug, issue_ref, worktree_path, branch_name, status, context_snapshot)
+     VALUES (?, ?, ?, ?, ?, 'pending', ?)`,
+  ).run(
+    input.id,
+    input.masterSquadSlug,
+    input.issueRef ?? null,
+    input.worktreePath,
+    input.branchName,
+    input.contextSnapshot ?? null,
+  );
+  return getInstance(input.id)!;
+}
+
+export function getInstance(id: string): SquadInstance | undefined {
+  const db = getDb();
+  return db.prepare("SELECT * FROM squad_instances WHERE id = ?").get(id) as SquadInstance | undefined;
+}
+
+export function listInstances(
+  masterSquadSlug: string,
+  opts?: { includeCompleted?: boolean },
+): Array<{ id: string; issue_ref: string | null; status: string; branch_name: string; created_at: string; completed_at: string | null }> {
+  const db = getDb();
+  const includeCompleted = opts?.includeCompleted ?? false;
+  if (includeCompleted) {
+    return db
+      .prepare("SELECT id, issue_ref, status, branch_name, created_at, completed_at FROM squad_instances WHERE master_squad_slug = ? ORDER BY created_at DESC")
+      .all(masterSquadSlug) as Array<{ id: string; issue_ref: string | null; status: string; branch_name: string; created_at: string; completed_at: string | null }>;
+  }
+  return db
+    .prepare("SELECT id, issue_ref, status, branch_name, created_at, completed_at FROM squad_instances WHERE master_squad_slug = ? AND status NOT IN ('done', 'failed') ORDER BY created_at DESC")
+    .all(masterSquadSlug) as Array<{ id: string; issue_ref: string | null; status: string; branch_name: string; created_at: string; completed_at: string | null }>;
+}
+
+export function updateInstanceStatus(id: string, status: string): void {
+  const db = getDb();
+  if (status === "done" || status === "failed") {
+    db.prepare("UPDATE squad_instances SET status = ?, completed_at = CURRENT_TIMESTAMP WHERE id = ?").run(status, id);
+  } else {
+    db.prepare("UPDATE squad_instances SET status = ? WHERE id = ?").run(status, id);
+  }
+}
+
+export function logInstanceDecision(instanceId: string, decision: string, context?: string): void {
+  const db = getDb();
+  db.prepare(
+    "INSERT INTO instance_decisions (instance_id, decision, context) VALUES (?, ?, ?)",
+  ).run(instanceId, decision, context ?? null);
+}
+
+export function getInstanceDecisions(instanceId: string): InstanceDecision[] {
+  const db = getDb();
+  return db
+    .prepare("SELECT decision, context, created_at, merged_to_master FROM instance_decisions WHERE instance_id = ? ORDER BY created_at ASC")
+    .all(instanceId) as InstanceDecision[];
+}
+
+/**
+ * Merge instance decisions back to master squad. Returns count merged.
+ */
+export function mergeInstanceDecisions(instanceId: string, masterSquadSlug: string): number {
+  const db = getDb();
+  const decisions = db
+    .prepare("SELECT id, decision, context FROM instance_decisions WHERE instance_id = ? AND merged_to_master = 0")
+    .all(instanceId) as Array<{ id: number; decision: string; context: string | null }>;
+
+  if (decisions.length === 0) return 0;
+
+  const insertStmt = db.prepare(
+    "INSERT INTO squad_decisions (squad_slug, decision, context) VALUES (?, ?, ?)",
+  );
+  const markStmt = db.prepare(
+    "UPDATE instance_decisions SET merged_to_master = 1 WHERE id = ?",
+  );
+
+  const mergeAll = db.transaction(() => {
+    for (const d of decisions) {
+      const ctx = d.context
+        ? `${d.context} [from instance: ${instanceId}]`
+        : `[from instance: ${instanceId}]`;
+      insertStmt.run(masterSquadSlug, d.decision, ctx);
+      markStmt.run(d.id);
+    }
+  });
+
+  mergeAll();
+  return decisions.length;
+}
+
+export function deleteInstance(id: string): void {
+  const db = getDb();
+  db.prepare("DELETE FROM instance_decisions WHERE instance_id = ?").run(id);
+  db.prepare("DELETE FROM squad_instances WHERE id = ?").run(id);
+}
+
+/**
+ * Build a JSON snapshot of the master squad's recent decisions for context inheritance.
+ */
+export function buildContextSnapshot(masterSquadSlug: string, limit: number = 30): string {
+  const decisions = getDecisions(masterSquadSlug, limit);
+  return JSON.stringify(
+    decisions.map((d) => ({ decision: d.decision, context: d.context, created_at: d.created_at })),
+  );
+}
+
+/**
+ * Reconcile instances on startup: detect orphaned worktrees and mark stale active instances.
+ * Returns the number of instances cleaned up.
+ */
+export function reconcileInstances(): number {
+  const db = getDb();
+  const activeInstances = db
+    .prepare("SELECT id, worktree_path FROM squad_instances WHERE status IN ('active', 'pending', 'merging')")
+    .all() as Array<{ id: string; worktree_path: string }>;
+
+  let cleaned = 0;
+  for (const inst of activeInstances) {
+    if (!worktreeExists(inst.worktree_path)) {
+      updateInstanceStatus(inst.id, "failed");
+      cleaned++;
+    }
+  }
+  return cleaned;
+}

--- a/src/store/instances.ts
+++ b/src/store/instances.ts
@@ -47,6 +47,8 @@ export function ensureInstanceTables(): void {
   `);
 }
 
+export const MAX_CONCURRENT_INSTANCES = 3;
+
 export function createInstance(input: {
   id: string;
   masterSquadSlug: string;
@@ -56,6 +58,14 @@ export function createInstance(input: {
   contextSnapshot?: string;
 }): SquadInstance {
   const db = getDb();
+  const activeCount = (
+    db
+      .prepare("SELECT COUNT(*) as cnt FROM squad_instances WHERE master_squad_slug = ? AND status NOT IN ('done', 'failed')")
+      .get(input.masterSquadSlug) as { cnt: number }
+  ).cnt;
+  if (activeCount >= MAX_CONCURRENT_INSTANCES) {
+    throw new Error(`Max concurrent instances (${MAX_CONCURRENT_INSTANCES}) reached for squad "${input.masterSquadSlug}"`);
+  }
   db.prepare(
     `INSERT INTO squad_instances (id, master_squad_slug, issue_ref, worktree_path, branch_name, status, context_snapshot)
      VALUES (?, ?, ?, ?, ?, 'pending', ?)`,

--- a/src/store/worktrees.ts
+++ b/src/store/worktrees.ts
@@ -1,0 +1,98 @@
+import { execSync } from "child_process";
+import { existsSync, rmSync, mkdirSync } from "fs";
+import path from "path";
+
+export interface WorktreeInfo {
+  path: string;
+  branch: string;
+}
+
+/**
+ * Create a git worktree for a squad instance.
+ * @param projectPath - The main project directory (must be a git repo)
+ * @param instanceId - Used to name the worktree subdirectory
+ * @param branchName - The branch to create for this worktree
+ * @param baseBranch - The branch to base the worktree on (default: "main")
+ * @returns The absolute path to the created worktree
+ */
+export function createWorktree(
+  projectPath: string,
+  instanceId: string,
+  branchName: string,
+  baseBranch: string = "main",
+): string {
+  const worktreeDir = path.join(projectPath, ".io-worktrees", instanceId);
+
+  const parentDir = path.join(projectPath, ".io-worktrees");
+  if (!existsSync(parentDir)) {
+    mkdirSync(parentDir, { recursive: true });
+  }
+
+  // Fetch latest to ensure base branch is up to date
+  try {
+    execSync(`git fetch origin ${baseBranch}`, { cwd: projectPath, stdio: "pipe" });
+  } catch {
+    // Best effort — might be offline or no remote
+  }
+
+  // Create the worktree with a new branch from the base
+  execSync(
+    `git worktree add "${worktreeDir}" -b "${branchName}" "origin/${baseBranch}"`,
+    { cwd: projectPath, stdio: "pipe" },
+  );
+
+  return worktreeDir;
+}
+
+/**
+ * Remove a git worktree. Falls back to rm -rf + prune if git remove fails.
+ */
+export function removeWorktree(projectPath: string, worktreePath: string): void {
+  try {
+    execSync(`git worktree remove "${worktreePath}" --force`, {
+      cwd: projectPath,
+      stdio: "pipe",
+    });
+  } catch {
+    // Fallback: force remove directory and prune
+    if (existsSync(worktreePath)) {
+      rmSync(worktreePath, { recursive: true, force: true });
+    }
+    try {
+      execSync("git worktree prune", { cwd: projectPath, stdio: "pipe" });
+    } catch {
+      // best effort
+    }
+  }
+}
+
+/**
+ * List all worktrees for a project.
+ */
+export function listWorktrees(projectPath: string): WorktreeInfo[] {
+  try {
+    const output = execSync("git worktree list --porcelain", {
+      cwd: projectPath,
+      encoding: "utf-8",
+    });
+    const entries: WorktreeInfo[] = [];
+    let currentPath = "";
+    for (const line of output.split("\n")) {
+      if (line.startsWith("worktree ")) {
+        currentPath = line.slice("worktree ".length);
+      } else if (line.startsWith("branch ")) {
+        entries.push({ path: currentPath, branch: line.slice("branch refs/heads/".length) });
+      }
+    }
+    return entries;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Check if a worktree path exists on disk.
+ */
+export function worktreeExists(worktreePath: string): boolean {
+  return existsSync(worktreePath);
+}


### PR DESCRIPTION
## Summary

Phase 1 implementation of #231 — Squad Instances / Parallel Squad Execution.

Enables spawning multiple concurrent instances of a squad, each working on a different issue with git worktree isolation and independent decision tracking.

## Changes

### New modules
- **`src/store/instances.ts`** — CRUD for squad instances + decision routing + merge-back logic + reconciliation
- **`src/store/worktrees.ts`** — Git worktree lifecycle (create/remove/list)
- **`src/store/instances.test.ts`** — 15 unit tests covering all store operations

### Schema migrations (`src/store/db.ts`)
- `squad_instances` table (id, master_squad_slug, worktree_path, branch_name, status, context_snapshot)
- `instance_decisions` table (instance_id, decision, context, merged_to_master)
- `idx_instance_decisions_instance` index
- `agent_tasks.instance_id` column (nullable, backward-compatible)

### Tools (`src/copilot/tools.ts`)
6 new tools for the orchestrator:
- `squad_instance_create` — Spawn instance with worktree + context snapshot
- `squad_instance_list` — List active instances
- `squad_instance_status` — Detailed instance info
- `squad_instance_complete` — Merge decisions back + cleanup worktree
- `squad_instance_abort` — Mark failed, preserve worktree
- `squad_instance_cleanup` — Force-remove failed instance

### API endpoints (`src/api/server.ts`)
- `GET /squads/:slug/instances` — List instances
- `POST /squads/:slug/instances` — Create instance
- `GET /squads/:slug/instances/:id` — Instance detail + decisions
- `POST /squads/:slug/instances/:id/complete` — Trigger merge-back
- `POST /squads/:slug/instances/:id/abort` — Abort instance

### Orchestrator wiring (`src/copilot/orchestrator.ts`)
- New deps wired into `registerTools()` call

## Key Design Decisions
- Max 3 concurrent instances per squad (enforced at store level)
- Worktrees created under `<project>/.io-worktrees/<instance-id>/`
- Decisions are append-only with provenance tags on merge-back
- SQLite transaction ensures concurrent completions don't corrupt
- `reconcileInstances()` marks stale instances as failed on restart

## Tests
All 160 tests pass (15 new for instances store).

## Remaining phases (not in this PR)
- Phase 2: Thread instance_id through agent dispatch + session isolation
- Phase 3: Vue instance management UI
- Phase 4: Stuck-instance watchdog + conflict detection

Closes #231 (Phase 1 only — additional phases tracked separately)