### PR TITLE
feat: Telegram image/file attachment support (#268)

### DIFF
--- a/src/copilot/orchestrator.ts
+++ b/src/copilot/orchestrator.ts
@@ -67,10 +67,18 @@ export type MessageSource =
 
 export type MessageCallback = (text: string, done: boolean) => void;
 
+export interface Attachment {
+  type: "blob";
+  data: string; // base64
+  mimeType: string;
+  displayName?: string;
+}
+
 interface QueuedMessage {
   prompt: string;
   source: MessageSource;
   callback: MessageCallback;
+  attachments?: Attachment[];
   resolve: () => void;
   reject: (err: Error) => void;
 }
@@ -438,6 +446,7 @@ function invalidateSession(): void {
 async function executeOnSession(
   prompt: string,
   callback: MessageCallback,
+  attachments?: Attachment[],
 ): Promise<string> {
   const session = await ensureOrchestratorSession();
 
@@ -449,7 +458,9 @@ async function executeOnSession(
   });
 
   try {
-    const result = await session.sendAndWait({ prompt }, SEND_TIMEOUT_MS);
+    const sendPayload: { prompt: string; attachments?: Attachment[] } = { prompt };
+    if (attachments && attachments.length > 0) sendPayload.attachments = attachments;
+    const result = await session.sendAndWait(sendPayload, SEND_TIMEOUT_MS);
     unsubDelta();
 
     const finalText = result?.data.content ?? accumulated;
@@ -513,7 +524,7 @@ async function processQueue(): Promise<void> {
 
       for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
         try {
-          const response = await executeOnSession(taggedPrompt, msg.callback);
+          const response = await executeOnSession(taggedPrompt, msg.callback, msg.attachments);
           logConversation("assistant", response, sourceLabel(msg.source));
           msg.resolve();
           lastError = undefined;
@@ -616,11 +627,12 @@ export async function sendToOrchestrator(
   prompt: string,
   source: MessageSource,
   callback: MessageCallback,
+  attachments?: Attachment[],
 ): Promise<void> {
   logConversation("user", prompt, sourceLabel(source));
 
   return new Promise<void>((resolve, reject) => {
-    messageQueue.push({ prompt, source, callback, resolve, reject });
+    messageQueue.push({ prompt, source, callback, attachments, resolve, reject });
     processQueue();
   });
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -135,11 +135,12 @@ export async function startDaemon(): Promise<void> {
 
   // Wire up Telegram handler
   if (config.telegramEnabled) {
-    setTelegramHandler(async (text, chatId, messageId, callback) => {
+    setTelegramHandler(async (text, chatId, messageId, callback, attachments) => {
       await sendToOrchestrator(
         text,
         { type: "telegram", chatId, messageId },
         callback,
+        attachments,
       );
     });
     createBot();

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -1,18 +1,35 @@
 import { Bot } from "grammy";
 import { config } from "../config.js";
+import type { Attachment } from "../copilot/orchestrator.js";
+
+export type { Attachment };
 
 const TELEGRAM_MAX_LENGTH = 4096;
 const EDIT_DEBOUNCE_MS = 500;
+const FILE_SIZE_LIMIT_BYTES = 5 * 1024 * 1024; // 5MB
 
 export type TelegramMessageHandler = (
   text: string,
   chatId: number,
   messageId: number,
   callback: (text: string, done: boolean) => void,
+  attachments?: Attachment[],
 ) => Promise<void>;
 
 let bot: Bot | undefined;
 let messageHandler: TelegramMessageHandler | undefined;
+
+async function downloadTelegramFile(
+  botInstance: Bot,
+  fileId: string,
+): Promise<{ data: string; mimeType: string; size: number }> {
+  const file = await botInstance.api.getFile(fileId);
+  const url = `https://api.telegram.org/file/bot${config.telegramBotToken}/${file.file_path}`;
+  const response = await fetch(url);
+  const buffer = Buffer.from(await response.arrayBuffer());
+  const mimeType = response.headers.get("content-type") ?? "application/octet-stream";
+  return { data: buffer.toString("base64"), mimeType, size: buffer.length };
+}
 
 export function setMessageHandler(handler: TelegramMessageHandler): void {
   messageHandler = handler;
@@ -106,6 +123,173 @@ export function createBot(): void {
       const message = err instanceof Error ? err.message : String(err);
       console.error("[io] Error handling message:", message);
       await editReply("An error occurred while processing your message.");
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Photo handler
+  // ---------------------------------------------------------------------------
+  bot.on("message:photo", async (ctx) => {
+    const userId = ctx.from?.id;
+    if (config.authorizedUserId && userId !== config.authorizedUserId) return;
+    if (!messageHandler || !bot) {
+      console.error("[io] No message handler registered");
+      return;
+    }
+
+    // Telegram sends an array of sizes — last element is the highest resolution
+    const photos = ctx.message.photo;
+    const photo = photos[photos.length - 1];
+    const chatId = ctx.chat.id;
+    const messageId = ctx.message.message_id;
+    const caption = ctx.message.caption ?? "";
+
+    await ctx.replyWithChatAction("typing");
+    const ack = await ctx.reply("📎 Processing attachment…");
+
+    try {
+      const { data, mimeType, size } = await downloadTelegramFile(bot, photo.file_id);
+
+      if (size > FILE_SIZE_LIMIT_BYTES) {
+        await ctx.api.editMessageText(chatId, ack.message_id, "⚠️ File too large (max 5MB). Attachment not processed.");
+        return;
+      }
+
+      const attachment: Attachment = { type: "blob", data, mimeType, displayName: "photo.jpg" };
+      const placeholder = await ctx.reply("…");
+      let accumulated = "";
+      let lastEditTime = 0;
+      let pendingEdit: ReturnType<typeof setTimeout> | undefined;
+
+      const editReply = async (content: string) => {
+        try {
+          const truncated = content.length > TELEGRAM_MAX_LENGTH
+            ? content.slice(0, TELEGRAM_MAX_LENGTH - 20) + "\n\n[…truncated]"
+            : content;
+          await ctx.api.editMessageText(chatId, placeholder.message_id, truncated);
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          if (!message.includes("message is not modified")) {
+            console.error("[io] Failed to edit message:", message);
+          }
+        }
+      };
+
+      await ctx.api.deleteMessage(chatId, ack.message_id);
+      await messageHandler(caption, chatId, messageId, (chunk, done) => {
+        accumulated += chunk;
+        if (done) {
+          if (pendingEdit) { clearTimeout(pendingEdit); pendingEdit = undefined; }
+          return;
+        }
+        const now = Date.now();
+        const timeSinceLastEdit = now - lastEditTime;
+        if (timeSinceLastEdit >= EDIT_DEBOUNCE_MS) {
+          lastEditTime = now;
+          void editReply(accumulated);
+        } else if (!pendingEdit) {
+          pendingEdit = setTimeout(() => {
+            pendingEdit = undefined;
+            lastEditTime = Date.now();
+            void editReply(accumulated);
+          }, EDIT_DEBOUNCE_MS - timeSinceLastEdit);
+        }
+      }, [attachment]);
+
+      if (pendingEdit) clearTimeout(pendingEdit);
+      if (accumulated.length > 0) await editReply(accumulated);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error("[io] Error handling photo:", message);
+      await ctx.api.editMessageText(chatId, ack.message_id, "An error occurred while processing the attachment.");
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Document handler
+  // ---------------------------------------------------------------------------
+  bot.on("message:document", async (ctx) => {
+    const userId = ctx.from?.id;
+    if (config.authorizedUserId && userId !== config.authorizedUserId) return;
+    if (!messageHandler || !bot) {
+      console.error("[io] No message handler registered");
+      return;
+    }
+
+    const doc = ctx.message.document;
+    const chatId = ctx.chat.id;
+    const messageId = ctx.message.message_id;
+    const caption = ctx.message.caption ?? "";
+
+    // Reject oversized files before downloading (file_size may be undefined for large files)
+    if (doc.file_size !== undefined && doc.file_size > FILE_SIZE_LIMIT_BYTES) {
+      await ctx.reply("⚠️ File too large (max 5MB). Attachment not processed.");
+      return;
+    }
+
+    await ctx.replyWithChatAction("typing");
+    const ack = await ctx.reply("📎 Processing attachment…");
+
+    try {
+      const { data, mimeType, size } = await downloadTelegramFile(bot, doc.file_id);
+
+      if (size > FILE_SIZE_LIMIT_BYTES) {
+        await ctx.api.editMessageText(chatId, ack.message_id, "⚠️ File too large (max 5MB). Attachment not processed.");
+        return;
+      }
+
+      const attachment: Attachment = {
+        type: "blob",
+        data,
+        mimeType,
+        displayName: doc.file_name ?? "document",
+      };
+      const placeholder = await ctx.reply("…");
+      let accumulated = "";
+      let lastEditTime = 0;
+      let pendingEdit: ReturnType<typeof setTimeout> | undefined;
+
+      const editReply = async (content: string) => {
+        try {
+          const truncated = content.length > TELEGRAM_MAX_LENGTH
+            ? content.slice(0, TELEGRAM_MAX_LENGTH - 20) + "\n\n[…truncated]"
+            : content;
+          await ctx.api.editMessageText(chatId, placeholder.message_id, truncated);
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          if (!message.includes("message is not modified")) {
+            console.error("[io] Failed to edit message:", message);
+          }
+        }
+      };
+
+      await ctx.api.deleteMessage(chatId, ack.message_id);
+      await messageHandler(caption, chatId, messageId, (chunk, done) => {
+        accumulated += chunk;
+        if (done) {
+          if (pendingEdit) { clearTimeout(pendingEdit); pendingEdit = undefined; }
+          return;
+        }
+        const now = Date.now();
+        const timeSinceLastEdit = now - lastEditTime;
+        if (timeSinceLastEdit >= EDIT_DEBOUNCE_MS) {
+          lastEditTime = now;
+          void editReply(accumulated);
+        } else if (!pendingEdit) {
+          pendingEdit = setTimeout(() => {
+            pendingEdit = undefined;
+            lastEditTime = Date.now();
+            void editReply(accumulated);
+          }, EDIT_DEBOUNCE_MS - timeSinceLastEdit);
+        }
+      }, [attachment]);
+
+      if (pendingEdit) clearTimeout(pendingEdit);
+      if (accumulated.length > 0) await editReply(accumulated);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error("[io] Error handling document:", message);
+      await ctx.api.editMessageText(chatId, ack.message_id, "An error occurred while processing the attachment.");
     }
   });
 


### PR DESCRIPTION
Closes #268. Adds photo and document attachment support in Telegram bot with base64 blob pass-through to the Copilot SDK session.