### PR TITLE
feat: Instance watchdog for stuck instances (Phase 4, #231)

### DIFF
--- a/src/copilot/orchestrator.ts
+++ b/src/copilot/orchestrator.ts
@@ -37,6 +37,7 @@ import { resetClient } from "./client.js";
 import { delegateToAgent, getActiveAgentTasks, clearAgentInMemorySession } from "./agents.js";
 import { saveConfig } from "../config.js";
 import { checkForUpdate } from "../update.js";
+import { startInstanceWatchdog } from "../instance-watchdog.js";
 import {
   createInstance,
   getInstance,
@@ -528,6 +529,7 @@ export async function initOrchestrator(copilotClient: CopilotClient): Promise<vo
   if (reconciledInstances > 0) {
     console.error(`[orchestrator] Reconciled ${reconciledInstances} stale instance(s) on startup`);
   }
+  startInstanceWatchdog();
   clearStaleTasks();
 
   // Validate the configured model and resolve model tiers

--- a/src/instance-watchdog.test.ts
+++ b/src/instance-watchdog.test.ts
@@ -1,0 +1,134 @@
+import { before, after, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { setDbPathForTests, closeDb, getDb } from "./store/db.js";
+import { ensureInstanceTables } from "./store/instances.js";
+import { findStaleInstances, startInstanceWatchdog } from "./instance-watchdog.js";
+
+let tmpDir: string;
+
+before(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "io-inst-watchdog-test-"));
+  setDbPathForTests(join(tmpDir, "io.db"));
+  ensureInstanceTables();
+});
+
+after(() => {
+  closeDb();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  const db = getDb();
+  db.prepare("DELETE FROM agent_tasks").run();
+  db.prepare("DELETE FROM squad_instances").run();
+  db.prepare("DELETE FROM squads").run();
+  db.prepare("INSERT INTO squads (slug, name, project_path) VALUES (?, ?, ?)").run("test-squad", "Test", "/tmp/test");
+});
+
+describe("instance watchdog", () => {
+  describe("findStaleInstances", () => {
+    it("detects stale active instances with no task activity", () => {
+      const db = getDb();
+      db.prepare(`
+        INSERT INTO squad_instances (id, master_squad_slug, worktree_path, branch_name, status, created_at)
+        VALUES (?, ?, ?, ?, 'active', datetime('now', '-60 minutes'))
+      `).run("test-squad--old", "test-squad", "/tmp/wt", "test-squad/instance/old");
+
+      const stale = findStaleInstances(30 * 60_000);
+      assert.strictEqual(stale.length, 1);
+      assert.strictEqual(stale[0].instance.id, "test-squad--old");
+    });
+
+    it("does not flag instances with recent task activity", () => {
+      const db = getDb();
+      db.prepare(`
+        INSERT INTO squad_instances (id, master_squad_slug, worktree_path, branch_name, status, created_at)
+        VALUES (?, ?, ?, ?, 'active', datetime('now', '-60 minutes'))
+      `).run("test-squad--recent", "test-squad", "/tmp/wt2", "test-squad/instance/recent");
+
+      db.prepare(`
+        INSERT INTO agent_tasks (task_id, agent_slug, description, instance_id, started_at)
+        VALUES (?, ?, ?, ?, datetime('now', '-5 minutes'))
+      `).run("task-recent", "agent-1", "Work", "test-squad--recent");
+
+      const stale = findStaleInstances(30 * 60_000);
+      assert.strictEqual(stale.length, 0);
+    });
+
+    it("does not flag non-active instances", () => {
+      const db = getDb();
+      db.prepare(`
+        INSERT INTO squad_instances (id, master_squad_slug, worktree_path, branch_name, status, created_at)
+        VALUES (?, ?, ?, ?, 'done', datetime('now', '-120 minutes'))
+      `).run("test-squad--done", "test-squad", "/tmp/wt3", "test-squad/instance/done");
+
+      const stale = findStaleInstances(30 * 60_000);
+      assert.strictEqual(stale.length, 0);
+    });
+
+    it("calculates idleMs correctly relative to now", () => {
+      const db = getDb();
+      db.prepare(`
+        INSERT INTO squad_instances (id, master_squad_slug, worktree_path, branch_name, status, created_at)
+        VALUES (?, ?, ?, ?, 'active', datetime('now', '-45 minutes'))
+      `).run("test-squad--mid", "test-squad", "/tmp/wt4", "test-squad/instance/mid");
+
+      const stale = findStaleInstances(30 * 60_000);
+      assert.strictEqual(stale.length, 1);
+      assert.ok(stale[0].idleMs >= 44 * 60_000);
+      assert.ok(stale[0].idleMs <= 46 * 60_000);
+    });
+  });
+
+  describe("startInstanceWatchdog", () => {
+    it("calls onAbort for stale instances and stops cleanly", async () => {
+      const db = getDb();
+      db.prepare(`
+        INSERT INTO squad_instances (id, master_squad_slug, worktree_path, branch_name, status, created_at)
+        VALUES (?, ?, ?, ?, 'active', datetime('now', '-60 minutes'))
+      `).run("test-squad--stale", "test-squad", "/tmp/wt5", "test-squad/instance/stale");
+
+      const aborted: string[] = [];
+      const stop = startInstanceWatchdog({
+        checkIntervalMs: 50,
+        staleThresholdMs: 30 * 60_000,
+        onAbort: (inst) => aborted.push(inst.id),
+      });
+
+      // Wait for at least one interval to fire
+      await new Promise((r) => setTimeout(r, 150));
+      stop();
+
+      assert.ok(aborted.includes("test-squad--stale"));
+
+      // Verify it was marked failed
+      const row = db.prepare("SELECT status FROM squad_instances WHERE id = ?").get("test-squad--stale") as { status: string };
+      assert.strictEqual(row.status, "failed");
+    });
+
+    it("stop function prevents further checks", async () => {
+      const db = getDb();
+      db.prepare(`
+        INSERT INTO squad_instances (id, master_squad_slug, worktree_path, branch_name, status, created_at)
+        VALUES (?, ?, ?, ?, 'active', datetime('now', '-60 minutes'))
+      `).run("test-squad--late", "test-squad", "/tmp/wt6", "test-squad/instance/late");
+
+      let abortCount = 0;
+      const stop = startInstanceWatchdog({
+        checkIntervalMs: 50,
+        staleThresholdMs: 30 * 60_000,
+        onAbort: () => abortCount++,
+      });
+
+      stop(); // Stop immediately before any tick fires
+
+      await new Promise((r) => setTimeout(r, 150));
+      // Instance should NOT have been aborted since we stopped before first tick
+      assert.strictEqual(abortCount, 0);
+    });
+  });
+});

