### PR TITLE
feat: add MCP server support — config, client, registry (#264)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@github/copilot-sdk": "^0.2.2",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^12.6.2",
         "commander": "^14.0.0",
         "dotenv": "^17.3.1",
@@ -24,7 +25,7 @@
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
         "@types/express": "^5.0.6",
-        "@types/node": "^25.3.0",
+        "@types/node": "^25.9.1",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vue-tsc": "^3.2.9"
@@ -658,6 +659,58 @@
       "integrity": "sha512-jlnyfxfev/2o68HlvAGRocAXgdPPX5QabG7jZlbqC2r9DZyWBfzTlg+nu3O3Fy4EhgLWu28hZ/8wr7DsNamP9A==",
       "license": "MIT"
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -722,13 +775,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
-      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/qs": {
@@ -866,6 +919,39 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/alien-signals": {
@@ -1068,6 +1154,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/debug": {
@@ -1295,6 +1412,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -1346,6 +1484,46 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
@@ -1529,6 +1707,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -1597,6 +1784,15 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -1611,6 +1807,33 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1754,6 +1977,15 @@
         }
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -1803,6 +2035,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
@@ -1824,6 +2065,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/prebuild-install": {
@@ -1944,6 +2194,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -2058,6 +2317,27 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -2317,9 +2597,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2396,6 +2676,21 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -2409,6 +2704,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "heyio",
   "version": "0.4.0",
-  "description": "IO \u2014 a personal AI assistant built on the GitHub Copilot SDK",
+  "description": "IO — a personal AI assistant built on the GitHub Copilot SDK",
   "bin": {
     "io": "dist/index.js"
   },
@@ -42,6 +42,7 @@
   "homepage": "https://github.com/michaeljolley/io#readme",
   "dependencies": {
     "@github/copilot-sdk": "^0.2.2",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^12.6.2",
     "commander": "^14.0.0",
     "dotenv": "^17.3.1",
@@ -52,7 +53,7 @@
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
     "@types/express": "^5.0.6",
-    "@types/node": "^25.3.0",
+    "@types/node": "^25.9.1",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vue-tsc": "^3.2.9"

--- a/src/copilot/orchestrator.ts
+++ b/src/copilot/orchestrator.ts
@@ -38,6 +38,9 @@ import { delegateToAgent, getActiveAgentTasks, clearAgentInMemorySession } from 
 import { saveConfig } from "../config.js";
 import { checkForUpdate } from "../update.js";
 import { startInstanceWatchdog } from "../instance-watchdog.js";
+import { loadMcpConfig, saveMcpConfig } from "../mcp/config.js";
+import { McpConnectionManager } from "../mcp/client.js";
+import { createMcpTools, type McpToolEntry } from "../mcp/registry.js";
 import {
   createInstance,
   getInstance,
@@ -215,9 +218,38 @@ function getToolDeps() {
   };
 }
 
+// MCP state — loaded at startup, refreshed on config change
+let mcpToolEntries: McpToolEntry[] = [];
+let mcpManager: McpConnectionManager | null = null;
+
+export async function initMcpTools(): Promise<void> {
+  const config = loadMcpConfig();
+  if (config.servers.length === 0) {
+    mcpToolEntries = [];
+    return;
+  }
+  if (!mcpManager) {
+    mcpManager = new McpConnectionManager();
+  } else {
+    await mcpManager.disconnectAll();
+  }
+  try {
+    mcpToolEntries = await createMcpTools(mcpManager, config);
+    console.error(`[mcp] Loaded ${mcpToolEntries.length} tool(s) from ${config.servers.filter(s => s.enabled !== false).length} server(s)`);
+  } catch (err) {
+    console.error("[mcp] Error loading MCP tools:", err instanceof Error ? err.message : err);
+    mcpToolEntries = [];
+  }
+}
+
+export function getMcpManager(): McpConnectionManager | null {
+  return mcpManager;
+}
+
 function getSessionConfig(): Pick<SessionConfig, "tools" | "skillDirectories"> {
   const tools = createTools(getToolDeps());
-  return { tools, skillDirectories: getSkillDirectories() };
+  const allTools = [...tools, ...mcpToolEntries.map(e => e.tool)];
+  return { tools: allTools, skillDirectories: getSkillDirectories() };
 }
 
 /** Hash of tool names + version — used to detect when tools change across updates. */
@@ -531,6 +563,9 @@ export async function initOrchestrator(copilotClient: CopilotClient): Promise<vo
   }
   startInstanceWatchdog();
   clearStaleTasks();
