### PR TITLE
feat: include squad wiki pages in instance snapshot and agent system prompt (#269)

### DIFF
--- a/src/copilot/agents.ts
+++ b/src/copilot/agents.ts
@@ -52,6 +52,7 @@ import { removeWorktree } from "../store/worktrees.js";
 import { createFeedEntry } from "../store/feed.js";
 import { SESSIONS_DIR } from "../paths.js";
 import { getUniverse } from "./universes.js";
+import { readSquadWikiPages } from "../wiki/fs.js";
 
 export interface AgentInfo {
   slug: string;
@@ -531,6 +532,10 @@ async function getOrCreateAgentSession(
   const squad = getSquad(squadSlug)!;
   const client = await getClient();
   const decisions = getDecisionsSummary(squadSlug);
+  const wikiPages = readSquadWikiPages(squadSlug);
+  const wikiSection = wikiPages.length > 0
+    ? `\n\n## Squad Wiki\n${wikiPages.map(p => `### ${p.path}\n${p.content}`).join("\n\n")}`
+    : "";
 
   console.error(`[io] Agent ${agent.character_name}: using model "${model}" (agent tier: ${agentTier}, task tier: ${taskTier}, effective: ${effectiveTier})`);
 
@@ -601,7 +606,7 @@ ${agent.charter ?? "General-purpose agent. Handle tasks as they come."}
 - **Path**: ${squad.project_path}
 
 ## Past Decisions
-${decisions}${leadSection}
+${decisions}${leadSection}${wikiSection}
 
 ## Repository Hygiene
 Before you make ANY code changes, you MUST sync your working copy with the remote default branch and work from a fresh feature branch. This prevents the merge conflicts the team hit on PRs like #45.
@@ -667,6 +672,10 @@ async function getOrCreateSession(
   const squad = getSquad(squadSlug)!;
   const client = await getClient();
   const decisions = getDecisionsSummary(squadSlug);
+  const wikiPages = readSquadWikiPages(squadSlug);
+  const wikiSection = wikiPages.length > 0
+    ? `\n\n## Squad Wiki\n${wikiPages.map(p => `### ${p.path}\n${p.content}`).join("\n\n")}`
+    : "";
   const agentTools = buildAgentTools(squadSlug);
   const model = getModelForTask(taskDescription ?? "", squad.model);
 

--- a/src/store/instances.test.ts
+++ b/src/store/instances.test.ts
@@ -298,21 +298,22 @@ describe("deleteInstance", () => {
 // ── buildContextSnapshot ──────────────────────────────────────────────────────
 
 describe("buildContextSnapshot", () => {
-  it("returns a JSON array of recent squad decisions", () => {
+  it("returns a JSON object with decisions array", () => {
     logDecision("test-squad", "use TypeScript everywhere", "consistency");
     logDecision("test-squad", "prefer functional style");
 
     const snapshot = buildContextSnapshot("test-squad");
-    const parsed = JSON.parse(snapshot) as Array<{ decision: string; context: string | null; created_at: string }>;
+    const parsed = JSON.parse(snapshot) as { decisions: Array<{ decision: string; context: string | null; created_at: string }> };
 
-    assert.ok(Array.isArray(parsed));
-    assert.equal(parsed.length, 2);
-    assert.ok(parsed.some((d) => d.decision === "use TypeScript everywhere"));
+    assert.ok(Array.isArray(parsed.decisions));
+    assert.equal(parsed.decisions.length, 2);
+    assert.ok(parsed.decisions.some((d) => d.decision === "use TypeScript everywhere"));
   });
 
-  it("returns an empty JSON array for a squad with no decisions", () => {
+  it("returns empty decisions array for a squad with no decisions", () => {
     const snapshot = buildContextSnapshot("test-squad");
-    assert.deepEqual(JSON.parse(snapshot), []);
+    const parsed = JSON.parse(snapshot) as { decisions: unknown[] };
+    assert.deepEqual(parsed.decisions, []);
   });
 
   it("respects the limit parameter", () => {
@@ -320,8 +321,26 @@ describe("buildContextSnapshot", () => {
       logDecision("test-squad", `decision ${i}`);
     }
     const snapshot = buildContextSnapshot("test-squad", 5);
-    const parsed = JSON.parse(snapshot) as unknown[];
-    assert.equal(parsed.length, 5);
+    const parsed = JSON.parse(snapshot) as { decisions: unknown[] };
+    assert.equal(parsed.decisions.length, 5);
+  });
+
+  it("includes wiki pages when they exist", async () => {
+    const { writePage, deletePage } = await import("../wiki/fs.js");
+    const testSlug = `test-squad-snap-${Date.now()}`;
+    const pagePath = `pages/squads/${testSlug}/rules.md`;
+    try {
+      writePage(pagePath, "# Rules\nNo force push.");
+      logDecision(testSlug, "test decision");
+      const snapshot = buildContextSnapshot(testSlug);
+      const parsed = JSON.parse(snapshot) as { decisions: unknown[]; wiki?: Array<{ path: string; content: string }> };
+      assert.ok(parsed.wiki);
+      assert.equal(parsed.wiki!.length, 1);
+      assert.equal(parsed.wiki![0].path, pagePath);
+      assert.ok(parsed.wiki![0].content.includes("No force push"));
+    } finally {
+      deletePage(pagePath);
+    }
   });
 });
 

--- a/src/store/instances.ts
+++ b/src/store/instances.ts
@@ -1,6 +1,7 @@
 import { getDb } from "./db.js";
 import { getDecisions } from "./squads.js";
 import { worktreeExists } from "./worktrees.js";
+import { readSquadWikiPages } from "../wiki/fs.js";
 
 export interface SquadInstance {
   id: string;
@@ -167,9 +168,17 @@ export function deleteInstance(id: string): void {
  */
 export function buildContextSnapshot(masterSquadSlug: string, limit: number = 30): string {
   const decisions = getDecisions(masterSquadSlug, limit);
-  return JSON.stringify(
-    decisions.map((d) => ({ decision: d.decision, context: d.context, created_at: d.created_at })),
-  );
+  const wikiPages = readSquadWikiPages(masterSquadSlug);
+
+  const snapshot: Record<string, unknown> = {
+    decisions: decisions.map((d) => ({ decision: d.decision, context: d.context, created_at: d.created_at })),
+  };
+
+  if (wikiPages.length > 0) {
+    snapshot.wiki = wikiPages.map(p => ({ path: p.path, content: p.content }));
+  }
+
+  return JSON.stringify(snapshot);
 }
 
 /**

--- a/src/wiki/fs.ts
+++ b/src/wiki/fs.ts
@@ -177,3 +177,15 @@ export function writeLogFile(content: string): void {
 export function getWikiDir(): string {
   return WIKI_DIR;
 }
+
+/**
+ * Read all wiki pages for a squad by slug.
+ * Returns array of { path, content } for pages under pages/squads/{slug}/.
+ */
+export function readSquadWikiPages(slug: string): Array<{ path: string; content: string }> {
+  const prefix = `pages/squads/${slug}/`;
+  return listPages()
+    .filter(p => p.startsWith(prefix))
+    .map(p => ({ path: p, content: readPage(p) ?? "" }))
+    .filter(entry => entry.content.length > 0);
+}

--- a/src/wiki/wiki-squad.test.ts
+++ b/src/wiki/wiki-squad.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readSquadWikiPages, writePage, deletePage } from "./fs.js";
+
+describe("readSquadWikiPages", () => {
+  it("returns empty array for non-existent squad", () => {
+    const pages = readSquadWikiPages("nonexistent-squad-xyz");
+    assert.ok(Array.isArray(pages));
+    assert.equal(pages.length, 0);
+  });
+
+  it("returns pages under pages/squads/{slug}/ prefix", () => {
+    const testSlug = `test-squad-${Date.now()}`;
+    const pagePath = `pages/squads/${testSlug}/workflow.md`;
+
+    try {
+      writePage(pagePath, "# Workflow Rules\nAlways use feature branches.");
+      const pages = readSquadWikiPages(testSlug);
+      assert.equal(pages.length, 1);
+      assert.equal(pages[0].path, pagePath);
+      assert.ok(pages[0].content.includes("feature branches"));
+    } finally {
+      deletePage(pagePath);
+    }
+  });
+
+  it("filters out empty pages", () => {
+    const testSlug = `test-squad-empty-${Date.now()}`;
+    const pagePath = `pages/squads/${testSlug}/empty.md`;
+
+    try {
+      writePage(pagePath, "");
+      const pages = readSquadWikiPages(testSlug);
+      assert.equal(pages.length, 0);
+    } finally {
+      deletePage(pagePath);
+    }
+  });
+
+  it("returns multiple pages for a squad", () => {
+    const testSlug = `test-squad-multi-${Date.now()}`;
+    const page1 = `pages/squads/${testSlug}/workflow.md`;
+    const page2 = `pages/squads/${testSlug}/coding-standards.md`;
+
+    try {
+      writePage(page1, "# Workflow\nUse PRs.");
+      writePage(page2, "# Standards\nESLint required.");
+      const pages = readSquadWikiPages(testSlug);
+      assert.equal(pages.length, 2);
+      const paths = pages.map(p => p.path).sort();
+      assert.deepEqual(paths, [page2, page1].sort());
+    } finally {
+      deletePage(page1);
+      deletePage(page2);
+    }
+  });
+});


### PR DESCRIPTION
Closes #269. Squad wiki pages at pages/squads/{slug}/ are now:
- Included immutably in instance context_snapshot at creation time
- Included in the agent system prompt for squad agents

This ensures squad-specific workflow rules (branch conventions, PR rules, etc.) are available to both instances and regular agents.