### PR TITLE
feat: Thread instance_id through agent dispatch (Phase 2, #231)

### DIFF
--- a/src/copilot/agents.ts
+++ b/src/copilot/agents.ts
@@ -244,6 +244,7 @@ export async function delegateToAgent(
   task: string,
   onComplete: (taskId: string, result: string) => void,
   targetAgent?: string,
+  instanceId?: string,
 ): Promise<string> {
   const squad = getSquad(squadSlug);
   if (!squad) {
@@ -301,7 +302,7 @@ export async function delegateToAgent(
 
   const taskId = randomUUID();
 
-  createTask(taskId, agentKey, task);
+  createTask(taskId, agentKey, task, undefined, instanceId);
   updateSquadStatus(squadSlug, "working");
   if (agent) updateAgentStatus(squadSlug, agent.character_name, "working");
 

--- a/src/copilot/orchestrator.ts
+++ b/src/copilot/orchestrator.ts
@@ -125,7 +125,8 @@ function getToolDeps() {
         created_at: d.created_at,
       })),
     updateSquadStatus,
-    delegateToAgent,
+    delegateToAgent: (squadSlug: string, task: string, onComplete: (taskId: string, result: string) => void, targetAgent?: string, instanceId?: string) =>
+      delegateToAgent(squadSlug, task, onComplete, targetAgent, instanceId),
     getTask,
     getActiveAgentTasks: () =>
       getActiveAgentTasks().map((t) => ({
@@ -209,6 +210,7 @@ function getToolDeps() {
     reconcileInstances,
     createWorktree,
     removeWorktree,
+    activeInstanceId: undefined,
   };
 }
 

--- a/src/copilot/tools.ts
+++ b/src/copilot/tools.ts
@@ -319,7 +319,7 @@ export interface ToolDeps {
     limit?: number,
   ) => Array<{ decision: string; context: string | null; created_at: string }>;
   updateSquadStatus: (slug: string, status: string) => void;
-  delegateToAgent: (squadSlug: string, task: string, onComplete: (taskId: string, result: string) => void, targetAgent?: string) => Promise<string>;
+  delegateToAgent: (squadSlug: string, task: string, onComplete: (taskId: string, result: string) => void, targetAgent?: string, instanceId?: string) => Promise<string>;
   getTask: (taskId: string) => { task_id: string; agent_slug: string; description: string; status: string; result: string | null } | undefined;
   getActiveAgentTasks: () => Array<{ taskId: string; agentSlug: string; description: string; status: string }>;
   addSquadAgent: (squadSlug: string, roleTitle: string, charter: string, modelTier?: string) => { character_name: string; role_title: string; personality: string | null; model_tier: string };
@@ -364,6 +364,7 @@ export interface ToolDeps {
   reconcileInstances: () => number;
   createWorktree: (projectPath: string, instanceId: string, branchName: string, baseBranch?: string) => string;
   removeWorktree: (projectPath: string, worktreePath: string) => void;
+  activeInstanceId?: string;  // Set when tools are executing within an instance context
 }
 
 
@@ -513,6 +514,11 @@ export function createTools(deps: ToolDeps) {
     }),
     handler: async ({ slug, decision, context }) => {
       try {
+        // If we're in an instance context, route to instance decisions
+        if (deps.activeInstanceId) {
+          deps.logInstanceDecision(deps.activeInstanceId, decision, context);
+          return `Decision logged for instance ${deps.activeInstanceId} (squad ${slug})`;
+        }
         deps.logDecision(slug, decision, context);
         return `Decision logged for squad ${slug}`;
       } catch (err) {
@@ -548,7 +554,7 @@ export function createTools(deps: ToolDeps) {
             createFeedEntry({ type: "deliverable", title: `[${slug}] Task result`, body: result });
             console.error(`[io] Task ${id} result routed to inbox`);
           }
-        }, agent);
+        }, agent, deps.activeInstanceId);
         const agentLabel = agent ? `agent "${agent}" in squad "${slug}"` : `squad "${slug}"`;
         const warningPrefix = coverage.warning
           ? `${coverage.warning} A dedicated lead and a QA reviewer should both hold veto power on PR promotion — fix gaps before promoting work.\n\n`
@@ -2024,7 +2030,38 @@ export function createTools(deps: ToolDeps) {
       return `Instance "${instance_id}" cleaned up and removed.`;
     },
   });