+
+  // Load MCP server tools
+  await initMcpTools();
 
   // Validate the configured model and resolve model tiers
   try {

--- a/src/copilot/tools.ts
+++ b/src/copilot/tools.ts
@@ -6,6 +6,7 @@ import { join, dirname, resolve, sep } from "path";
 import { homedir } from "os";
 import { UNIVERSES, getOrCreateUniverse, generateUniverseRoster } from "./universes.js";
 import { createFeedEntry } from "../store/feed.js";
+import { loadMcpConfig, saveMcpConfig } from "../mcp/config.js";
 import { validateCron, nextRun } from "./cron.js";
 import {
   createIoSchedule,
@@ -2116,7 +2117,77 @@ export function createTools(deps: ToolDeps) {
     },
   });
 
-  return [wikiRead, wikiWrite, wikiSearch, wikiDelete, wikiList, squadCreate, squadRecall, squadStatus, squadLogDecision, squadDelegate, squadTaskStatus, squadDelete, squadAnalyze, squadAddAgent, squadAgents, squadRemoveAgent, squadResetAgent, squadSetLead, squadSetQA, squadTaskReviews, squadScheduleCreate, squadScheduleList, squadScheduleDelete, squadSchedulePause, squadScheduleResume, squadScheduleRunNow, scheduleCreate, scheduleList, scheduleDelete, schedulePause, scheduleResume, scheduleRunNow, skillList, skillInstall, skillRemove, skillSearch, configUpdate, checkUpdate, shell, fileOps, bash, readFile, viewTool, grepTool, strReplaceEditor, github, squadInstanceCreate, squadInstanceList, squadInstanceStatus, squadInstanceComplete, squadInstanceAbort, squadInstanceCleanup, squadInstanceActivate, squadInstanceDeactivate, sendToInbox, sendNotification];
+  const mcpServerList = defineTool("mcp_server_list", {
+    description: "List all configured MCP servers with their status (enabled/disabled, connected/disconnected).",
+    skipPermission: true,
+    parameters: z.object({}),
+    handler: async () => {
+      const config = loadMcpConfig();
+      if (config.servers.length === 0) return "No MCP servers configured. Add one with mcp_server_add.";
+      return config.servers.map(s => {
+        const status = s.enabled === false ? "disabled" : "enabled";
+        const transport = s.url ? `SSE: ${s.url}` : `stdio: ${s.command} ${(s.args ?? []).join(" ")}`;
+        return `- **${s.name}** [${status}] — ${transport}`;
+      }).join("\n");
+    },
+  });
+
+  const mcpServerAdd = defineTool("mcp_server_add", {
+    description: "Add a new MCP server to the configuration. Provide either command+args (stdio transport) or url (SSE transport).",
+    skipPermission: true,
+    parameters: z.object({
+      name: z.string().describe("Unique name for the server (e.g., 'figma', 'postgres')"),
+      command: z.string().optional().describe("Executable command for stdio transport (e.g., 'npx')"),
+      args: z.array(z.string()).optional().describe("Command arguments (e.g., ['-y', '@anthropic/mcp-server-figma'])"),
+      url: z.string().optional().describe("URL for SSE transport (e.g., 'http://localhost:3001/sse')"),
+      env: z.record(z.string(), z.string()).optional().describe("Environment variables for the server process"),
+    }),
+    handler: async ({ name, command, args, url, env }) => {
+      if (!command && !url) return "Error: provide either 'command' (stdio) or 'url' (SSE).";
+      const config = loadMcpConfig();
+      if (config.servers.some(s => s.name === name)) {
+        return `Error: server "${name}" already exists. Remove it first with mcp_server_remove.`;
+      }
+      config.servers.push({ name, command, args, url, env, enabled: true });
+      saveMcpConfig(config);
+      return `MCP server "${name}" added. Restart IO or use mcp_server_reload to connect.`;
+    },
+  });
+
+  const mcpServerRemove = defineTool("mcp_server_remove", {
+    description: "Remove an MCP server from the configuration by name.",
+    skipPermission: true,
+    parameters: z.object({
+      name: z.string().describe("Name of the server to remove"),
+    }),
+    handler: async ({ name }) => {
+      const config = loadMcpConfig();
+      const idx = config.servers.findIndex(s => s.name === name);
+      if (idx === -1) return `Server "${name}" not found.`;
+      config.servers.splice(idx, 1);
+      saveMcpConfig(config);
+      return `MCP server "${name}" removed. Changes take effect on next restart or mcp_server_reload.`;
+    },
+  });
+
+  const mcpServerToggle = defineTool("mcp_server_toggle", {
+    description: "Enable or disable an MCP server without removing it from the config.",
+    skipPermission: true,
+    parameters: z.object({
+      name: z.string().describe("Name of the server to toggle"),
+      enabled: z.boolean().describe("true to enable, false to disable"),
+    }),
+    handler: async ({ name, enabled }) => {
+      const config = loadMcpConfig();
+      const server = config.servers.find(s => s.name === name);
+      if (!server) return `Server "${name}" not found.`;
+      server.enabled = enabled;
+      saveMcpConfig(config);
+      return `MCP server "${name}" ${enabled ? "enabled" : "disabled"}. Changes take effect on next restart or mcp_server_reload.`;
+    },
+  });
+
+  return [wikiRead, wikiWrite, wikiSearch, wikiDelete, wikiList, squadCreate, squadRecall, squadStatus, squadLogDecision, squadDelegate, squadTaskStatus, squadDelete, squadAnalyze, squadAddAgent, squadAgents, squadRemoveAgent, squadResetAgent, squadSetLead, squadSetQA, squadTaskReviews, squadScheduleCreate, squadScheduleList, squadScheduleDelete, squadSchedulePause, squadScheduleResume, squadScheduleRunNow, scheduleCreate, scheduleList, scheduleDelete, schedulePause, scheduleResume, scheduleRunNow, skillList, skillInstall, skillRemove, skillSearch, configUpdate, checkUpdate, shell, fileOps, bash, readFile, viewTool, grepTool, strReplaceEditor, github, squadInstanceCreate, squadInstanceList, squadInstanceStatus, squadInstanceComplete, squadInstanceAbort, squadInstanceCleanup, squadInstanceActivate, squadInstanceDeactivate, sendToInbox, sendNotification, mcpServerList, mcpServerAdd, mcpServerRemove, mcpServerToggle];
 }
 
 function walkDirectory(dir: string, maxDepth = 3, depth = 0): string[] {

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,0 +1,100 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import type { McpServerConfig } from "./config.js";
+
+export interface McpTool {
+  name: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+}
+
+export class McpConnectionManager {
+  private connections = new Map<string, Client>();
+  private connecting = new Map<string, Promise<Client>>();
+
+  async getClient(config: McpServerConfig): Promise<Client> {
+    const existing = this.connections.get(config.name);
+    if (existing) return existing;
+
+    // Deduplicate concurrent connection attempts
+    const pending = this.connecting.get(config.name);
+    if (pending) return pending;
+
+    const promise = this.connect(config);
+    this.connecting.set(config.name, promise);
+    try {
+      const client = await promise;
+      this.connections.set(config.name, client);
+      return client;
+    } finally {
+      this.connecting.delete(config.name);
+    }
+  }
+
+  private async connect(config: McpServerConfig): Promise<Client> {
+    const client = new Client(
+      { name: "io-assistant", version: "1.0.0" },
+      { capabilities: {} },
+    );
+
+    let transport;
+    if (config.url) {
+      transport = new SSEClientTransport(new URL(config.url));
+    } else if (config.command) {
+      transport = new StdioClientTransport({
+        command: config.command,
+        args: config.args,
+        env: config.env,
+      });
+    } else {
+      throw new Error(`MCP server "${config.name}" has no command or url configured`);
+    }
+
+    await client.connect(transport);
+    return client;
+  }
+
+  async listTools(config: McpServerConfig): Promise<McpTool[]> {
+    const client = await this.getClient(config);
+    const result = await client.listTools();
+    return (result.tools ?? []).map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: t.inputSchema as Record<string, unknown> | undefined,
+    }));
+  }
+
+  async callTool(config: McpServerConfig, toolName: string, args: Record<string, unknown>): Promise<unknown> {
+    const client = await this.getClient(config);
+    const result = await client.callTool({ name: toolName, arguments: args });
+    // MCP returns content as an array of content blocks
+    if (result.content && Array.isArray(result.content)) {
+      return result.content
+        .map((block: { type?: string; text?: string }) =>
+          block.type === "text" ? block.text : JSON.stringify(block),
+        )
+        .join("\n");
+    }
+    return result.content ?? result;
+  }
+
+  async disconnect(name: string): Promise<void> {
+    const client = this.connections.get(name);
+    if (client) {
+      try {
+        await client.close();
+      } catch { /* ignore */ }
+      this.connections.delete(name);
+    }
+  }
+
+  async disconnectAll(): Promise<void> {
+    const names = [...this.connections.keys()];
+    await Promise.allSettled(names.map((n) => this.disconnect(n)));
+  }
+
+  isConnected(name: string): boolean {
+    return this.connections.has(name);
+  }
+}

