### PR TITLE
feat(web): animate chat overlay during active response (#234)

### DIFF
--- a/web/src/components/FloatingChat.vue
+++ b/web/src/components/FloatingChat.vue
@@ -128,6 +128,15 @@
         v-if="hasUnread"
         class="absolute top-0 right-0 w-3 h-3 rounded-full bg-accent border-2 border-surface-2 shadow-glow-sm"
       ></span>
+      <!-- Activity pulse ring (visible when IO is thinking) -->
+      <span
+        v-if="store.isLoading"
+        class="absolute inset-0 rounded-full border-2 border-accent/60 animate-ping pointer-events-none"
+      ></span>
+      <span
+        v-if="store.isLoading"
+        class="absolute inset-0 rounded-full border border-accent/30 animate-pulse pointer-events-none"
+      ></span>
     </button>
   </div>
 </template>


### PR DESCRIPTION
Adds a pulsing ring animation to the collapsed floating chat bubble when IO is processing a response. Uses Tailwind `animate-ping` + `animate-pulse` — CSS-only, no JS overhead.

- Animation visible only when overlay is collapsed AND `isLoading` is true
- Stops immediately when response completes
- `pointer-events-none` so click target is unaffected

Closes #234