### PR TITLE
fix: watchdog monitors stuck 'merging' instances (#267)

### DIFF
--- a/src/instance-watchdog.test.ts
+++ b/src/instance-watchdog.test.ts
@@ -30,7 +30,7 @@ beforeEach(() => {
 });
 
 describe("instance watchdog", () => {
-  describe("findStaleInstances", () => {
+  describe("findStaleInstances — active instances", () => {
     it("detects stale active instances with no task activity", () => {
       const db = getDb();
       db.prepare(`
@@ -59,7 +59,7 @@ describe("instance watchdog", () => {
       assert.strictEqual(stale.length, 0);
     });
 
-    it("does not flag non-active instances", () => {
+    it("does not flag non-active/non-merging instances", () => {
       const db = getDb();
       db.prepare(`
         INSERT INTO squad_instances (id, master_squad_slug, worktree_path, branch_name, status, created_at)
@@ -82,8 +82,6 @@ describe("instance watchdog", () => {
       assert.ok(stale[0].idleMs >= 44 * 60_000);
       assert.ok(stale[0].idleMs <= 46 * 60_000);
     });
-  });
-
 
     it("skips active instances whose latest task status is done (#261)", () => {
       const db = getDb();
@@ -92,16 +90,88 @@ describe("instance watchdog", () => {
         VALUES (?, ?, ?, ?, 'active', datetime('now', '-60 minutes'))
       `).run("test-squad--task-done", "test-squad", "/tmp/wt7", "test-squad/instance/task-done");
 
-      // The instance's task completed successfully
       db.prepare(`
         INSERT INTO agent_tasks (task_id, agent_slug, description, status, instance_id, started_at, completed_at)
         VALUES (?, ?, ?, 'done', ?, datetime('now', '-35 minutes'), datetime('now', '-34 minutes'))
       `).run("task-done-1", "agent-1", "Finished work", "test-squad--task-done");
 
-      // Would be stale by time (34min idle > 30min threshold) but latest task is done
       const stale = findStaleInstances(30 * 60_000);
       assert.strictEqual(stale.length, 0);
     });
+  });
+
+  describe("findStaleInstances — merging instances (#267)", () => {
+    it("detects merging instance older than merging threshold", () => {
+      const db = getDb();
+      db.prepare(`
+        INSERT INTO squad_instances (id, master_squad_slug, worktree_path, branch_name, status, created_at)
+        VALUES (?, ?, ?, ?, 'merging', datetime('now', '-30 minutes'))
+      `).run("test-squad--stuck-merge", "test-squad", "/tmp/wt-merge1", "test-squad/instance/merge1");
+
+      // Task completed 10 minutes ago — merging has been stuck since then
+      db.prepare(`
+        INSERT INTO agent_tasks (task_id, agent_slug, description, status, instance_id, started_at, completed_at)
+        VALUES (?, ?, ?, 'done', ?, datetime('now', '-15 minutes'), datetime('now', '-10 minutes'))
+      `).run("task-merge-1", "agent-1", "Work done", "test-squad--stuck-merge");
+
+      // 10 min since last task completed > 5 min merging threshold
+      const stale = findStaleInstances(30 * 60_000, 5 * 60_000);
+      assert.strictEqual(stale.length, 1);
+      assert.strictEqual(stale[0].instance.id, "test-squad--stuck-merge");
+      assert.strictEqual(stale[0].instance.status, "merging");
+    });
+
+    it("does not flag merging instance younger than merging threshold", () => {
+      const db = getDb();
+      db.prepare(`
+        INSERT INTO squad_instances (id, master_squad_slug, worktree_path, branch_name, status, created_at)
+        VALUES (?, ?, ?, ?, 'merging', datetime('now', '-30 minutes'))
+      `).run("test-squad--fresh-merge", "test-squad", "/tmp/wt-merge2", "test-squad/instance/merge2");
+
+      // Task completed 2 minutes ago — merging just started
+      db.prepare(`
+        INSERT INTO agent_tasks (task_id, agent_slug, description, status, instance_id, started_at, completed_at)
+        VALUES (?, ?, ?, 'done', ?, datetime('now', '-5 minutes'), datetime('now', '-2 minutes'))
+      `).run("task-merge-2", "agent-1", "Work done", "test-squad--fresh-merge");
+
+      // 2 min since last task completed < 5 min merging threshold
+      const stale = findStaleInstances(30 * 60_000, 5 * 60_000);
+      assert.strictEqual(stale.length, 0);
+    });
+
+    it("uses created_at as fallback when merging instance has no tasks", () => {
+      const db = getDb();
+      db.prepare(`
+        INSERT INTO squad_instances (id, master_squad_slug, worktree_path, branch_name, status, created_at)
+        VALUES (?, ?, ?, ?, 'merging', datetime('now', '-10 minutes'))
+      `).run("test-squad--no-tasks-merge", "test-squad", "/tmp/wt-merge3", "test-squad/instance/merge3");
+
+      // No tasks at all — falls back to created_at (10 min ago > 5 min threshold)
+      const stale = findStaleInstances(30 * 60_000, 5 * 60_000);
+      assert.strictEqual(stale.length, 1);
+      assert.strictEqual(stale[0].instance.id, "test-squad--no-tasks-merge");
+    });
+
+    it("does not apply done-task skip logic to merging instances", () => {
+      const db = getDb();
+      db.prepare(`
+        INSERT INTO squad_instances (id, master_squad_slug, worktree_path, branch_name, status, created_at)
+        VALUES (?, ?, ?, ?, 'merging', datetime('now', '-30 minutes'))
+      `).run("test-squad--merging-done-task", "test-squad", "/tmp/wt-merge4", "test-squad/instance/merge4");
+
+      // Latest task is done — but for merging instances this should NOT skip
+      db.prepare(`
+        INSERT INTO agent_tasks (task_id, agent_slug, description, status, instance_id, started_at, completed_at)
+        VALUES (?, ?, ?, 'done', ?, datetime('now', '-20 minutes'), datetime('now', '-10 minutes'))
+      `).run("task-merge-4", "agent-1", "Done", "test-squad--merging-done-task");
+
+      // 10 min since task completed > 5 min merging threshold — should be detected
+      const stale = findStaleInstances(30 * 60_000, 5 * 60_000);
+      assert.strictEqual(stale.length, 1);
+      assert.strictEqual(stale[0].instance.id, "test-squad--merging-done-task");
+    });
+  });
+
   describe("startInstanceWatchdog", () => {
     it("calls onAbort for stale instances and stops cleanly", async () => {
       const db = getDb();
@@ -117,13 +187,11 @@ describe("instance watchdog", () => {
         onAbort: (inst) => aborted.push(inst.id),
       });
 
-      // Wait for at least one interval to fire
       await new Promise((r) => setTimeout(r, 150));
       stop();
 
       assert.ok(aborted.includes("test-squad--stale"));
 
-      // Verify it was marked failed
       const row = db.prepare("SELECT status FROM squad_instances WHERE id = ?").get("test-squad--stale") as { status: string };
       assert.strictEqual(row.status, "failed");
     });
@@ -142,10 +210,9 @@ describe("instance watchdog", () => {
         onAbort: () => abortCount++,
       });
 
-      stop(); // Stop immediately before any tick fires
+      stop();
 
       await new Promise((r) => setTimeout(r, 150));
-      // Instance should NOT have been aborted since we stopped before first tick
       assert.strictEqual(abortCount, 0);
     });
   });

--- a/src/instance-watchdog.ts
+++ b/src/instance-watchdog.ts
@@ -3,6 +3,7 @@
  *
  * Periodically checks for active squad instances that haven't had any
  * task activity beyond a configurable timeout and auto-aborts them.
+ * Also detects instances stuck in 'merging' state (#267).
  */
 
 import { getDb } from "./store/db.js";
@@ -11,30 +12,58 @@ import { createFeedEntry } from "./store/feed.js";
 
 const DEFAULT_CHECK_INTERVAL_MS = 5 * 60_000;  // Check every 5 minutes
 const DEFAULT_STALE_THRESHOLD_MS = 30 * 60_000; // 30 minutes with no task activity
+const DEFAULT_MERGING_THRESHOLD_MS = 5 * 60_000; // 5 minutes stuck in merging
 
 export interface InstanceWatchdogOptions {
   checkIntervalMs?: number;
   staleThresholdMs?: number;
+  mergingThresholdMs?: number;
   onAbort?: (instance: SquadInstance, idleMs: number) => void;
 }
 
 /**
- * Find active instances whose last task activity exceeds the threshold.
- * "Activity" is defined as the most recent started_at or completed_at
- * in agent_tasks for that instance, or the instance's created_at if no tasks.
+ * Find instances that are stale or stuck.
+ *
+ * For 'active' instances: uses task-activity-based staleness (last started_at/completed_at).
+ * For 'merging' instances: uses wall-clock since entering merging state (shorter threshold).
  */
-export function findStaleInstances(thresholdMs: number): Array<{ instance: SquadInstance; idleMs: number }> {
+export function findStaleInstances(
+  thresholdMs: number,
+  mergingThresholdMs: number = DEFAULT_MERGING_THRESHOLD_MS,
+): Array<{ instance: SquadInstance; idleMs: number }> {
   const db = getDb();
   const now = Date.now();
 
-  const activeInstances = db.prepare(
-    "SELECT * FROM squad_instances WHERE status = 'active'"
+  const instances = db.prepare(
+    "SELECT * FROM squad_instances WHERE status IN ('active', 'merging')"
   ).all() as SquadInstance[];
 
   const stale: Array<{ instance: SquadInstance; idleMs: number }> = [];
 
-  for (const instance of activeInstances) {
-    // Skip instances whose most recent task completed successfully —
+  for (const instance of instances) {
+    if (instance.status === "merging") {
+      // Merging instances: use the time they've been in merging state.
+      // We approximate this from completed_at (set when status changes to terminal)
+      // or fall back to created_at. Since updateInstanceStatus doesn't set completed_at
+      // for non-terminal states, we use a query on the DB's internal timestamp approach.
+      // Best proxy: last task completed_at (since merging happens after task completion).
+      const lastTaskCompleted = db.prepare(`
+        SELECT MAX(completed_at) AS last_ts
+        FROM agent_tasks
+        WHERE instance_id = ?
+      `).get(instance.id) as { last_ts: string | null } | undefined;
+
+      const rawTs = lastTaskCompleted?.last_ts ?? instance.created_at;
+      const lastTs = new Date(rawTs.includes("T") ? rawTs : rawTs + "Z").getTime();
+      const idleMs = now - lastTs;
+
+      if (idleMs >= mergingThresholdMs) {
+        stale.push({ instance, idleMs });
+      }
+      continue;
+    }
+
+    // Active instances: skip those whose most recent task completed successfully —
     // auto-complete in agents.ts handles these (#261)
     const latestTaskStatus = db.prepare(`
       SELECT status FROM agent_tasks
@@ -70,14 +99,16 @@ export function findStaleInstances(thresholdMs: number): Array<{ instance: Squad
 export function startInstanceWatchdog(opts: InstanceWatchdogOptions = {}): () => void {
   const checkInterval = opts.checkIntervalMs ?? DEFAULT_CHECK_INTERVAL_MS;
   const staleThreshold = opts.staleThresholdMs ?? DEFAULT_STALE_THRESHOLD_MS;
+  const mergingThreshold = opts.mergingThresholdMs ?? DEFAULT_MERGING_THRESHOLD_MS;
 
   const timer = setInterval(() => {
     try {
-      const staleInstances = findStaleInstances(staleThreshold);
+      const staleInstances = findStaleInstances(staleThreshold, mergingThreshold);
 
       for (const { instance, idleMs } of staleInstances) {
+        const reason = instance.status === "merging" ? "stuck in merging" : "idle";
         console.error(
-          `[instance-watchdog] Auto-aborting stale instance "${instance.id}" — idle for ${Math.round(idleMs / 60_000)}m (threshold: ${Math.round(staleThreshold / 60_000)}m)`
+          `[instance-watchdog] Auto-aborting ${reason} instance "${instance.id}" — ${Math.round(idleMs / 60_000)}m (threshold: ${Math.round(instance.status === "merging" ? mergingThreshold / 60_000 : staleThreshold / 60_000)}m)`
         );
 
         updateInstanceStatus(instance.id, "failed");
@@ -85,7 +116,7 @@ export function startInstanceWatchdog(opts: InstanceWatchdogOptions = {}): () =>
         createFeedEntry({
           type: "notification",
           title: `[${instance.master_squad_slug}] Instance auto-aborted`,
-          body: `Instance "${instance.id}" was auto-aborted after ${Math.round(idleMs / 60_000)} minutes of inactivity. Worktree preserved at: ${instance.worktree_path}`,
+          body: `Instance "${instance.id}" was auto-aborted (${reason}) after ${Math.round(idleMs / 60_000)} minutes. Worktree preserved at: ${instance.worktree_path}`,
           source_type: "instance-watchdog",
         });
 


### PR DESCRIPTION
Closes #267. Extends instance watchdog to detect instances stuck in 'merging' state with a shorter 5-minute threshold, preventing zombie merging instances from lingering indefinitely.

**Changes:**
- `findStaleInstances()` now queries `status IN ('active', 'merging')`
- Merging instances use a separate threshold (default 5min vs 30min for active)
- Staleness clock for merging: last task `completed_at` (not task activity)
- Done-task skip logic only applies to active instances, not merging
- New `mergingThresholdMs` option in `InstanceWatchdogOptions`

**Tests:** 4 new tests for merging behavior + existing tests refactored. All 286 pass.