--- a/src/instance-watchdog.ts
+++ b/src/instance-watchdog.ts
@@ -1,0 +1,95 @@
+/**
+ * Instance liveness watchdog.
+ *
+ * Periodically checks for active squad instances that haven't had any
+ * task activity beyond a configurable timeout and auto-aborts them.
+ */
+
+import { getDb } from "./store/db.js";
+import { updateInstanceStatus, type SquadInstance } from "./store/instances.js";
+import { createFeedEntry } from "./store/feed.js";
+
+const DEFAULT_CHECK_INTERVAL_MS = 5 * 60_000;  // Check every 5 minutes
+const DEFAULT_STALE_THRESHOLD_MS = 30 * 60_000; // 30 minutes with no task activity
+
+export interface InstanceWatchdogOptions {
+  checkIntervalMs?: number;
+  staleThresholdMs?: number;
+  onAbort?: (instance: SquadInstance, idleMs: number) => void;
+}
+
+/**
+ * Find active instances whose last task activity exceeds the threshold.
+ * "Activity" is defined as the most recent started_at or completed_at
+ * in agent_tasks for that instance, or the instance's created_at if no tasks.
+ */
+export function findStaleInstances(thresholdMs: number): Array<{ instance: SquadInstance; idleMs: number }> {
+  const db = getDb();
+  const now = Date.now();
+
+  const activeInstances = db.prepare(
+    "SELECT * FROM squad_instances WHERE status = 'active'"
+  ).all() as SquadInstance[];
+
+  const stale: Array<{ instance: SquadInstance; idleMs: number }> = [];
+
+  for (const instance of activeInstances) {
+    // Find the most recent task activity for this instance
+    const lastActivity = db.prepare(`
+      SELECT MAX(COALESCE(completed_at, started_at)) AS last_ts
+      FROM agent_tasks
+      WHERE instance_id = ?
+    `).get(instance.id) as { last_ts: string | null } | undefined;
+
+    const rawTs = lastActivity?.last_ts ?? instance.created_at;
+    const lastTs = new Date(rawTs.includes("T") ? rawTs : rawTs + "Z").getTime();
+    const idleMs = now - lastTs;
+
+    if (idleMs >= thresholdMs) {
+      stale.push({ instance, idleMs });
+    }
+  }
+
+  return stale;
+}
+
+/**
+ * Start the instance watchdog. Returns a stop function.
+ */
+export function startInstanceWatchdog(opts: InstanceWatchdogOptions = {}): () => void {
+  const checkInterval = opts.checkIntervalMs ?? DEFAULT_CHECK_INTERVAL_MS;
+  const staleThreshold = opts.staleThresholdMs ?? DEFAULT_STALE_THRESHOLD_MS;
+
+  const timer = setInterval(() => {
+    try {
+      const staleInstances = findStaleInstances(staleThreshold);
+
+      for (const { instance, idleMs } of staleInstances) {
+        console.error(
+          `[instance-watchdog] Auto-aborting stale instance "${instance.id}" — idle for ${Math.round(idleMs / 60_000)}m (threshold: ${Math.round(staleThreshold / 60_000)}m)`
+        );
+
+        updateInstanceStatus(instance.id, "failed");
+
+        createFeedEntry({
+          type: "notification",
+          title: `[${instance.master_squad_slug}] Instance auto-aborted`,
+          body: `Instance "${instance.id}" was auto-aborted after ${Math.round(idleMs / 60_000)} minutes of inactivity. Worktree preserved at: ${instance.worktree_path}`,
+          source_type: "instance-watchdog",
+        });
+
+        if (opts.onAbort) {
+          opts.onAbort(instance, idleMs);
+        }
+      }
+    } catch (err) {
+      console.error("[instance-watchdog] Error during check:", err);
+    }
+  }, checkInterval);
+
+  timer.unref();
+
+  return () => {
+    clearInterval(timer);
+  };
+}