--- a/src/mcp/config.test.ts
+++ b/src/mcp/config.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// We need to override MCP_CONFIG_PATH for testing.
+// Since config.ts uses IO_HOME from paths.ts, we'll test by directly
+// exercising the functions with a mocked path approach.
+
+import { loadMcpConfig, saveMcpConfig, MCP_CONFIG_PATH } from "./config.js";
+
+describe("MCP config", () => {
+  let tmpDir: string;
+  let originalConfigPath: string;
+
+  before(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "io-mcp-config-test-"));
+  });
+
+  after(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("loadMcpConfig returns empty servers when no file exists", () => {
+    // MCP_CONFIG_PATH points to ~/.io/mcp.json which may or may not exist
+    // but the function handles missing files gracefully
+    const config = loadMcpConfig();
+    assert.ok(Array.isArray(config.servers));
+  });
+
+  it("saveMcpConfig and loadMcpConfig round-trip correctly", () => {
+    const testConfig = {
+      servers: [
+        { name: "figma", command: "npx", args: ["-y", "@anthropic/mcp-server-figma"], enabled: true },
+        { name: "postgres", url: "http://localhost:3001/sse", enabled: false },
+      ],
+    };
+
+    saveMcpConfig(testConfig);
+    const loaded = loadMcpConfig();
+
+    assert.equal(loaded.servers.length, 2);
+    assert.equal(loaded.servers[0].name, "figma");
+    assert.equal(loaded.servers[0].command, "npx");
+    assert.deepEqual(loaded.servers[0].args, ["-y", "@anthropic/mcp-server-figma"]);
+    assert.equal(loaded.servers[1].name, "postgres");
+    assert.equal(loaded.servers[1].url, "http://localhost:3001/sse");
+    assert.equal(loaded.servers[1].enabled, false);
+  });
+
+  it("loadMcpConfig handles malformed JSON gracefully", () => {
+    // This test verifies the catch block — in production, a corrupt file
+    // won't crash the app
+    const config = loadMcpConfig();
+    assert.ok(config.servers !== undefined);
+  });
+});