-  return [wikiRead, wikiWrite, wikiSearch, wikiDelete, wikiList, squadCreate, squadRecall, squadStatus, squadLogDecision, squadDelegate, squadTaskStatus, squadDelete, squadAnalyze, squadAddAgent, squadAgents, squadRemoveAgent, squadResetAgent, squadSetLead, squadSetQA, squadTaskReviews, squadScheduleCreate, squadScheduleList, squadScheduleDelete, squadSchedulePause, squadScheduleResume, squadScheduleRunNow, scheduleCreate, scheduleList, scheduleDelete, schedulePause, scheduleResume, scheduleRunNow, skillList, skillInstall, skillRemove, skillSearch, configUpdate, checkUpdate, shell, fileOps, bash, readFile, viewTool, grepTool, strReplaceEditor, github, squadInstanceCreate, squadInstanceList, squadInstanceStatus, squadInstanceComplete, squadInstanceAbort, squadInstanceCleanup];
+
+  // ---------------------------------------------------------------------------
+  // Squad Instance context tools (#231 Phase 2)
+  // ---------------------------------------------------------------------------
+
+  const squadInstanceActivate = defineTool("squad_instance_activate", {
+    description: "Activate an instance context. After activation, delegated tasks and decisions are scoped to this instance until deactivated.",
+    skipPermission: true,
+    parameters: z.object({
+      instance_id: z.string().describe("Instance ID to activate"),
+    }),
+    handler: async ({ instance_id }) => {
+      const instance = deps.getInstance(instance_id);
+      if (!instance) return `Instance not found: ${instance_id}`;
+      if (instance.status !== "active") return `Instance is not active (status: ${instance.status})`;
+      deps.activeInstanceId = instance_id;
+      return `Instance context activated: ${instance_id}. Tasks and decisions will be scoped to this instance.`;
+    },
+  });
+
+  const squadInstanceDeactivate = defineTool("squad_instance_deactivate", {
+    description: "Deactivate the current instance context, returning to master squad scope.",
+    skipPermission: true,
+    parameters: z.object({}),
+    handler: async () => {
+      const prev = deps.activeInstanceId;
+      deps.activeInstanceId = undefined;
+      return prev ? `Instance context deactivated (was: ${prev})` : `No instance context was active.`;
+    },
+  });
+
+  return [wikiRead, wikiWrite, wikiSearch, wikiDelete, wikiList, squadCreate, squadRecall, squadStatus, squadLogDecision, squadDelegate, squadTaskStatus, squadDelete, squadAnalyze, squadAddAgent, squadAgents, squadRemoveAgent, squadResetAgent, squadSetLead, squadSetQA, squadTaskReviews, squadScheduleCreate, squadScheduleList, squadScheduleDelete, squadSchedulePause, squadScheduleResume, squadScheduleRunNow, scheduleCreate, scheduleList, scheduleDelete, schedulePause, scheduleResume, scheduleRunNow, skillList, skillInstall, skillRemove, skillSearch, configUpdate, checkUpdate, shell, fileOps, bash, readFile, viewTool, grepTool, strReplaceEditor, github, squadInstanceCreate, squadInstanceList, squadInstanceStatus, squadInstanceComplete, squadInstanceAbort, squadInstanceCleanup, squadInstanceActivate, squadInstanceDeactivate];
 }
 
 function walkDirectory(dir: string, maxDepth = 3, depth = 0): string[] {

--- a/src/store/tasks.test.ts
+++ b/src/store/tasks.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for src/store/tasks.ts — agent task store.
+ *
+ * DB isolation: setDbPathForTests() redirects the SQLite singleton to a
+ * fresh tmp file so these tests never touch ~/.io/io.db.
+ */
+import { before, after, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { setDbPathForTests, closeDb, getDb } from "./db.js";
+import { createTask, getTask, getActiveTasks, completeTask, failTask, cancelTask, listRecentTasks } from "./tasks.js";
+
+// ── DB isolation ─────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+before(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "io-tasks-test-"));
+  setDbPathForTests(join(tmpDir, "io.db"));
+});
+
+after(() => {
+  closeDb();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  getDb().prepare("DELETE FROM agent_tasks").run();
+});
+
+// ── createTask / getTask ──────────────────────────────────────────────────────
+
+describe("createTask", () => {
+  it("creates a task with correct base fields", () => {
+    const task = createTask("t-base", "agent-1", "Do something");
+    assert.equal(task.task_id, "t-base");
+    assert.equal(task.agent_slug, "agent-1");
+    assert.equal(task.description, "Do something");
+    assert.equal(task.status, "running");
+    assert.equal(task.result, null);
+    assert.equal(task.origin_channel, null);
+    assert.ok(task.started_at);
+    assert.equal(task.completed_at, null);
+  });
+
+  it("stores null instance_id when not provided", () => {
+    const task = createTask("t-no-instance", "agent-1", "Do something");
+    assert.equal(task.instance_id, null);
+    const fetched = getTask("t-no-instance");
+    assert.equal(fetched?.instance_id, null);
+  });
+
+  it("stores instance_id when provided", () => {
+    const task = createTask("t-with-instance", "agent-1", "Do something", undefined, "test-squad--issue-42");
+    assert.equal(task.instance_id, "test-squad--issue-42");
+  });
+
+  it("stores origin_channel when provided", () => {
+    const task = createTask("t-channel", "agent-1", "Task", "telegram");
+    assert.equal(task.origin_channel, "telegram");
+  });
+
+  it("stores both origin_channel and instance_id together", () => {
+    const task = createTask("t-both", "agent-1", "Task", "telegram", "squad--issue-5");
+    assert.equal(task.origin_channel, "telegram");
+    assert.equal(task.instance_id, "squad--issue-5");
+  });
+});
+
+describe("getTask", () => {
+  it("returns undefined for non-existent task_id", () => {
+    assert.equal(getTask("no-such-task"), undefined);
+  });
+
+  it("returns instance_id field correctly from DB", () => {
+    createTask("t-fetch", "agent-2", "Fetch test", undefined, "squad--issue-99");
+    const fetched = getTask("t-fetch");
+    assert.ok(fetched);
+    assert.equal(fetched.instance_id, "squad--issue-99");
+    assert.equal(fetched.task_id, "t-fetch");
+  });
+
+  it("returns null instance_id for tasks created without one", () => {
+    createTask("t-fetch-null", "agent-2", "No instance");
+    const fetched = getTask("t-fetch-null");
+    assert.equal(fetched?.instance_id, null);
+  });
+});
+
+// ── getActiveTasks ────────────────────────────────────────────────────────────
+
+describe("getActiveTasks", () => {
+  it("returns only running tasks", () => {
+    createTask("t-run1", "agent-1", "Running 1");
+    createTask("t-run2", "agent-1", "Running 2");
+    const t = createTask("t-done", "agent-1", "Done task");
+    completeTask(t.task_id, "finished");
+
+    const active = getActiveTasks();
+    assert.equal(active.length, 2);
+    assert.ok(active.every((t) => t.status === "running"));
+  });
+
+  it("returns empty array when no running tasks", () => {
+    assert.deepEqual(getActiveTasks(), []);
+  });
+});
+
+// ── completeTask ──────────────────────────────────────────────────────────────
+
+describe("completeTask", () => {
+  it("sets status to done and records result and completed_at", () => {
+    createTask("t-complete", "agent-1", "Task to complete");
+    completeTask("t-complete", "all done");
+    const t = getTask("t-complete");
+    assert.equal(t?.status, "done");
+    assert.equal(t?.result, "all done");
+    assert.ok(t?.completed_at);
+  });
+});
+
+// ── failTask ──────────────────────────────────────────────────────────────────
+
+describe("failTask", () => {
+  it("sets status to failed and records error and completed_at", () => {
+    createTask("t-fail", "agent-1", "Task to fail");
+    failTask("t-fail", "something went wrong");
+    const t = getTask("t-fail");
+    assert.equal(t?.status, "failed");
+    assert.equal(t?.result, "something went wrong");
+    assert.ok(t?.completed_at);
+  });
+});
+
+// ── cancelTask ────────────────────────────────────────────────────────────────
+
+describe("cancelTask", () => {
+  it("cancels a running task with default reason", () => {
+    createTask("t-cancel", "agent-1", "Task to cancel");
+    cancelTask("t-cancel");
+    const t = getTask("t-cancel");
+    assert.equal(t?.status, "cancelled");
+    assert.ok(t?.result?.includes("Cancelled"));
+  });
+
+  it("does not cancel an already-completed task", () => {
+    createTask("t-cancel-done", "agent-1", "Already done");
+    completeTask("t-cancel-done", "done");
+    cancelTask("t-cancel-done");
+    // status should remain 'done'
+    assert.equal(getTask("t-cancel-done")?.status, "done");
+  });
+});
+
+// ── listRecentTasks ───────────────────────────────────────────────────────────
+
+describe("listRecentTasks", () => {
+  it("returns tasks newest first", () => {
+    createTask("t-list-1", "agent-1", "First");
+    createTask("t-list-2", "agent-1", "Second");
+    const tasks = listRecentTasks();
+    assert.equal(tasks.length, 2);
+    // Both should be present; newest (by insert order / task_id sort) first
+    assert.ok(tasks.some((t) => t.task_id === "t-list-1"));
+    assert.ok(tasks.some((t) => t.task_id === "t-list-2"));
+  });
+
+  it("respects limit", () => {
+    for (let i = 0; i < 5; i++) {
+      createTask(`t-limit-${i}`, "agent-1", `Task ${i}`);
+    }
+    const tasks = listRecentTasks(3);
+    assert.equal(tasks.length, 3);
+  });
+});

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -16,11 +16,12 @@ export function createTask(
   agentSlug: string,
   description: string,
   originChannel?: string,
+  instanceId?: string,
 ): AgentTask {
   const db = getDb();
   db.prepare(
-    "INSERT INTO agent_tasks (task_id, agent_slug, description, origin_channel) VALUES (?, ?, ?, ?)",
-  ).run(taskId, agentSlug, description, originChannel ?? null);
+    "INSERT INTO agent_tasks (task_id, agent_slug, description, origin_channel, instance_id) VALUES (?, ?, ?, ?, ?)",
+  ).run(taskId, agentSlug, description, originChannel ?? null, instanceId ?? null);
   return getTask(taskId)!;
 }
 

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -7,6 +7,7 @@ export interface AgentTask {
   status: string;
   result: string | null;
   origin_channel: string | null;
+  instance_id: string | null;
   started_at: string;
   completed_at: string | null;
 }


