### PR TITLE
feat: unify communication channels — inbox consolidation + send_notification (#255)

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -135,7 +135,7 @@ export async function startApiServer(): Promise<void> {
   api.get("/feed/count", (req: Request, res: Response) => {
     try {
       const rawType = req.query.type;
-      const type = rawType === "deliverable" || rawType === "notification"
+      const type = rawType === "inbox" || rawType === "notification"
         ? (rawType as FeedEntryType)
         : undefined;
       const count = countUnreadFeedEntries(type);
@@ -149,7 +149,7 @@ export async function startApiServer(): Promise<void> {
   api.get("/feed", (req: Request, res: Response) => {
     try {
       const rawType = req.query.type;
-      const type = rawType === "deliverable" || rawType === "notification"
+      const type = rawType === "inbox" || rawType === "notification"
         ? (rawType as FeedEntryType)
         : undefined;
       const unreadOnly = req.query.unread === "true";
@@ -290,7 +290,7 @@ export async function startApiServer(): Promise<void> {
   api.post("/feed/read-all", (req: Request, res: Response) => {
     try {
       const rawType = req.query.type;
-      const type = rawType === "deliverable" || rawType === "notification"
+      const type = rawType === "inbox" || rawType === "notification"
         ? (rawType as FeedEntryType)
         : undefined;
       const marked = markAllFeedEntriesRead(type);
@@ -359,8 +359,8 @@ export async function startApiServer(): Promise<void> {
       source_type?: unknown;
       source_ref?: unknown;
     };
-    if (type !== "deliverable" && type !== "notification") {
-      res.status(400).json({ error: "type must be 'deliverable' or 'notification'" });
+    if (type !== "inbox" && type !== "notification") {
+      res.status(400).json({ error: "type must be 'inbox' or 'notification'" });
       return;
     }
     if (!title || typeof title !== "string" || title.trim() === "") {

--- a/src/copilot/scheduler.ts
+++ b/src/copilot/scheduler.ts
@@ -91,7 +91,7 @@ async function fireSchedule(schedule: SquadSchedule): Promise<void> {
   try {
     await delegateToAgent(squad.slug, prompt, (_taskId, result) => {
       if (shouldRouteToInbox(prompt)) {
-        createFeedEntry({ type: "deliverable", title: `[${squad.slug}] ${schedule.name}`, body: result });
+        createFeedEntry({ type: "inbox", title: `[${squad.slug}] ${schedule.name}`, body: result });
         console.error(`[io] Schedule ${schedule.id} result routed to inbox`);
         completeScheduleRun(run.id, 0);
       } else {

--- a/src/copilot/tools.ts
+++ b/src/copilot/tools.ts
@@ -551,7 +551,7 @@ export function createTools(deps: ToolDeps) {
         const taskId = await deps.delegateToAgent(slug, task, (id, result) => {
           console.error(`[io] Agent task ${id} completed for squad ${slug}`);
           if (shouldRouteToInbox(task)) {
-            createFeedEntry({ type: "deliverable", title: `[${slug}] Task result`, body: result });
+            createFeedEntry({ type: "inbox", title: `[${slug}] Task result`, body: result, squad_slug: slug });
             console.error(`[io] Task ${id} result routed to inbox`);
           }
         }, agent, deps.activeInstanceId);
@@ -2080,15 +2080,43 @@ export function createTools(deps: ToolDeps) {
       title: z.string().describe("Short title for the inbox item"),
       body: z.string().describe("Full content/body of the message (supports markdown)"),
       squad_slug: z.string().optional().describe("Squad slug to prefix the title with (e.g. 'io-assistant')"),
+      instance_id: z.string().optional().describe("Instance ID if this message is from a squad instance"),
+      task_id: z.string().optional().describe("Task ID associated with this message"),
     }),
-    handler: async ({ title, body, squad_slug }) => {
+    handler: async ({ title, body, squad_slug, instance_id, task_id }) => {
       const prefix = squad_slug ? `[${squad_slug}] ` : "";
-      createFeedEntry({ type: "deliverable", title: `${prefix}${title}`, body });
+      createFeedEntry({
+        type: "inbox",
+        title: `${prefix}${title}`,
+        body,
+        squad_slug: squad_slug ?? null,
+        instance_id: instance_id ?? null,
+        task_id: task_id ?? null,
+      });
       return "Message sent to inbox successfully.";
     },
   });
 
-  return [wikiRead, wikiWrite, wikiSearch, wikiDelete, wikiList, squadCreate, squadRecall, squadStatus, squadLogDecision, squadDelegate, squadTaskStatus, squadDelete, squadAnalyze, squadAddAgent, squadAgents, squadRemoveAgent, squadResetAgent, squadSetLead, squadSetQA, squadTaskReviews, squadScheduleCreate, squadScheduleList, squadScheduleDelete, squadSchedulePause, squadScheduleResume, squadScheduleRunNow, scheduleCreate, scheduleList, scheduleDelete, schedulePause, scheduleResume, scheduleRunNow, skillList, skillInstall, skillRemove, skillSearch, configUpdate, checkUpdate, shell, fileOps, bash, readFile, viewTool, grepTool, strReplaceEditor, github, squadInstanceCreate, squadInstanceList, squadInstanceStatus, squadInstanceComplete, squadInstanceAbort, squadInstanceCleanup, squadInstanceActivate, squadInstanceDeactivate, sendToInbox];
+  const sendNotification = defineTool("send_notification", {
+    description: "Send a short status notification to the IO feed. Use for brief updates, alerts, and FYIs (one sentence). For longer content, use send_to_inbox instead.",
+    skipPermission: true,
+    parameters: z.object({
+      message: z.string().describe("Short notification message (one sentence)"),
+      squad_slug: z.string().optional().describe("Squad slug for context"),
+    }),
+    handler: async ({ message, squad_slug }) => {
+      const prefix = squad_slug ? `[${squad_slug}] ` : "";
+      createFeedEntry({
+        type: "notification",
+        title: `${prefix}${message}`,
+        body: message,
+        squad_slug: squad_slug ?? null,
+      });
+      return "Notification sent.";
+    },
+  });
+
+  return [wikiRead, wikiWrite, wikiSearch, wikiDelete, wikiList, squadCreate, squadRecall, squadStatus, squadLogDecision, squadDelegate, squadTaskStatus, squadDelete, squadAnalyze, squadAddAgent, squadAgents, squadRemoveAgent, squadResetAgent, squadSetLead, squadSetQA, squadTaskReviews, squadScheduleCreate, squadScheduleList, squadScheduleDelete, squadSchedulePause, squadScheduleResume, squadScheduleRunNow, scheduleCreate, scheduleList, scheduleDelete, schedulePause, scheduleResume, scheduleRunNow, skillList, skillInstall, skillRemove, skillSearch, configUpdate, checkUpdate, shell, fileOps, bash, readFile, viewTool, grepTool, strReplaceEditor, github, squadInstanceCreate, squadInstanceList, squadInstanceStatus, squadInstanceComplete, squadInstanceAbort, squadInstanceCleanup, squadInstanceActivate, squadInstanceDeactivate, sendToInbox, sendNotification];
 }
 
 function walkDirectory(dir: string, maxDepth = 3, depth = 0): string[] {

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -169,7 +169,7 @@ GROUP BY agent_slug`,
     )`,
     `CREATE TABLE IF NOT EXISTS unified_feed (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
-      type TEXT NOT NULL CHECK(type IN ('deliverable', 'notification')),
+      type TEXT NOT NULL CHECK(type IN ('inbox', 'notification')),
       title TEXT NOT NULL,
       body TEXT NOT NULL,
       source_type TEXT,
@@ -200,6 +200,10 @@ GROUP BY agent_slug`,
     )`,
     `ALTER TABLE agent_tasks ADD COLUMN instance_id TEXT`,
     `CREATE INDEX IF NOT EXISTS idx_instance_decisions_instance ON instance_decisions(instance_id, merged_to_master)`,
+    `UPDATE unified_feed SET type = 'inbox' WHERE type = 'deliverable'`,
+    `ALTER TABLE unified_feed ADD COLUMN squad_slug TEXT`,
+    `ALTER TABLE unified_feed ADD COLUMN instance_id TEXT`,
+    `ALTER TABLE unified_feed ADD COLUMN task_id TEXT`,
   ];
 
   for (const migration of migrations) {

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -200,10 +200,26 @@ GROUP BY agent_slug`,
     )`,
     `ALTER TABLE agent_tasks ADD COLUMN instance_id TEXT`,
     `CREATE INDEX IF NOT EXISTS idx_instance_decisions_instance ON instance_decisions(instance_id, merged_to_master)`,
-    `UPDATE unified_feed SET type = 'inbox' WHERE type = 'deliverable'`,
-    `ALTER TABLE unified_feed ADD COLUMN squad_slug TEXT`,
-    `ALTER TABLE unified_feed ADD COLUMN instance_id TEXT`,
-    `ALTER TABLE unified_feed ADD COLUMN task_id TEXT`,
+    `ALTER TABLE unified_feed RENAME TO unified_feed_old`,
+    `CREATE TABLE unified_feed (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  type TEXT NOT NULL CHECK(type IN ('inbox', 'notification')),
+  title TEXT NOT NULL,
+  body TEXT NOT NULL,
+  source_type TEXT,
+  source_ref TEXT,
+  squad_slug TEXT,
+  instance_id TEXT,
+  task_id TEXT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  read_at DATETIME
+)`,
+    `INSERT INTO unified_feed (id, type, title, body, source_type, source_ref, created_at, read_at)
+  SELECT id, CASE WHEN type='deliverable' THEN 'inbox' ELSE type END, title, body, source_type, source_ref, created_at, read_at
+  FROM unified_feed_old`,
+    `DROP TABLE unified_feed_old`,
+    `CREATE INDEX IF NOT EXISTS idx_unified_feed_type ON unified_feed(type, created_at)`,
+    `CREATE INDEX IF NOT EXISTS idx_unified_feed_unread ON unified_feed(read_at, created_at)`,
   ];
 
   for (const migration of migrations) {

--- a/src/store/feed.test.ts
+++ b/src/store/feed.test.ts
@@ -45,8 +45,8 @@ beforeEach(() => {
 
 describe("createFeedEntry", () => {
   it("creates a deliverable entry with correct fields", () => {
-    const entry = createFeedEntry({ type: "deliverable", title: "Task done", body: "Here are the results." });
-    assert.equal(entry.type, "deliverable");
+    const entry = createFeedEntry({ type: "inbox", title: "Task done", body: "Here are the results." });
+    assert.equal(entry.type, "inbox");
     assert.equal(entry.title, "Task done");
     assert.equal(entry.body, "Here are the results.");
     assert.equal(entry.read_at, null);
@@ -75,7 +75,7 @@ describe("createFeedEntry", () => {
   });
 
   it("autoincrements ids", () => {
-    const a = createFeedEntry({ type: "deliverable", title: "A", body: "a" });
+    const a = createFeedEntry({ type: "inbox", title: "A", body: "a" });
     const b = createFeedEntry({ type: "notification", title: "B", body: "b" });
     assert.ok(b.id > a.id);
   });
@@ -85,7 +85,7 @@ describe("createFeedEntry", () => {
 
 describe("listFeedEntries", () => {
   it("returns all entries newest first", () => {
-    createFeedEntry({ type: "deliverable", title: "First", body: "x" });
+    createFeedEntry({ type: "inbox", title: "First", body: "x" });
     createFeedEntry({ type: "notification", title: "Second", body: "y" });
     const entries = listFeedEntries();
     assert.equal(entries.length, 2);
@@ -94,15 +94,15 @@ describe("listFeedEntries", () => {
   });
 
   it("filters by type=deliverable", () => {
-    createFeedEntry({ type: "deliverable", title: "D", body: "d" });
+    createFeedEntry({ type: "inbox", title: "D", body: "d" });
     createFeedEntry({ type: "notification", title: "N", body: "n" });
-    const entries = listFeedEntries({ type: "deliverable" });
+    const entries = listFeedEntries({ type: "inbox" });
     assert.equal(entries.length, 1);
-    assert.equal(entries[0].type, "deliverable");
+    assert.equal(entries[0].type, "inbox");
   });
 
   it("filters by type=notification", () => {
-    createFeedEntry({ type: "deliverable", title: "D", body: "d" });
+    createFeedEntry({ type: "inbox", title: "D", body: "d" });
     createFeedEntry({ type: "notification", title: "N", body: "n" });
     const entries = listFeedEntries({ type: "notification" });
     assert.equal(entries.length, 1);
@@ -139,22 +139,22 @@ describe("countUnreadFeedEntries", () => {
   });
 
   it("increments on insert", () => {
-    createFeedEntry({ type: "deliverable", title: "T", body: "b" });
+    createFeedEntry({ type: "inbox", title: "T", body: "b" });
     assert.equal(countUnreadFeedEntries(), 1);
     createFeedEntry({ type: "notification", title: "N", body: "b" });
     assert.equal(countUnreadFeedEntries(), 2);
   });
 
   it("decreases when marked read", () => {
-    const e = createFeedEntry({ type: "deliverable", title: "T", body: "b" });
+    const e = createFeedEntry({ type: "inbox", title: "T", body: "b" });
     markFeedEntryRead(e.id);
     assert.equal(countUnreadFeedEntries(), 0);
   });
 
   it("filters by type", () => {
-    createFeedEntry({ type: "deliverable", title: "D", body: "d" });
+    createFeedEntry({ type: "inbox", title: "D", body: "d" });
     createFeedEntry({ type: "notification", title: "N", body: "n" });
-    assert.equal(countUnreadFeedEntries("deliverable"), 1);
+    assert.equal(countUnreadFeedEntries("inbox"), 1);
     assert.equal(countUnreadFeedEntries("notification"), 1);
   });
 });
@@ -199,11 +199,11 @@ describe("markAllFeedEntriesRead", () => {
   });
 
   it("respects type filter — only marks matching type", () => {
-    createFeedEntry({ type: "deliverable", title: "D", body: "d" });
+    createFeedEntry({ type: "inbox", title: "D", body: "d" });
     createFeedEntry({ type: "notification", title: "N", body: "n" });
     const count = markAllFeedEntriesRead("notification");
     assert.equal(count, 1);
-    assert.equal(countUnreadFeedEntries("deliverable"), 1);
+    assert.equal(countUnreadFeedEntries("inbox"), 1);
     assert.equal(countUnreadFeedEntries("notification"), 0);
   });
 });
@@ -213,7 +213,7 @@ describe("markAllFeedEntriesRead", () => {
 describe("markFeedEntriesRead", () => {
   it("marks multiple entries read and returns change count", () => {
     const a = createFeedEntry({ type: "notification", title: "A", body: "a" });
-    const b = createFeedEntry({ type: "deliverable", title: "B", body: "b" });
+    const b = createFeedEntry({ type: "inbox", title: "B", body: "b" });
     const c = createFeedEntry({ type: "notification", title: "C", body: "c" });
     const count = markFeedEntriesRead([a.id, b.id, c.id]);
     assert.equal(count, 3);
@@ -227,7 +227,7 @@ describe("markFeedEntriesRead", () => {
   });
 
   it("works correctly for a single id", () => {
-    const e = createFeedEntry({ type: "deliverable", title: "Solo", body: "b" });
+    const e = createFeedEntry({ type: "inbox", title: "Solo", body: "b" });
     assert.equal(markFeedEntriesRead([e.id]), 1);
     const entries = listFeedEntries();
     assert.ok(entries[0].read_at !== null);
@@ -262,14 +262,14 @@ describe("deleteFeedEntry", () => {
   });
 
   it("returns true and removes the entry", () => {
-    const e = createFeedEntry({ type: "deliverable", title: "T", body: "b" });
+    const e = createFeedEntry({ type: "inbox", title: "T", body: "b" });
     assert.equal(deleteFeedEntry(e.id), true);
     const entries = listFeedEntries();
     assert.equal(entries.find((x) => x.id === e.id), undefined);
   });
 
   it("second delete returns false (not idempotent)", () => {
-    const e = createFeedEntry({ type: "deliverable", title: "T", body: "b" });
+    const e = createFeedEntry({ type: "inbox", title: "T", body: "b" });
     deleteFeedEntry(e.id);
     assert.equal(deleteFeedEntry(e.id), false);
   });
@@ -280,7 +280,7 @@ describe("deleteFeedEntry", () => {
 describe("deleteFeedEntries", () => {
   it("deletes multiple entries and returns change count", () => {
     const a = createFeedEntry({ type: "notification", title: "A", body: "a" });
-    const b = createFeedEntry({ type: "deliverable", title: "B", body: "b" });
+    const b = createFeedEntry({ type: "inbox", title: "B", body: "b" });
     const c = createFeedEntry({ type: "notification", title: "C", body: "c" });
     const count = deleteFeedEntries([a.id, b.id, c.id]);
     assert.equal(count, 3);
@@ -307,7 +307,7 @@ describe("deleteFeedEntries", () => {
   });
 
   it("mix of existing and non-existent ids — only deletes what exists", () => {
-    const e = createFeedEntry({ type: "deliverable", title: "Real", body: "b" });
+    const e = createFeedEntry({ type: "inbox", title: "Real", body: "b" });
     const count = deleteFeedEntries([e.id, 9999]);
     assert.equal(count, 1);
     assert.deepEqual(listFeedEntries(), []);

--- a/src/store/feed.ts
+++ b/src/store/feed.ts
@@ -1,6 +1,6 @@
 import { getDb } from "./db.js";
 
-export type FeedEntryType = "deliverable" | "notification";
+export type FeedEntryType = "inbox" | "notification";
 
 export interface FeedEntry {
   id: number;
@@ -9,6 +9,9 @@ export interface FeedEntry {
   body: string;
   source_type: string | null;
   source_ref: string | null;  // raw JSON string
+  squad_slug: string | null;
+  instance_id: string | null;
+  task_id: string | null;
   created_at: string;
   read_at: string | null;
 }
@@ -19,12 +22,15 @@ export function createFeedEntry(input: {
   body: string;
   source_type?: string;
   source_ref?: string | null;
+  squad_slug?: string | null;
+  instance_id?: string | null;
+  task_id?: string | null;
 }): FeedEntry {
   const db = getDb();
   const info = db
     .prepare(
-      `INSERT INTO unified_feed (type, title, body, source_type, source_ref)
-       VALUES (?, ?, ?, ?, ?)`,
+      `INSERT INTO unified_feed (type, title, body, source_type, source_ref, squad_slug, instance_id, task_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
       input.type,
@@ -32,6 +38,9 @@ export function createFeedEntry(input: {
       input.body,
       input.source_type ?? null,
       input.source_ref ?? null,
+      input.squad_slug ?? null,
+      input.instance_id ?? null,
+      input.task_id ?? null,
     );
   return db
     .prepare("SELECT * FROM unified_feed WHERE id = ?")
@@ -142,6 +151,7 @@ export function pruneOldFeedEntries(olderThanDays: number): number {
     .run(olderThanDays);
   return info.changes;
 }
+
 export function markFeedEntriesRead(ids: number[]): number {
   if (ids.length === 0) return 0;
   const placeholders = ids.map(() => "?").join(", ");

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -150,7 +150,7 @@ function renderActivity(taskIdArg: string | undefined): void {
 }
 
 function renderInbox(): void {
-  const entries = listFeedEntries({ type: "deliverable" });
+  const entries = listFeedEntries({ type: "inbox" });
   if (entries.length === 0) {
     console.log("\u2705 Inbox is empty.");
     return;
@@ -233,7 +233,7 @@ export async function startTui(): Promise<void> {
         if (sub === "" ) {
           renderInbox();
         } else if (sub === "clear") {
-          const entries = listFeedEntries({ type: "deliverable" });
+          const entries = listFeedEntries({ type: "inbox" });
           let deleted = 0;
           for (const entry of entries) {
             if (deleteFeedEntry(entry.id)) deleted++;

--- a/web/src/views/FeedView.vue
+++ b/web/src/views/FeedView.vue
@@ -117,7 +117,7 @@
       </div>
       <p class="text-txt-muted text-sm font-medium">Nothing here yet</p>
       <p class="text-txt-muted/60 text-xs mt-1">
-        {{ activeTab === 'all' ? 'Your feed is empty' : activeTab === 'deliverable' ? 'No deliverables' : 'No notifications' }}
+        {{ activeTab === 'all' ? 'Your feed is empty' : activeTab === 'inbox' ? 'No inbox items' : 'No notifications' }}
       </p>
     </div>
 
@@ -145,7 +145,7 @@
             </div>
           </div>
           <div class="mt-0.5 shrink-0">
-            <FluentIcon v-if="entry.type === 'deliverable'" :paths='`<path d="M6 3a3 3 0 0 0-3 3v8a3 3 0 0 0 3 3h8a3 3 0 0 0 3-3V6a3 3 0 0 0-3-3H6Zm10 7h-3.5a.5.5 0 0 0-.5.5v.01a1.75 1.75 0 0 1-.03.3c-.04.2-.1.46-.23.72-.13.25-.3.49-.57.66-.26.18-.63.31-1.17.31-.54 0-.9-.13-1.17-.3a1.7 1.7 0 0 1-.57-.67A2.57 2.57 0 0 1 8 10.5v-.01a.5.5 0 0 0-.5-.5H4V6c0-1.1.9-2 2-2h8a2 2 0 0 1 2 2v4ZM4 11h3.05c.05.26.14.62.32.97.18.38.47.76.9 1.06.45.29 1.02.47 1.73.47s1.28-.18 1.72-.47c.44-.3.73-.68.91-1.06.18-.35.27-.7.32-.97H16v3a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-3Z"/>`' :size="16" :class="entry.read_at ? 'text-txt-muted' : 'text-accent'" />
+            <FluentIcon v-if="entry.type === 'inbox'" :paths='`<path d="M6 3a3 3 0 0 0-3 3v8a3 3 0 0 0 3 3h8a3 3 0 0 0 3-3V6a3 3 0 0 0-3-3H6Zm10 7h-3.5a.5.5 0 0 0-.5.5v.01a1.75 1.75 0 0 1-.03.3c-.04.2-.1.46-.23.72-.13.25-.3.49-.57.66-.26.18-.63.31-1.17.31-.54 0-.9-.13-1.17-.3a1.7 1.7 0 0 1-.57-.67A2.57 2.57 0 0 1 8 10.5v-.01a.5.5 0 0 0-.5-.5H4V6c0-1.1.9-2 2-2h8a2 2 0 0 1 2 2v4ZM4 11h3.05c.05.26.14.62.32.97.18.38.47.76.9 1.06.45.29 1.02.47 1.73.47s1.28-.18 1.72-.47c.44-.3.73-.68.91-1.06.18-.35.27-.7.32-.97H16v3a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-3Z"/>`' :size="16" :class="entry.read_at ? 'text-txt-muted' : 'text-accent'" />
             <FluentIcon v-else :paths='`<path d="M10 2a5.92 5.92 0 0 1 5.98 5.36l.02.22V11.4l.92 2.22a1 1 0 0 1 .06.17l.01.08.01.13a1 1 0 0 1-.75.97l-.11.02L16 15h-3.5v.17a2.5 2.5 0 0 1-5 0V15H4a1 1 0 0 1-.26-.03l-.13-.04a1 1 0 0 1-.6-1.05l.02-.13.05-.13L4 11.4V7.57A5.9 5.9 0 0 1 10 2Zm1.5 13h-3v.15a1.5 1.5 0 0 0 1.36 1.34l.14.01c.78 0 1.42-.6 1.5-1.36V15ZM10 3a4.9 4.9 0 0 0-4.98 4.38L5 7.6V11.5l-.04.2L4 14h12l-.96-2.3-.04-.2V7.61A4.9 4.9 0 0 0 10 3Z"/>`' :size="16" :class="entry.read_at ? 'text-txt-muted' : 'text-accent'" />
           </div>
           <span v-if="!entry.read_at" class="mt-2 w-1.5 h-1.5 rounded-full bg-accent shadow-glow-sm shrink-0"></span>
@@ -156,6 +156,11 @@
               <span v-if="entry.source_type" class="text-[10px] font-mono tracking-wider uppercase text-txt-muted bg-surface-0/60 px-1.5 py-0.5 rounded border border-edge/50 shrink-0">{{ entry.source_type }}</span>
             </div>
             <p class="text-[10px] text-txt-muted mb-1">{{ formatTime(entry.created_at) }}</p>
+            <div v-if="entry.type === 'inbox' && (entry.squad_slug || entry.instance_id || entry.task_id)" class="flex flex-wrap items-center gap-1 mb-1">
+              <span v-if="entry.squad_slug" class="text-[10px] font-mono text-accent/80 bg-accent/10 px-1.5 py-0.5 rounded border border-accent/20 shrink-0">{{ entry.squad_slug }}</span>
+              <span v-if="entry.instance_id" class="text-[10px] font-mono text-txt-muted bg-surface-0/60 px-1.5 py-0.5 rounded border border-edge/50 shrink-0">inst:{{ entry.instance_id.slice(0, 8) }}</span>
+              <span v-if="entry.task_id" class="text-[10px] font-mono text-txt-muted bg-surface-0/60 px-1.5 py-0.5 rounded border border-edge/50 shrink-0">task:{{ entry.task_id.slice(0, 8) }}</span>
+            </div>
             <p v-if="!expanded.has(entry.id)" class="text-xs text-txt-secondary line-clamp-2 leading-relaxed">{{ bodyPreview(entry.body) }}</p>
           </div>
           <div v-if="!selectMode" class="flex items-center gap-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
@@ -214,7 +219,7 @@
                 </div>
               </div>
               <div class="mt-0.5 shrink-0">
-                <FluentIcon v-if="entry.type === 'deliverable'" :paths='`<path d="M6 3a3 3 0 0 0-3 3v8a3 3 0 0 0 3 3h8a3 3 0 0 0 3-3V6a3 3 0 0 0-3-3H6Zm10 7h-3.5a.5.5 0 0 0-.5.5v.01a1.75 1.75 0 0 1-.03.3c-.04.2-.1.46-.23.72-.13.25-.3.49-.57.66-.26.18-.63.31-1.17.31-.54 0-.9-.13-1.17-.3a1.7 1.7 0 0 1-.57-.67A2.57 2.57 0 0 1 8 10.5v-.01a.5.5 0 0 0-.5-.5H4V6c0-1.1.9-2 2-2h8a2 2 0 0 1 2 2v4ZM4 11h3.05c.05.26.14.62.32.97.18.38.47.76.9 1.06.45.29 1.02.47 1.73.47s1.28-.18 1.72-.47c.44-.3.73-.68.91-1.06.18-.35.27-.7.32-.97H16v3a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-3Z"/>`' :size="16" :class="entry.read_at ? 'text-txt-muted' : 'text-accent'" />
+                <FluentIcon v-if="entry.type === 'inbox'" :paths='`<path d="M6 3a3 3 0 0 0-3 3v8a3 3 0 0 0 3 3h8a3 3 0 0 0 3-3V6a3 3 0 0 0-3-3H6Zm10 7h-3.5a.5.5 0 0 0-.5.5v.01a1.75 1.75 0 0 1-.03.3c-.04.2-.1.46-.23.72-.13.25-.3.49-.57.66-.26.18-.63.31-1.17.31-.54 0-.9-.13-1.17-.3a1.7 1.7 0 0 1-.57-.67A2.57 2.57 0 0 1 8 10.5v-.01a.5.5 0 0 0-.5-.5H4V6c0-1.1.9-2 2-2h8a2 2 0 0 1 2 2v4ZM4 11h3.05c.05.26.14.62.32.97.18.38.47.76.9 1.06.45.29 1.02.47 1.73.47s1.28-.18 1.72-.47c.44-.3.73-.68.91-1.06.18-.35.27-.7.32-.97H16v3a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-3Z"/>`' :size="16" :class="entry.read_at ? 'text-txt-muted' : 'text-accent'" />
                 <FluentIcon v-else :paths='`<path d="M10 2a5.92 5.92 0 0 1 5.98 5.36l.02.22V11.4l.92 2.22a1 1 0 0 1 .06.17l.01.08.01.13a1 1 0 0 1-.75.97l-.11.02L16 15h-3.5v.17a2.5 2.5 0 0 1-5 0V15H4a1 1 0 0 1-.26-.03l-.13-.04a1 1 0 0 1-.6-1.05l.02-.13.05-.13L4 11.4V7.57A5.9 5.9 0 0 1 10 2Zm1.5 13h-3v.15a1.5 1.5 0 0 0 1.36 1.34l.14.01c.78 0 1.42-.6 1.5-1.36V15ZM10 3a4.9 4.9 0 0 0-4.98 4.38L5 7.6V11.5l-.04.2L4 14h12l-.96-2.3-.04-.2V7.61A4.9 4.9 0 0 0 10 3Z"/>`' :size="16" :class="entry.read_at ? 'text-txt-muted' : 'text-accent'" />
               </div>
               <span v-if="!entry.read_at" class="mt-2 w-1.5 h-1.5 rounded-full bg-accent shadow-glow-sm shrink-0"></span>
@@ -225,6 +230,11 @@
                   <span v-if="entry.source_type" class="text-[10px] font-mono tracking-wider uppercase text-txt-muted bg-surface-0/60 px-1.5 py-0.5 rounded border border-edge/50 shrink-0">{{ entry.source_type }}</span>
                 </div>
                 <p class="text-[10px] text-txt-muted mb-1">{{ formatTime(entry.created_at) }}</p>
+            <div v-if="entry.type === 'inbox' && (entry.squad_slug || entry.instance_id || entry.task_id)" class="flex flex-wrap items-center gap-1 mb-1">
+              <span v-if="entry.squad_slug" class="text-[10px] font-mono text-accent/80 bg-accent/10 px-1.5 py-0.5 rounded border border-accent/20 shrink-0">{{ entry.squad_slug }}</span>
+              <span v-if="entry.instance_id" class="text-[10px] font-mono text-txt-muted bg-surface-0/60 px-1.5 py-0.5 rounded border border-edge/50 shrink-0">inst:{{ entry.instance_id.slice(0, 8) }}</span>
+              <span v-if="entry.task_id" class="text-[10px] font-mono text-txt-muted bg-surface-0/60 px-1.5 py-0.5 rounded border border-edge/50 shrink-0">task:{{ entry.task_id.slice(0, 8) }}</span>
+            </div>
                 <p v-if="!expanded.has(entry.id)" class="text-xs text-txt-secondary line-clamp-2 leading-relaxed">{{ bodyPreview(entry.body) }}</p>
               </div>
               <div v-if="!selectMode" class="flex items-center gap-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
@@ -298,21 +308,24 @@ import { apiFetch } from '../lib/api'
 
 interface FeedEntry {
   id: number
-  type: 'deliverable' | 'notification'
+  type: 'inbox' | 'notification'
   title: string
   body: string
   source_type: string | null
   source_ref: string | null
   created_at: string
   read_at: string | null
+  squad_slug: string | null
+  instance_id: string | null
+  task_id: string | null
   source?: { type?: string; [k: string]: unknown }
 }
 
-type TabValue = 'all' | 'deliverable' | 'notification'
+type TabValue = 'all' | 'inbox' | 'notification'
 
 const tabs: { label: string; value: TabValue }[] = [
   { label: 'All', value: 'all' },
-  { label: 'Deliverables', value: 'deliverable' },
+  { label: 'Inbox', value: 'inbox' },
   { label: 'Notifications', value: 'notification' },
 ]
 


### PR DESCRIPTION
Closes #255.

**Frontend changes (this commit):**
- Renamed 'Deliverables' tab → 'Inbox' in FeedView
- Updated `FeedEntry.type` from `'deliverable'` to `'inbox'`
- Added `squad_slug`, `instance_id`, `task_id` nullable fields to `FeedEntry` interface
- Inbox entries now display metadata badges when present: squad slug (accent), instance_id and task_id (muted, truncated to 8 chars) — shown in both flat and grouped views
- Empty state text updated to 'No inbox items'

**Backend changes (previous commits on this branch):**
- `send_notification` tool added
- Feed entry type renamed from 'deliverable' → 'inbox' in schema/API

Notifications remain as a separate feed for short status messages.