### PR TITLE
fix: separate feed and inbox views to use correct unified_feed types

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -17,7 +17,7 @@ import { listSchedules, getSchedule, deleteSchedule, setScheduleEnabled } from "
 import { listIoSchedules, getIoSchedule, deleteIoSchedule, setIoScheduleEnabled } from "../store/io-schedules.js";
 import { getScheduleRuns } from "../store/schedule-runs.js";
 import { createFeedEntry, listFeedEntries, listFeedSquads, countUnreadFeedEntries, markFeedEntryRead, markAllFeedEntriesRead, deleteFeedEntry, markFeedEntriesRead, deleteFeedEntries, type FeedEntryType } from "../store/feed.js";
-import { listInboxEntries, countInboxEntries, deleteInboxEntry } from "../store/inbox.js";
+
 import { listPages, readPage } from "../wiki/fs.js";
 import { runScheduleNow } from "../copilot/scheduler.js";
 import { runIoScheduleNow } from "../copilot/io-scheduler.js";
@@ -410,7 +410,7 @@ export async function startApiServer(): Promise<void> {
   // Inbox endpoints
   api.get("/inbox/count", (_req: Request, res: Response) => {
     try {
-      const count = countInboxEntries();
+      const count = countUnreadFeedEntries("inbox");
       res.json({ count });
     } catch (e) {
       console.error("Error counting inbox entries:", e);
@@ -420,7 +420,7 @@ export async function startApiServer(): Promise<void> {
 
   api.get("/inbox", (_req: Request, res: Response) => {
     try {
-      const entries = listInboxEntries();
+      const entries = listFeedEntries({ type: "inbox" });
       res.json({ entries });
     } catch (e) {
       console.error("Error listing inbox entries:", e);
@@ -436,7 +436,7 @@ export async function startApiServer(): Promise<void> {
       return;
     }
     try {
-      const deleted = deleteInboxEntry(id);
+      const deleted = deleteFeedEntry(id);
       if (!deleted) {
         res.status(404).json({ error: "Inbox entry not found" });
         return;

--- a/web/src/views/FeedView.vue
+++ b/web/src/views/FeedView.vue
@@ -64,24 +64,8 @@
       </button>
     </div>
 
-    <!-- Filter tabs + Group-by-team toggle -->
-    <div class="flex gap-1.5 mb-4 p-1 bg-surface-2/50 rounded-xl border border-edge">
-      <button
-        v-for="tab in tabs"
-        :key="tab.value"
-        @click="activeTab = tab.value"
-        class="flex-1 text-xs font-medium py-1.5 px-3 rounded-lg transition-all duration-150"
-        :class="activeTab === tab.value
-          ? 'bg-accent/10 text-accent border border-accent/20'
-          : 'text-txt-muted hover:text-txt-secondary hover:bg-surface-3/50 border border-transparent'"
-      >
-        {{ tab.label }}
-        <span
-          v-if="tab.value !== 'all' && tabCount(tab.value) > 0"
-          class="ml-1 font-mono text-[10px] opacity-70"
-        >({{ tabCount(tab.value) }})</span>
-      </button>
-      <!-- Group by team toggle -->
+    <!-- Group-by-team toggle -->
+    <div class="flex gap-1.5 mb-4">
       <button
         @click="groupByTeam = !groupByTeam"
         class="flex items-center gap-1.5 text-xs font-medium py-1.5 px-3 rounded-lg transition-all duration-150 shrink-0"
@@ -117,7 +101,7 @@
       </div>
       <p class="text-txt-muted text-sm font-medium">Nothing here yet</p>
       <p class="text-txt-muted/60 text-xs mt-1">
-        {{ activeTab === 'all' ? 'Your feed is empty' : activeTab === 'inbox' ? 'No inbox items' : 'No notifications' }}
+        No notifications
       </p>
     </div>
 
@@ -321,17 +305,8 @@ interface FeedEntry {
   source?: { type?: string; [k: string]: unknown }
 }
 
-type TabValue = 'all' | 'inbox' | 'notification'
-
-const tabs: { label: string; value: TabValue }[] = [
-  { label: 'All', value: 'all' },
-  { label: 'Inbox', value: 'inbox' },
-  { label: 'Notifications', value: 'notification' },
-]
-
 const entries = ref<FeedEntry[]>([])
 const loading = ref(true)
-const activeTab = ref<TabValue>('all')
 const expanded = ref(new Set<number>())
 const deleting = ref(new Set<number>())
 const errorMsg = ref<string | null>(null)
@@ -356,8 +331,7 @@ function extractSquad(title: string): string | null {
 }
 
 const filtered = computed(() => {
-  if (activeTab.value === 'all') return entries.value
-  return entries.value.filter(e => e.type === activeTab.value)
+  return entries.value
 })
 
 const groupedEntries = computed(() => {
@@ -382,10 +356,6 @@ const groupedEntries = computed(() => {
 const allSelected = computed(() =>
   filtered.value.length > 0 && filtered.value.every(e => selected.value.has(e.id))
 )
-
-function tabCount(type: TabValue): number {
-  return entries.value.filter(e => e.type === type).length
-}
 
 function formatTime(ts: string): string {
   try {
@@ -436,7 +406,7 @@ async function loadEntries(search?: string) {
   loading.value = true
   errorMsg.value = null
   try {
-    const params = new URLSearchParams({ limit: '100' })
+    const params = new URLSearchParams({ limit: '100', type: 'notification' })
     if (search) params.set('search', search)
     const res = await apiFetch(`/api/feed?${params}`)
     if (res.ok) {
@@ -456,12 +426,11 @@ async function markRead(id: number) {
 }
 
 async function markAllRead() {
-  const typeParam = activeTab.value !== 'all' ? `?type=${activeTab.value}` : ''
   try {
-    await apiFetch(`/api/feed/read-all${typeParam}`, { method: 'POST' })
+    await apiFetch('/api/feed/read-all?type=notification', { method: 'POST' })
     const now = new Date().toISOString()
     for (const e of entries.value) {
-      if (!e.read_at && (activeTab.value === 'all' || e.type === activeTab.value)) {
+      if (!e.read_at) {
         e.read_at = now
       }
     }

--- a/web/src/views/InboxView.vue
+++ b/web/src/views/InboxView.vue
@@ -56,6 +56,11 @@
             </button>
           </div>
         </div>
+        <div v-if="entry.squad_slug || entry.instance_id || entry.task_id" class="flex flex-wrap items-center gap-1 mt-1.5 mb-1">
+          <span v-if="entry.squad_slug" class="text-[10px] font-mono text-accent/80 bg-accent/10 px-1.5 py-0.5 rounded border border-accent/20">{{ entry.squad_slug }}</span>
+          <span v-if="entry.instance_id" class="text-[10px] font-mono text-txt-muted bg-surface-0/60 px-1.5 py-0.5 rounded border border-edge/50">inst:{{ entry.instance_id }}</span>
+          <span v-if="entry.task_id" class="text-[10px] font-mono text-txt-muted bg-surface-0/60 px-1.5 py-0.5 rounded border border-edge/50">task:{{ entry.task_id }}</span>
+        </div>
         <div
           class="mt-2 text-sm text-txt-secondary wiki-content prose-sm"
           v-html="renderMarkdown(entry.body)"
@@ -74,9 +79,15 @@ const INBOX_LAST_SEEN_KEY = 'inbox-last-seen-id'
 
 interface InboxEntry {
   id: number
+  type: string
   title: string
   body: string
   created_at: string
+  read_at: string | null
+  source_type: string | null
+  squad_slug: string | null
+  instance_id: string | null
+  task_id: string | null
 }
 
 const entries = ref<InboxEntry[]>([])


### PR DESCRIPTION
Fixes the feed/inbox bleed-through after #255 unification.

**Backend (server.ts):**
- `GET /api/inbox` now reads from `unified_feed WHERE type='inbox'` via `listFeedEntries({ type: 'inbox' })`
- `DELETE /api/inbox/:id` uses `deleteFeedEntry()` instead of `deleteInboxEntry()`
- `GET /api/inbox/count` uses `countUnreadFeedEntries('inbox')`
- Removed unused `listInboxEntries`/`countInboxEntries`/`deleteInboxEntry` imports

**FeedView.vue:**
- Removed tabs (All / Inbox / Notifications) — feed is now notifications-only
- Always fetches with `type=notification`
- `markAllRead` always passes `?type=notification`
- Removed `TabValue` type, `tabs` array, `activeTab` ref, `tabCount()` function, tab UI

**InboxView.vue:**
- Expanded `InboxEntry` interface to match `unified_feed` shape (includes `squad_slug`, `instance_id`, `task_id`, `read_at`, etc.)
- Displays squad/instance/task metadata badges when present
- API URL unchanged (`/api/inbox`) — backend now serves from `unified_feed`

276/276 tests pass.