### PR DESCRIPTION
## Summary

Phase 4 (final) of #231 — Detects and auto-aborts stuck squad instances.

## Changes

### New: `src/instance-watchdog.ts`
- setInterval-based watchdog (5-min check interval, `.unref()`'d)
- Finds active instances where last task activity exceeds 30 minutes
- Auto-aborts stale instances and posts a feed notification
- Overridable callbacks for testing (`onAbort`)
- Exported `findStaleInstances()` for unit testing

### New: `src/instance-watchdog.test.ts`
- 6 tests: stale detection, recent activity exclusion, non-active exclusion, timing accuracy, stop/cleanup

### Modified: `src/copilot/orchestrator.ts`
- Imports and starts instance watchdog on `initOrchestrator()`

## Design
- Mirrors the existing `src/watchdog.ts` pattern (setInterval + .unref + callbacks)
- "Activity" = most recent `started_at` or `completed_at` in `agent_tasks` for that instance, falling back to `created_at`
- Stale threshold: 30 minutes (configurable via options)
- Feed notification tags: `source_type: "instance-watchdog"` for traceability

## Completes #231
All 4 phases now merged:
- Phase 1: Schema, store, worktrees, tools ✅
- Phase 2: Instance threading ✅
- Phase 3: Vue UI ✅
- Phase 4: Watchdog ✅

182 tests pass, CI green.