### PR TITLE
feat: MCP client auto-reconnect on server crash (#274)

### DIFF
--- a/src/mcp/client.test.ts
+++ b/src/mcp/client.test.ts
@@ -1,0 +1,121 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { McpConnectionManager } from "./client.js";
+import type { McpServerConfig } from "./config.js";
+
+describe("McpConnectionManager — auto-reconnect", () => {
+  const testConfig: McpServerConfig = { name: "test-server", command: "echo", args: ["hello"] };
+
+  it("callTool retries once on connection failure", async () => {
+    const manager = new McpConnectionManager();
+    let attempts = 0;
+
+    // Inject a mock client that fails on first callTool, succeeds on second
+    const mockClient = {
+      callTool: async () => {
+        attempts++;
+        if (attempts === 1) throw new Error("connection reset");
+        return { content: [{ type: "text", text: "success" }] };
+      },
+      listTools: async () => ({ tools: [] }),
+      close: async () => {},
+    };
+
+    // Inject into connections map
+    (manager as any).connections.set("test-server", mockClient);
+
+    // Override getClient to return a fresh mock on reconnect
+    const originalGetClient = manager.getClient.bind(manager);
+    (manager as any).getClient = async (config: McpServerConfig) => {
+      if (!(manager as any).connections.has(config.name)) {
+        // Simulate reconnect — put a working mock
+        const freshMock = {
+          callTool: async () => ({ content: [{ type: "text", text: "reconnected" }] }),
+          close: async () => {},
+        };
+        (manager as any).connections.set(config.name, freshMock);
+        return freshMock;
+      }
+      return (manager as any).connections.get(config.name);
+    };
+
+    const result = await manager.callTool(testConfig, "test_tool", {});
+    assert.equal(result, "reconnected");
+  });
+
+  it("callTool throws after retry also fails", async () => {
+    const manager = new McpConnectionManager();
+
+    const failingClient = {
+      callTool: async () => { throw new Error("permanently broken"); },
+      close: async () => {},
+    };
+
+    (manager as any).connections.set("test-server", failingClient);
+
+    // Override getClient to always return a broken client
+    (manager as any).getClient = async () => failingClient;
+
+    await assert.rejects(
+      () => manager.callTool(testConfig, "test_tool", {}),
+      (err: Error) => {
+        assert.ok(err.message.includes("failed after reconnect"));
+        return true;
+      },
+    );
+  });
+
+  it("listTools retries once on connection failure", async () => {
+    const manager = new McpConnectionManager();
+    let attempts = 0;
+
+    const mockClient = {
+      listTools: async () => {
+        attempts++;
+        if (attempts === 1) throw new Error("connection lost");
+        return { tools: [{ name: "tool1", description: "A tool", inputSchema: {} }] };
+      },
+      close: async () => {},
+    };
+
+    (manager as any).connections.set("test-server", mockClient);
+
+    (manager as any).getClient = async (config: McpServerConfig) => {
+      if (!(manager as any).connections.has(config.name)) {
+        const freshMock = {
+          listTools: async () => ({ tools: [{ name: "tool1", description: "A tool", inputSchema: {} }] }),
+          close: async () => {},
+        };
+        (manager as any).connections.set(config.name, freshMock);
+        return freshMock;
+      }
+      return (manager as any).connections.get(config.name);
+    };
+
+    const tools = await manager.listTools(testConfig);
+    assert.equal(tools.length, 1);
+    assert.equal(tools[0].name, "tool1");
+  });
+
+  it("clears dead connection from map on failure", async () => {
+    const manager = new McpConnectionManager();
+
+    const deadClient = {
+      callTool: async () => { throw new Error("dead"); },
+      close: async () => {},
+    };
+
+    (manager as any).connections.set("test-server", deadClient);
+    assert.ok(manager.isConnected("test-server"));
+
+    // Override getClient to simulate a reconnect failure too
+    (manager as any).getClient = async () => { throw new Error("cannot reconnect"); };
+
+    try {
+      await manager.callTool(testConfig, "test_tool", {});
+    } catch { /* expected */ }
+
+    // Dead connection should have been cleared
+    assert.ok(!manager.isConnected("test-server"));
+  });
+});

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -56,27 +56,52 @@ export class McpConnectionManager {
   }
 
   async listTools(config: McpServerConfig): Promise<McpTool[]> {
-    const client = await this.getClient(config);
-    const result = await client.listTools();
-    return (result.tools ?? []).map((t) => ({
-      name: t.name,
-      description: t.description,
-      inputSchema: t.inputSchema as Record<string, unknown> | undefined,
-    }));
+    const execute = async () => {
+      const client = await this.getClient(config);
+      const result = await client.listTools();
+      return (result.tools ?? []).map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema as Record<string, unknown> | undefined,
+      }));
+    };
+
+    try {
+      return await execute();
+    } catch (err) {
+      console.error(`[mcp] listTools failed for ${config.name}, attempting reconnect:`, err instanceof Error ? err.message : err);
+      this.connections.delete(config.name);
+      return await execute();
+    }
   }
 
   async callTool(config: McpServerConfig, toolName: string, args: Record<string, unknown>): Promise<unknown> {
-    const client = await this.getClient(config);
-    const result = await client.callTool({ name: toolName, arguments: args });
-    // MCP returns content as an array of content blocks
-    if (result.content && Array.isArray(result.content)) {
-      return result.content
-        .map((block: { type?: string; text?: string }) =>
-          block.type === "text" ? block.text : JSON.stringify(block),
-        )
-        .join("\n");
+    const execute = async () => {
+      const client = await this.getClient(config);
+      const result = await client.callTool({ name: toolName, arguments: args });
+      // MCP returns content as an array of content blocks
+      if (result.content && Array.isArray(result.content)) {
+        return result.content
+          .map((block: { type?: string; text?: string }) =>
+            block.type === "text" ? block.text : JSON.stringify(block),
+          )
+          .join("\n");
+      }
+      return result.content ?? result;
+    };
+
+    try {
+      return await execute();
+    } catch (err) {
+      // Connection likely dead — clear and retry once
+      console.error(`[mcp] Tool call failed for ${config.name}/${toolName}, attempting reconnect:`, err instanceof Error ? err.message : err);
+      this.connections.delete(config.name);
+      try {
+        return await execute();
+      } catch (retryErr) {
+        throw new Error(`MCP tool ${config.name}/${toolName} failed after reconnect: ${retryErr instanceof Error ? retryErr.message : String(retryErr)}`);
+      }
     }
-    return result.content ?? result;
   }
 
   async disconnect(name: string): Promise<void> {


### PR DESCRIPTION
Closes #274. Adds retry-once logic to callTool and listTools — on error, clears the dead connection and attempts one reconnect before surfacing the error.

**Strategy:** Single retry with connection eviction. If the first call fails, the cached client is removed from the map and a fresh connection is attempted. If the retry also fails, the error is thrown to the caller. This handles the common case of a crashed subprocess without masking persistent failures with infinite retries.

**Tests:** 4 new tests covering retry success, retry failure, listTools retry, and connection cleanup.