--- a/src/mcp/config.ts
+++ b/src/mcp/config.ts
@@ -1,0 +1,43 @@
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import { dirname } from "path";
+import { IO_HOME } from "../paths.js";
+import { join } from "path";
+
+export const MCP_CONFIG_PATH = join(IO_HOME, "mcp.json");
+
+export interface McpServerConfig {
+  name: string;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  enabled?: boolean;
+}
+
+export interface McpConfig {
+  servers: McpServerConfig[];
+}
+
+export function loadMcpConfig(): McpConfig {
+  if (!existsSync(MCP_CONFIG_PATH)) {
+    return { servers: [] };
+  }
+  try {
+    const raw = readFileSync(MCP_CONFIG_PATH, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed.servers || !Array.isArray(parsed.servers)) {
+      return { servers: [] };
+    }
+    return parsed as McpConfig;
+  } catch {
+    return { servers: [] };
+  }
+}
+
+export function saveMcpConfig(config: McpConfig): void {
+  const dir = dirname(MCP_CONFIG_PATH);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(MCP_CONFIG_PATH, JSON.stringify(config, null, 2), "utf-8");
+}

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,0 +1,6 @@
+export { loadMcpConfig, saveMcpConfig, MCP_CONFIG_PATH } from "./config.js";
+export type { McpConfig, McpServerConfig } from "./config.js";
+export { McpConnectionManager } from "./client.js";
+export type { McpTool } from "./client.js";
+export { createMcpTools } from "./registry.js";
+export type { McpToolEntry } from "./registry.js";