### PR DESCRIPTION
## Summary

Phase 2 of #231 — threads `instance_id` through agent dispatch and decision routing so that work done within an instance context is properly isolated.

## Changes

### Agent dispatch (`src/copilot/agents.ts`)
- `delegateToAgent()` accepts optional `instanceId` parameter
- Passes it to `createTask()` for recording in `agent_tasks.instance_id`

### Task store (`src/store/tasks.ts`)
- `createTask()` accepts optional `instanceId`, writes to DB
- `AgentTask` interface includes `instance_id: string | null`

### Decision routing (`src/copilot/tools.ts`)
- `squad_log_decision` checks `deps.activeInstanceId` — routes to `logInstanceDecision()` when in instance context
- `squad_delegate` passes `deps.activeInstanceId` to `delegateToAgent()`
- New tools: `squad_instance_activate` / `squad_instance_deactivate` for explicit instance scoping

### Orchestrator wiring (`src/copilot/orchestrator.ts`)
- `activeInstanceId` added to deps, threaded through delegateToAgent wrapper

### Tests (`src/store/tasks.test.ts`)
- 16 new tests for task creation with/without instance_id

## How it works
1. User/orchestrator calls `squad_instance_activate` with an instance ID
2. All subsequent `squad_delegate` calls tag the task with that instance
3. All `squad_log_decision` calls route to `instance_decisions`
4. `squad_instance_deactivate` returns to master scope

176 tests pass, CI green.