### PR TITLE
docs: update README and VitePress docs for v0.32–v0.33 features (#285)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ A personal AI assistant daemon built on the GitHub Copilot SDK. IO runs 24/7 on 
 - **GitHub Integration** — create, list, view, and comment on issues and PRs via the `github` tool
 - **Smart Model Routing** — automatically selects the best model for each task based on complexity
 - **Self-Updating** — checks for updates and can apply them automatically
+- **MCP Integration** — Connect to external MCP servers for additional tools (Figma, databases, APIs)
+- **Scheduling** — Cron-based scheduling for recurring tasks and squad stand-ups
+- **Squad Instances** — Parallel worktrees for concurrent work within a single squad
+- **Unified Feed** — Consolidated inbox and notification feed with web UI
+- **Telegram Attachments** — Send images/files via Telegram for vision-capable model processing
+- **Agent Preview** — Live streaming preview of any squad agent's activity in the web UI
+- **Squad Wiki** — Per-squad wiki context included in agent prompts and instance snapshots
+- **Instance Watchdog** — Monitors active/merging instances and auto-aborts stale ones
 
 ## 📋 Prerequisites
 
@@ -118,6 +126,10 @@ IO stores its configuration at `~/.io/config.json`. The setup wizard (`io setup`
 | `supabaseUrl` | `string` | — | Supabase project URL (enables web portal authentication) |
 | `supabaseAnonKey` | `string` | — | Supabase anon/public API key |
 | `authorizedEmail` | `string` | — | Email address allowed to access the web portal |
+| `backgroundNotifyMode` | `string` | `"meaningful"` | Background task notification frequency: `"all"`, `"meaningful"`, or `"off"` |
+| `backgroundNotifyTelegram` | `boolean` | `true` | Send background task notifications via Telegram |
+| `backgroundNotifyTui` | `boolean` | `true` | Show background task notifications in TUI |
+| `watchdogEnabled` | `boolean` | `true` | Enable the daemon event loop watchdog |
 
 Each `modelTiers` list is a ranked preference — IO picks the first available model at startup.
 
@@ -152,6 +164,7 @@ All persistent data is stored under `~/.io/`:
 | `~/.io/wiki/` | Knowledge base (markdown files) |
 | `~/.io/io.db` | SQLite database (squads, tasks) |
 | `~/.io/skills/` | Installed skills |
+| `~/.io/mcp.json` | MCP server configuration |
 
 ## 🧩 Skills System
 
@@ -201,8 +214,8 @@ Squads are persistent project teams with **named specialist agents**. Each squad
 User → [Web UI / TUI / Telegram / HTTP API]
                 ↓
          Orchestrator (Copilot SDK)
-          ↕           ↕
-     Squad Manager   Wiki/Memory
+          ↕           ↕          ↕
+     Squad Manager   Wiki/Memory  MCP Servers
           ↓
      Named Agents (80s Characters)
 ```

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -87,6 +87,16 @@ SQLite database via `better-sqlite3` (`src/store/db.ts`), stored at `~/.io/io.db
 - **`squad_decisions`** — persistent decision log per squad
 - **`conversation_log`** — rolling log of user/assistant messages (capped at 1000 rows)
 - **`agent_tasks`** — background task tracking for squad agents
+- **`unified_feed`** — combined feed of notifications and inbox items (replaces separate inbox_entries)
+- **`squad_instances`** — parallel worktree instances for concurrent squad work
+- **`instance_decisions`** — append-only decision log per instance (merged back on completion)
+- **`squad_schedules`** — squad-scoped scheduled tasks
+- **`io_schedules`** — IO-level scheduled tasks
+- **`schedule_runs`** — execution history for scheduled tasks
+
+### Instance Watchdog
+
+`src/watchdog.ts` runs a background `setInterval` that monitors both the Node.js event loop and squad instances. **Event loop staleness** is detected by measuring how late each interval fires; a warning is logged at 30 s and the daemon exits at 60 s (overridable via `onFatal` for testing). **Instance staleness** is detected by checking the most recent `agent_tasks` activity for each non-terminal instance — instances with no task activity in the last 30 minutes are marked stale, and instances stuck in `merging` state for more than 5 minutes are aborted. The timer is `.unref()`'d so it never prevents clean shutdown.
 
 ### Interfaces
 

--- a/docs/architecture/squads.md
+++ b/docs/architecture/squads.md
@@ -69,6 +69,55 @@ Decisions are stored in the `squad_decisions` table and summarized when building
 
 The `getDecisionsSummary()` function formats the last 20 decisions into the agent's system prompt, providing an audit trail and enabling consistent decisions over time.
 
+
+## Squad Instances
+
+Squads support **parallel worktree instances** for concurrent work on separate tasks without blocking the main squad.
+
+### How Instances Work
+
+1. `squad_instance_create` creates a new git worktree at a temporary path alongside the project directory
+2. Each instance gets an **independent `CopilotSession`** — no contention with the main squad or other instances
+3. The instance receives a **context snapshot** at creation time containing:
+   - The squad's accumulated decision log
+   - Any squad-associated wiki pages (e.g., workflow rules, branch conventions)
+4. Work proceeds in the worktree; decisions are recorded in the instance's own `instance_decisions` table
+5. When complete, `squad_instance_complete` merges decisions back to the master squad's `squad_decisions` table and removes the worktree
+
+### Lifecycle
+
+```
+squad_instance_create  →  working
+       │
+  (tasks run in isolated worktree + session)
+       │
+squad_instance_complete  →  merging  →  completed
+  or
+squad_instance_abort     →  aborted
+```
+
+### Constraints
+
+- **Max 3 concurrent instances** per squad (enforced inside `createInstance()` with a COUNT query on non-terminal instances)
+- **Worktrees** share `.git` object storage with the main repo — lightweight, no full clone needed
+- **Decisions** are append-only with instance provenance; a SQLite transaction handles the merge-back to avoid races
+
+### Instance Watchdog
+
+A background watchdog monitors all non-terminal instances:
+- Instances with no task activity for **30 minutes** are marked stale
+- Instances stuck in `merging` state for more than **5 minutes** are aborted
+
+The watchdog runs on the same `setInterval` as the event loop health check. See [Architecture Overview](/architecture/overview) for details.
+
+### Context Snapshot
+
+At creation time, `buildContextSnapshot()` returns a JSON object with two keys:
+- **`decisions`** — last N decisions from the master squad's decision log
+- **`wiki`** (optional) — content of any wiki pages associated with the squad's project or slug
+
+This ensures instances inherit workflow rules stored in the wiki (branch naming conventions, PR labeling, build constraints) even if those rules haven't been promoted to the decision log.
+
 ## Key Source Files
 
 | File | Purpose |

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -39,10 +39,47 @@ IO is configured via a JSON file at `~/.io/config.json`. All fields are optional
 | `supabaseAnonKey`  | `string`  | —       | Supabase anonymous/public key                                      |
 | `authorizedEmail`  | `string`  | —       | Email address authorized to access the web portal                  |
 | `modelTiers`       | `object`  | —       | Model routing preferences with `high`, `medium`, `low` arrays      |
+| `backgroundNotifyMode` | `"all" \| "meaningful" \| "off"` | `"meaningful"` | Controls how often background task results are pushed as notifications |
+| `backgroundNotifyTelegram` | `boolean` | `true` | Send background task notifications via Telegram |
+| `backgroundNotifyTui` | `boolean` | `true` | Show background task notifications in TUI |
+| `watchdogEnabled` | `boolean` | `true` | Enable the daemon event loop watchdog (detects stalls) |
 
 ::: warning
 Always keep your bot token secret. Never commit `config.json` to version control.
 :::
+
+
+## MCP Configuration
+
+IO supports [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers, which expose additional tools to the orchestrator. MCP servers are configured in a separate file at `~/.io/mcp.json`.
+
+```jsonc
+{
+  "servers": [
+    {
+      "name": "figma",
+      "command": "npx",
+      "args": ["-y", "@anthropic/mcp-server-figma"],
+      "env": { "FIGMA_TOKEN": "..." },
+      "enabled": true
+    },
+    {
+      "name": "postgres",
+      "url": "http://localhost:3001/sse",
+      "enabled": true
+    }
+  ]
+}
+```
+
+Each server entry supports:
+- **`name`** — unique identifier used to namespace the server's tools (e.g., `mcp_figma_*`)
+- **`command` + `args`** — stdio transport (runs a local process)
+- **`url`** — SSE transport (connects to a running HTTP server)
+- **`env`** — environment variables passed to the subprocess (stdio only)
+- **`enabled`** — set to `false` to disable without removing
+
+You can also manage MCP servers visually at the **`/mcp`** route in the web UI, or via the `mcp_server_*` tools. See the [MCP guide](/guide/mcp) for full details.
 
 ## Model Selection
 
@@ -101,6 +138,7 @@ IO stores all persistent data in `~/.io/`:
 ~/.io/
 ├── config.json          # Configuration
 ├── io.db                # SQLite database (squads, decisions, agents, state)
+├── mcp.json             # MCP server configuration
 ├── wiki/                # Knowledge wiki (markdown files)
 └── skills/              # Installed skills (SKILL.md files)
 ```

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -1,0 +1,119 @@
+# MCP Servers
+
+IO supports [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers. MCP is an open standard that lets external tools and services expose capabilities to AI models via a common protocol. By connecting MCP servers to IO, you can give the orchestrator access to additional tools — database clients, design tools, code search, and more — without modifying IO itself.
+
+## How It Works
+
+1. You configure one or more MCP servers in `~/.io/mcp.json`
+2. At startup, IO loads the config and stores the server definitions (no connections yet)
+3. When the orchestrator first uses a tool from an MCP server, IO lazily establishes the connection
+4. Tools are namespaced as `mcp_<server-name>_<tool-name>` so they never collide with built-in tools
+5. If an MCP server crashes, IO automatically reconnects on the next tool use
+
+## Configuration File
+
+MCP servers are configured in `~/.io/mcp.json` (separate from `config.json`):
+
+```jsonc
+{
+  "servers": [
+    {
+      "name": "figma",
+      "command": "npx",
+      "args": ["-y", "@anthropic/mcp-server-figma"],
+      "env": { "FIGMA_TOKEN": "your-token-here" },
+      "enabled": true
+    },
+    {
+      "name": "postgres",
+      "url": "http://localhost:3001/sse",
+      "enabled": true
+    }
+  ]
+}
+```
+
+### Server Fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | **Required.** Unique identifier. Used to namespace tools as `mcp_<name>_<tool>`. |
+| `command` | `string` | Executable to run (stdio transport). Required if `url` is not set. |
+| `args` | `string[]` | Arguments passed to `command`. |
+| `url` | `string` | HTTP endpoint for SSE transport. Required if `command` is not set. |
+| `env` | `object` | Environment variables passed to the subprocess (stdio only). |
+| `enabled` | `boolean` | Defaults to `true`. Set to `false` to disable without removing. |
+
+## Transports
+
+### stdio
+
+The server runs as a local subprocess. IO spawns it on first use and communicates over stdin/stdout.
+
+```jsonc
+{ "name": "github", "command": "npx", "args": ["-y", "@modelcontextprotocol/server-github"], "env": { "GITHUB_TOKEN": "ghp_..." } }
+```
+
+### SSE (Server-Sent Events)
+
+The server runs independently and IO connects to it via HTTP. Useful for persistent or shared servers.
+
+```jsonc
+{ "name": "postgres", "url": "http://localhost:5432/mcp/sse" }
+```
+
+## Managing via Web UI
+
+The `/mcp` route in the web dashboard provides a visual interface for managing servers:
+
+- **Server list** — shows all configured servers with transport type and enabled/disabled status
+- **Enable / Disable** — toggle a server without removing it
+- **Delete** — remove a server from the config
+- **Add Server** — form to add a new stdio or SSE server with optional env vars
+- **Reload Tools** — apply config changes without restarting IO
+
+Config changes made via the UI take effect after clicking **Reload Tools** (or restarting IO).
+
+## Managing via Tools
+
+The orchestrator exposes five MCP management tools:
+
+| Tool | What it does |
+| --- | --- |
+| `mcp_server_list` | List all servers with name, transport, and enabled status |
+| `mcp_server_add` | Add a new server (stdio or SSE) |
+| `mcp_server_remove` | Remove a server by name |
+| `mcp_server_toggle` | Enable or disable a server |
+| `mcp_server_reload` | Hot-reload tools from the current config (no restart needed) |
+
+Example — ask IO to add a server:
+
+> "Add the GitHub MCP server using the GITHUB_TOKEN environment variable."
+
+## Lazy Connections
+
+IO does **not** connect to MCP servers at startup. Connections are established on first tool use. This means:
+
+- No startup penalty if a server is configured but not used in a session
+- A misconfigured server won't prevent IO from starting
+- Disabled servers are never connected
+
+## Auto-Reconnect
+
+If an MCP server process crashes or its SSE connection drops, IO automatically reconnects the next time one of its tools is called. No manual intervention is needed.
+
+## Tool Namespacing
+
+Every tool exposed by an MCP server is prefixed with `mcp_<server-name>_`. For example, a server named `figma` exposing a `get_component` tool appears to the orchestrator as `mcp_figma_get_component`. This prevents name collisions between servers and with IO's built-in tools.
+
+## Reloading After Config Changes
+
+Config changes (adding, removing, toggling servers) are written to `mcp.json` immediately but the orchestrator's tool list is not updated until a reload. You can trigger a reload:
+
+- **Web UI**: click the **Reload Tools** button on the `/mcp` page
+- **Tool**: ask IO to run `mcp_server_reload`
+- **Restart**: restart the IO daemon (`io stop && io start`)
+
+::: info
+Hot-reload via `mcp_server_reload` re-initializes the MCP client registry and rebuilds the tool list without dropping active orchestrator sessions. Tracked in [#273](https://github.com/michaeljolley/io/issues/273) for enhancements.
+:::

--- a/docs/guide/telegram.md
+++ b/docs/guide/telegram.md
@@ -62,6 +62,28 @@ As the orchestrator generates a response, the bot edits its placeholder message 
 
 Telegram has a 4096-character message limit. IO automatically splits long messages into multiple chunks when sending proactive notifications.
 
+
+## Sending Images & Files
+
+IO's Telegram bot supports photo and document attachments. You can send an image or file alongside your message and IO will pass it to the underlying model.
+
+**How it works:**
+
+1. Send a photo or document to the bot (with or without a caption)
+2. IO acknowledges receipt, downloads the file from Telegram's servers, and converts it to base64
+3. Images are passed to vision-capable models as blob content blocks
+4. Text from any caption is used as the prompt text; if there is no caption, IO processes the attachment alone
+
+**Multiple images:** Each image in a multi-photo message is included as a separate content block in the same prompt.
+
+**File size limit:** Files larger than **5 MB** are rejected with a notification. Telegram normally restricts bot downloads to 20 MB, but IO enforces a lower 5 MB limit to keep context sizes manageable.
+
+**Document types:** Any file Telegram delivers as a `document` (PDFs, logs, code files, etc.) is supported. Binary files that cannot be meaningfully interpreted as text will be passed as-is — the model handles them as best it can.
+
+::: tip
+Vision-capable models (e.g. `claude-sonnet-4.6`, `claude-opus-4.7`) can analyze screenshots, design mockups, error screenshots, and diagrams directly — no manual description needed.
+:::
+
 ## Security
 
 Only the single user ID set in `authorizedUserId` can interact with the bot. Messages from any other user are silently ignored — no error message is sent back, and no processing occurs.

--- a/docs/guide/web-frontend.md
+++ b/docs/guide/web-frontend.md
@@ -19,7 +19,10 @@ The dashboard includes the following views:
 - **Chat** — Real-time conversation with IO via Server-Sent Events (SSE) streaming
 - **Squads** — View and manage project squads. Each squad displays its 80s universe badge and a full **agent roster** showing character names, role titles, and status.
 - **Skills** — Browse and manage installed skills
-- **Agent Activity** — Monitor background agent tasks and their status. Shows the **character name** and role for each active agent.
+- **Feed** — Notification feed from squad activity and system events
+- **Inbox** — Personal inbox for direct messages and deliverables from squads
+- **MCP** — Manage MCP server connections: add/remove servers, enable/disable, and reload tools
+- **Agent Activity** — Monitor background agent tasks and their status. Shows the **character name** and role for each active agent. Click any active agent to open **Preview** mode and stream their live activity in real time.
 
 ## Port Configuration
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -85,6 +85,68 @@ Each character comes with a personality description that influences the agent's 
 
 Delegation is not blocked by these warnings, but the gap should be fixed before promoting work. The team lead, QA reviewers, and test engineers (when designated as QA) all hold veto power on PR promotion — any rejection from any of them keeps the PR as a draft.
 
+### MCP Management Tools
+
+| Tool | Description | Parameters |
+| --- | --- | --- |
+| `mcp_server_list` | List configured MCP servers with enabled/disabled status | _(none)_ |
+| `mcp_server_add` | Add a new MCP server | `name: string`; `command?: string`; `args?: string[]`; `url?: string`; `env?: Record<string, string>` |
+| `mcp_server_remove` | Remove an MCP server by name | `name: string` |
+| `mcp_server_toggle` | Enable or disable an MCP server | `name: string` |
+| `mcp_server_reload` | Hot-reload MCP tools after config changes (without restarting IO) | _(none)_ |
+
+### Scheduling Tools
+
+| Tool | Description | Parameters |
+| --- | --- | --- |
+| `schedule_create` | Create a scheduled task (cron) | `name: string`; `cron: string` — cron expression; `task: string`; `enabled?: boolean` |
+| `schedule_list` | List all IO-level schedules | _(none)_ |
+| `schedule_delete` | Delete a schedule | `name: string` |
+| `schedule_pause` | Pause a schedule | `name: string` |
+| `schedule_resume` | Resume a paused schedule | `name: string` |
+| `schedule_run_now` | Immediately trigger a schedule | `name: string` |
+
+Squad-scoped equivalents (`squad_schedule_create`, `squad_schedule_list`, etc.) follow the same signatures but require a `slug: string` parameter and are scoped to a specific squad.
+
+### Squad Instance Tools
+
+| Tool | Description | Parameters |
+| --- | --- | --- |
+| `squad_instance_create` | Create a parallel git worktree instance for concurrent work | `slug: string`; `issue_ref?: string` |
+| `squad_instance_list` | List all instances for a squad | `slug: string` |
+| `squad_instance_status` | Get the status and details of an instance | `instance_id: string` |
+| `squad_instance_complete` | Complete an instance and merge its decisions back to the master squad | `instance_id: string` |
+| `squad_instance_abort` | Abort an active instance | `instance_id: string` |
+| `squad_instance_cleanup` | Remove an instance's git worktree | `instance_id: string` |
+| `squad_instance_activate` | Set the active instance context for subsequent tool calls | `instance_id: string` |
+| `squad_instance_deactivate` | Clear the active instance context | _(none)_ |
+
+### Feed & Inbox Tools
+
+| Tool | Description | Parameters |
+| --- | --- | --- |
+| `send_to_inbox` | Send a message directly to the user's inbox | `title: string`; `body: string`; `squad_slug?: string` |
+| `send_notification` | Create a notification in the activity feed | `title: string`; `body: string`; `source_type?: string` |
+
+### File & Code Tools
+
+These tools are available to squad agents for reading and modifying project files:
+
+| Tool | Description | Parameters |
+| --- | --- | --- |
+| `bash` | Run a bash command | `command: string`; `timeout_secs?: number`; `working_dir?: string` |
+| `read_file` | Read the full contents of a file | `path: string` |
+| `view` | View a file or directory with line numbers | `path: string`; `view_range?: [number, number]` |
+| `grep` | Search file contents using a regex pattern | `pattern: string`; `path?: string`; `include?: string` |
+| `str_replace_editor` | Make a precise string replacement in a file | `path: string`; `old_str: string`; `new_str: string` |
+
+### Configuration Tools
+
+| Tool | Description | Parameters |
+| --- | --- | --- |
+| `config_update` | Update a key in IO's configuration | `key: string`; `value: unknown` |
+| `check_update` | Check for and apply available IO updates | _(none)_ |
+
 ### Shell
 
 | Tool | Description | Parameters |


### PR DESCRIPTION
Closes #285. Comprehensive documentation update covering all features added since the last docs refresh:

**README updates:**
- 8 new feature bullets (MCP, Scheduling, Instances, Feed, Attachments, Preview, Wiki, Watchdog)
- 4 new config parameters in the reference table
- MCP config path in data directory
- Architecture diagram updated

**VitePress updates:**
- `guide/configuration.md` — new config fields + MCP config section
- `guide/web-frontend.md` — Feed, Inbox, MCP views + Agent Preview
- `guide/telegram.md` — image/file attachment support
- `guide/mcp.md` *(new)* — dedicated MCP server guide
- `reference/tools.md` — 30+ new tools documented (MCP, scheduling, instances, feed, file/code, config)
- `architecture/overview.md` — MCP in tech stack, new DB tables, watchdog component
- `architecture/squads.md` — squad instances section