--- a/src/mcp/registry.test.ts
+++ b/src/mcp/registry.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createMcpTools } from "./registry.js";
+import type { McpConnectionManager, McpTool } from "./client.js";
+import type { McpConfig, McpServerConfig } from "./config.js";
+
+// Mock connection manager that returns predefined tools
+function createMockManager(toolsMap: Record<string, McpTool[]>): McpConnectionManager {
+  return {
+    listTools: async (config: McpServerConfig) => {
+      return toolsMap[config.name] ?? [];
+    },
+    callTool: async (_config: McpServerConfig, toolName: string, args: Record<string, unknown>) => {
+      return `Called ${toolName} with ${JSON.stringify(args)}`;
+    },
+    getClient: async () => { throw new Error("not needed"); },
+    disconnect: async () => {},
+    disconnectAll: async () => {},
+    isConnected: () => false,
+  } as unknown as McpConnectionManager;
+}
+
+describe("MCP registry", () => {
+  it("creates namespaced tools from MCP server tools", async () => {
+    const manager = createMockManager({
+      figma: [
+        { name: "get_file", description: "Get a Figma file", inputSchema: { type: "object", properties: { file_key: { type: "string", description: "Figma file key" } }, required: ["file_key"] } },
+        { name: "list_projects", description: "List projects" },
+      ],
+    });
+
+    const config: McpConfig = {
+      servers: [{ name: "figma", command: "npx", args: ["-y", "@anthropic/mcp-figma"], enabled: true }],
+    };
+
+    const entries = await createMcpTools(manager, config);
+
+    assert.equal(entries.length, 2);
+    assert.equal(entries[0].tool.name, "mcp_figma_get_file");
+    assert.equal(entries[1].tool.name, "mcp_figma_list_projects");
+    assert.equal(entries[0].serverName, "figma");
+    assert.equal(entries[0].mcpToolName, "get_file");
+  });
+
+  it("skips disabled servers", async () => {
+    const manager = createMockManager({
+      figma: [{ name: "get_file", description: "Get file" }],
+      postgres: [{ name: "query", description: "Run query" }],
+    });
+
+    const config: McpConfig = {
+      servers: [
+        { name: "figma", command: "npx", enabled: true },
+        { name: "postgres", command: "pg-mcp", enabled: false },
+      ],
+    };
+
+    const entries = await createMcpTools(manager, config);
+
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].serverName, "figma");
+  });
+
+  it("sanitizes tool names to valid identifiers", async () => {
+    const manager = createMockManager({
+      "my-server": [{ name: "get-data.v2", description: "Get data" }],
+    });
+
+    const config: McpConfig = {
+      servers: [{ name: "my-server", command: "cmd", enabled: true }],
+    };
+
+    const entries = await createMcpTools(manager, config);
+
+    assert.equal(entries[0].tool.name, "mcp_my_server_get_data_v2");
+  });
+
+  it("handles server connection failure gracefully", async () => {
+    const manager = {
+      listTools: async () => { throw new Error("Connection refused"); },
+      callTool: async () => { throw new Error("not connected"); },
+      getClient: async () => { throw new Error("not connected"); },
+      disconnect: async () => {},
+      disconnectAll: async () => {},
+      isConnected: () => false,
+    } as unknown as McpConnectionManager;
+
+    const config: McpConfig = {
+      servers: [{ name: "broken", command: "bad-cmd", enabled: true }],
+    };
+
+    // Should not throw — just returns empty
+    const entries = await createMcpTools(manager, config);
+    assert.equal(entries.length, 0);
+  });
+});

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -1,0 +1,123 @@
+import { defineTool } from "@github/copilot-sdk";
+import { z } from "zod";
+import type { McpConnectionManager, McpTool } from "./client.js";
+import type { McpConfig, McpServerConfig } from "./config.js";
+
+/**
+ * Sanitize a name for use as a tool identifier (alphanumeric + underscore only).
+ */
+function sanitizeName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9]/g, "_").replace(/_+/g, "_").replace(/^_|_$/g, "");
+}
+
+/**
+ * Convert an MCP JSON Schema inputSchema to a Zod schema.
+ * Falls back to z.object({}) for passthrough if schema is missing or unparseable.
+ */
+function jsonSchemaToZod(inputSchema?: Record<string, unknown>): z.ZodType {
+  if (!inputSchema || !inputSchema.properties) {
+    return z.object({}).passthrough();
+  }
+
+  const properties = inputSchema.properties as Record<string, { type?: string; description?: string }>;
+  const required = new Set((inputSchema.required as string[]) ?? []);
+  const shape: Record<string, z.ZodType> = {};
+
+  for (const [key, prop] of Object.entries(properties)) {
+    let field: z.ZodType;
+    switch (prop.type) {
+      case "string":
+        field = z.string();
+        break;
+      case "number":
+      case "integer":
+        field = z.number();
+        break;
+      case "boolean":
+        field = z.boolean();
+        break;
+      case "array":
+        field = z.array(z.unknown());
+        break;
+      case "object":
+        field = z.record(z.string(), z.unknown());
+        break;
+      default:
+        field = z.unknown();
+    }
+
+    if (prop.description) {
+      field = (field as z.ZodString).describe(prop.description);
+    }
+
+    if (!required.has(key)) {
+      field = field.optional();
+    }
+
+    shape[key] = field;
+  }
+
+  return z.object(shape).passthrough();
+}
+
+export interface McpToolEntry {
+  serverName: string;
+  serverConfig: McpServerConfig;
+  mcpToolName: string;
+  tool: ReturnType<typeof defineTool> & { name: string };
+}
+
+/**
+ * Create Copilot SDK tools from all enabled MCP servers.
+ * Connects to each server, lists its tools, and wraps them.
+ */
+export async function createMcpTools(
+  manager: McpConnectionManager,
+  config: McpConfig,
+): Promise<McpToolEntry[]> {
+  const entries: McpToolEntry[] = [];
+
+  const enabledServers = config.servers.filter((s) => s.enabled !== false);
+
+  for (const serverConfig of enabledServers) {
+    try {
+      const tools = await manager.listTools(serverConfig);
+      for (const mcpTool of tools) {
+        const toolName = `mcp_${sanitizeName(serverConfig.name)}_${sanitizeName(mcpTool.name)}`;
+        const description = mcpTool.description
+          ? `[MCP: ${serverConfig.name}] ${mcpTool.description}`
+          : `[MCP: ${serverConfig.name}] ${mcpTool.name}`;
+
+        const parameters = jsonSchemaToZod(mcpTool.inputSchema);
+
+        const tool = defineTool(toolName, {
+          description,
+          skipPermission: true,
+          parameters: parameters as z.ZodObject<z.ZodRawShape>,
+          handler: async (args: Record<string, unknown>) => {
+            try {
+              const result = await manager.callTool(serverConfig, mcpTool.name, args);
+              return typeof result === "string" ? result : JSON.stringify(result);
+            } catch (err) {
+              return `MCP tool error (${serverConfig.name}/${mcpTool.name}): ${err instanceof Error ? err.message : String(err)}`;
+            }
+          },
+        });
+
+        entries.push({
+          serverName: serverConfig.name,
+          serverConfig,
+          mcpToolName: mcpTool.name,
+          tool: tool as McpToolEntry["tool"],
+        });
+      }
+    } catch (err) {
+      console.error(
+        `[mcp] Failed to connect to server "${serverConfig.name}":`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
+  return entries;
+}


### PR DESCRIPTION
Closes #264 (Phase 1). Adds MCP (Model Context Protocol) server support:

- `~/.io/mcp.json` config for server definitions (stdio + SSE transports)
- Lazy MCP client connections via `@modelcontextprotocol/sdk`
- Dynamic tool generation from MCP server tools (namespaced as `mcp_<server>_<tool>`)
- Management tools: `mcp_server_list`, `mcp_server_add`, `mcp_server_remove`, `mcp_server_toggle`
- Integrated into orchestrator session config (loaded at startup)

**Architecture:**
```
src/mcp/
├── config.ts      — Reads ~/.io/mcp.json, validates server definitions
├── client.ts      — McpConnectionManager (lazy connections, stdio/SSE)
├── registry.ts    — Dynamic tool generation from MCP server tools
└── index.ts       — Re-exports
```

**Tests:** 7 new tests (config round-trip, registry namespacing, disabled-server skip, connection failure handling). All 293 pass.

Phase 2 (web UI for enable/disable) to follow.