### PR TITLE
fix(web): close blockquote before starting list (#253)

### DIFF
--- a/web/src/lib/markdown.test.ts
+++ b/web/src/lib/markdown.test.ts
@@ -208,6 +208,29 @@ describe('renderMarkdown — blockquotes', () => {
     contains(html, '<blockquote ')
     contains(html, '</blockquote>')
   })
+
+  it('closes blockquote before unordered list with no blank line (regression #253)', () => {
+    const html = renderMarkdown('> quoted\n- item one\n- item two')
+    contains(html, '<blockquote ')
+    contains(html, '</blockquote>')
+    contains(html, '<ul ')
+    contains(html, '</ul>')
+    // blockquote must close before the list opens
+    const bqClose = html.indexOf('</blockquote>')
+    const ulOpen = html.indexOf('<ul ')
+    assert.ok(bqClose < ulOpen, 'blockquote must close before <ul> opens')
+  })
+
+  it('closes blockquote before ordered list with no blank line (regression #253)', () => {
+    const html = renderMarkdown('> quoted\n1. first\n2. second')
+    contains(html, '<blockquote ')
+    contains(html, '</blockquote>')
+    contains(html, '<ol ')
+    contains(html, '</ol>')
+    const bqClose = html.indexOf('</blockquote>')
+    const olOpen = html.indexOf('<ol ')
+    assert.ok(bqClose < olOpen, 'blockquote must close before <ol> opens')
+  })
 })
 
 // ── unordered lists ───────────────────────────────────────────────────────────

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -243,6 +243,7 @@ export function renderMarkdown(md: string): string {
     const li = line.match(/^[-*+]\s+(.+)/)
     if (li) {
       if (listType === 'ol') closeList()
+      closeBlockquote()
       if (!listType) { out.push('<ul class="list-disc list-inside my-2 space-y-1 pl-2">'); listType = 'ul' }
       out.push(`<li>${inlineFormat(li[1])}</li>`)
       continue
@@ -252,6 +253,7 @@ export function renderMarkdown(md: string): string {
     const oli = line.match(/^\d+\.\s+(.+)/)
     if (oli) {
       if (listType === 'ul') closeList()
+      closeBlockquote()
       if (!listType) { out.push('<ol class="list-decimal list-inside my-2 space-y-1 pl-2">'); listType = 'ol' }
       out.push(`<li>${inlineFormat(oli[1])}</li>`)
       continue


### PR DESCRIPTION
Fixes #253.

Adds `closeBlockquote()` calls in the UL and OL list-item handlers so a list immediately following a blockquote (no blank line) renders as a sibling element, not nested inside the blockquote.

This mirrors the existing cross-list-type transition pattern (`closeList()` when switching between ul/ol).

**Tests:** 2 new regression tests — blockquote→ul and blockquote→ol without blank line. All 49 tests pass.