### PR TITLE
fix(web): restore list indentation and numbering in wiki-content (#256)

### DIFF
--- a/web/src/components/FloatingChat.vue
+++ b/web/src/components/FloatingChat.vue
@@ -305,4 +305,7 @@ async function sendMessage() {
 .floating-chat-md :deep(code) { font-family: 'JetBrains Mono', monospace; }
 .floating-chat-md :deep(a) { color: #22d3ee; }
 .floating-chat-md :deep(a:hover) { text-decoration: underline; }
+.floating-chat-md :deep(ol) { list-style-type: decimal; padding-left: 1.5em; margin: 0.5em 0; }
+.floating-chat-md :deep(ul) { list-style-type: disc; padding-left: 1.5em; margin: 0.5em 0; }
+.floating-chat-md :deep(li) { margin: 0.25em 0; }
 </style>

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -110,3 +110,20 @@ body {
     box-shadow: inset 0 1px 0 rgba(34, 211, 238, 0.04), inset 0 -1px 0 rgba(0, 0, 0, 0.2);
   }
 }
+
+/* ── wiki-content markdown list styles ────────── */
+/* Tailwind preflight resets list-style and padding; restore them for rendered markdown */
+
+.wiki-content ol {
+  list-style-type: decimal;
+  padding-left: 1.5em;
+  margin: 0.5em 0;
+}
+.wiki-content ul {
+  list-style-type: disc;
+  padding-left: 1.5em;
+  margin: 0.5em 0;
+}
+.wiki-content li {
+  margin: 0.25em 0;
+}


### PR DESCRIPTION
Fixes #256.

Tailwind preflight resets `list-style: none` and `padding: 0` on `ol`/`ul`, stripping numbering and indentation from rendered markdown lists.

**Changes:**
- Added `.wiki-content ol/ul/li` overrides in `web/src/style.css` (global, covers Feed, Inbox, Wiki, AgentActivity views)
- Added equivalent `.floating-chat-md :deep(ol/ul/li)` rules in `FloatingChat.vue` scoped styles

The markdown renderer already emits correct `<ol><li>` / `<ul><li>` structure (fixed in #241/#252) — this fix ensures the browser renders the native list markers and indentation.