### PR TITLE
fix: add ordering tiebreaker to getDecisions query (#248)

### DIFF
--- a/src/store/squads.ts
+++ b/src/store/squads.ts
@@ -267,7 +267,7 @@ export function getDecisions(
 ): SquadDecision[] {
   return getDb()
     .prepare(
-      "SELECT * FROM squad_decisions WHERE squad_slug = ? ORDER BY created_at DESC LIMIT ?",
+      "SELECT * FROM squad_decisions WHERE squad_slug = ? ORDER BY created_at DESC, id DESC LIMIT ?",
     )
     .all(squadSlug, limit) as SquadDecision[];
 }


### PR DESCRIPTION
Fixes #248.

Adds `, id DESC` tiebreaker to `ORDER BY created_at DESC` in `getDecisions()` so two decisions inserted within the same second have deterministic order. Affects `buildContextSnapshot()` and `getDecisionsSummary()`.

All 227 tests pass, `tsc --noEmit` clean.