### PR TITLE
feat: rebuild web UI to match Figma designs

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,39 +1,42 @@
 <template>
-  <div class="flex h-screen bg-surface-0 relative overflow-hidden">
-    <!-- Ambient background depth system -->
-    <div class="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
-      <!-- Primary: large top-right cyan glow — the main light source -->
-      <div class="absolute -top-[30%] -right-[15%] w-[65%] h-[70%] rounded-full bg-accent/[0.03] blur-[160px]"></div>
-      <!-- Secondary: bottom-left deep navy orb for balance -->
-      <div class="absolute -bottom-[25%] -left-[15%] w-[55%] h-[55%] rounded-full bg-blue-900/[0.06] blur-[140px]"></div>
-      <!-- Tertiary: mid-canvas indigo warmth — breaks up the flat center -->
-      <div class="absolute top-[15%] left-[25%] w-[45%] h-[50%] rounded-full bg-indigo-950/[0.08] blur-[180px]"></div>
-      <!-- Aurora: hairline gradient strip across the very top -->
-      <div class="absolute top-0 inset-x-0 h-px bg-gradient-to-r from-transparent via-accent/[0.18] to-transparent"></div>
-      <!-- Vignette: edges fade to deeper black, prevents glow bleed -->
-      <div class="absolute inset-0" style="background: radial-gradient(ellipse 85% 75% at 50% 40%, transparent 45%, rgba(3, 5, 10, 0.35) 100%)"></div>
+  <div v-if="route.name === 'login'" class="h-screen">
+    <RouterView />
+  </div>
+  <div v-else class="flex flex-col h-screen bg-bg-app text-text overflow-hidden">
+    <!-- Header -->
+    <AppHeader @toggle-sidebar="sidebarOpen = !sidebarOpen" />
+    <!-- Main area -->
+    <div class="flex flex-1 min-h-0">
+      <AppSidebar :visible="sidebarOpen" @navigate="sidebarOpen = false" />
+      <main class="flex-1 overflow-auto relative">
+        <RouterView v-slot="{ Component }">
+          <transition name="view" mode="out-in">
+            <component :is="Component" />
+          </transition>
+        </RouterView>
+      </main>
     </div>
-
-    <AppNav />
-
-    <main class="flex-1 overflow-auto relative z-0 pb-16 md:pb-0">
-      <!-- Subtle gradient highlight at the top edge of the content pane -->
-      <div class="pointer-events-none absolute top-0 inset-x-0 h-[2px] bg-gradient-to-r from-transparent via-accent/[0.1] to-transparent z-10" aria-hidden="true"></div>
-      <RouterView v-slot="{ Component }">
-        <transition name="view" mode="out-in">
-          <component :is="Component" />
-        </transition>
-      </RouterView>
-    </main>
-
-    <FloatingChat />
+    <!-- Status bar -->
+    <AppStatusBar />
+    <!-- Command bar (floating) -->
+    <CommandBar :chat-open="chatRef?.isOpen ?? false" @open="chatRef?.open()" />
+    <!-- Chat overlay -->
+    <FloatingChat ref="chatRef" />
   </div>
 </template>
 
 <script setup lang="ts">
-import AppNav from './components/AppNav.vue'
+import { ref } from 'vue'
+import { useRoute, RouterView } from 'vue-router'
+import AppHeader from './components/AppHeader.vue'
+import AppSidebar from './components/AppSidebar.vue'
+import AppStatusBar from './components/AppStatusBar.vue'
+import CommandBar from './components/CommandBar.vue'
 import FloatingChat from './components/FloatingChat.vue'
-import { RouterView } from 'vue-router'
+
+const route = useRoute()
+const sidebarOpen = ref(false)
+const chatRef = ref<InstanceType<typeof FloatingChat> | null>(null)
 </script>
 
 <style scoped>

--- a/web/src/components/AppHeader.vue
+++ b/web/src/components/AppHeader.vue
@@ -1,0 +1,59 @@
+<template>
+  <header class="shrink-0 h-11 flex items-center justify-between px-4 bg-bg-surface border-b border-border">
+    <!-- Left -->
+    <div class="flex items-center gap-0">
+      <!-- Mobile hamburger -->
+      <button
+        class="md:hidden p-1.5 mr-2 rounded-md text-text-muted hover:text-text hover:bg-bg-elevated transition-colors"
+        @click="$emit('toggle-sidebar')"
+        aria-label="Toggle navigation"
+      >
+        <svg viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4"><path fill-rule="evenodd" d="M2 4.75A.75.75 0 0 1 2.75 4h14.5a.75.75 0 0 1 0 1.5H2.75A.75.75 0 0 1 2 4.75Zm0 5A.75.75 0 0 1 2.75 9h14.5a.75.75 0 0 1 0 1.5H2.75A.75.75 0 0 1 2 9.75Zm0 5a.75.75 0 0 1 .75-.75h14.5a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1-.75-.75Z" clip-rule="evenodd"/></svg>
+      </button>
+      <span class="text-accent-cyan font-mono font-bold text-lg select-none">IO</span>
+      <div class="w-px h-3 bg-border mx-3"></div>
+      <span class="text-text-muted text-xs hidden sm:inline">Mission Control · Developer AI Assistant</span>
+    </div>
+    <!-- Right -->
+    <router-link
+      to="/feed"
+      class="relative flex items-center gap-1.5 px-3 py-1 rounded-md text-text-muted hover:bg-bg-elevated hover:text-text transition-colors"
+      @click="onFeedClick"
+    >
+      <svg viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4"><path d="M10 2a5.92 5.92 0 0 1 5.98 5.36l.02.22V11.4l.92 2.22a1 1 0 0 1 .06.17l.01.08.01.13a1 1 0 0 1-.75.97l-.11.02L16 15h-3.5v.17a2.5 2.5 0 0 1-5 0V15H4a1 1 0 0 1-.26-.03l-.13-.04a1 1 0 0 1-.6-1.05l.02-.13.05-.13L4 11.4V7.57A5.9 5.9 0 0 1 10 2Zm1.5 13h-3v.15a1.5 1.5 0 0 0 1.36 1.34l.14.01c.78 0 1.42-.6 1.5-1.36V15ZM10 3a4.9 4.9 0 0 0-4.98 4.38L5 7.6V11.5l-.04.2L4 14h12l-.96-2.3-.04-.2V7.61A4.9 4.9 0 0 0 10 3Z"/></svg>
+      <span class="text-xs">Feed</span>
+      <!-- Unread badge -->
+      <span
+        v-if="unreadCount > 0"
+        class="absolute -top-0.5 -right-0.5 min-w-4 h-4 flex items-center justify-center rounded-full bg-accent-red text-white text-[9px] font-bold px-1"
+      >{{ unreadCount > 99 ? '99+' : unreadCount }}</span>
+    </router-link>
+  </header>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { apiFetch } from '../lib/api'
+import { useAuthStore } from '../stores/auth'
+
+defineEmits<{ 'toggle-sidebar': [] }>()
+
+const auth = useAuthStore()
+const unreadCount = ref(0)
+
+function onFeedClick() {
+  unreadCount.value = 0
+}
+
+onMounted(async () => {
+  await auth.init()
+  if (auth.authEnabled && !auth.user) return
+  try {
+    const res = await apiFetch('/api/feed/count')
+    if (res.ok) {
+      const data = (await res.json()) as { count?: number }
+      unreadCount.value = data.count ?? 0
+    }
+  } catch { /* best effort */ }
+})
+</script>

--- a/web/src/components/AppSidebar.vue
+++ b/web/src/components/AppSidebar.vue
@@ -1,0 +1,69 @@
+<template>
+  <nav
+    class="shrink-0 w-[39px] bg-bg-surface border-r border-border flex-col items-center py-2 gap-0.5 z-30"
+    :class="[visible ? 'flex' : 'hidden md:flex']"
+  >
+    <router-link
+      v-for="item in navItems"
+      :key="item.name"
+      :to="item.to"
+      class="relative w-[39px] h-[39px] flex items-center justify-center transition-colors duration-150 group"
+      :class="isActive(item.name) ? 'text-accent-cyan' : 'text-text-muted hover:text-text'"
+      :title="item.label"
+      @click="$emit('navigate')"
+    >
+      <!-- Active indicator bar -->
+      <span
+        v-if="isActive(item.name)"
+        class="absolute left-0 top-[8px] bottom-[8px] w-[3px] rounded-r bg-accent-cyan"
+      ></span>
+      <svg viewBox="0 0 20 20" fill="currentColor" class="w-[18px] h-[18px]" v-html="item.icon" aria-hidden="true"></svg>
+      <!-- Inbox badge -->
+      <span
+        v-if="item.name === 'inbox' && inboxCount > 0"
+        class="absolute top-1 right-1 min-w-3 h-3 flex items-center justify-center rounded-full bg-accent-red text-white text-[8px] font-bold px-0.5"
+      >{{ inboxCount > 9 ? '9+' : inboxCount }}</span>
+    </router-link>
+  </nav>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import { apiFetch } from '../lib/api'
+import { useAuthStore } from '../stores/auth'
+
+defineProps<{ visible?: boolean }>()
+defineEmits<{ navigate: [] }>()
+
+const route = useRoute()
+const auth = useAuthStore()
+const inboxCount = ref(0)
+
+const navItems = [
+  { to: '/chat',      name: 'chat',      icon: '<path d="M10 2a8 8 0 1 1-3.61 15.14l-.12-.07-3.65.92a.5.5 0 0 1-.62-.45v-.08l.01-.08.92-3.64-.07-.12a7.95 7.95 0 0 1-.83-2.9l-.02-.37L2 10a8 8 0 0 1 8-8Zm0 1a7 7 0 0 0-6.1 10.42.5.5 0 0 1 .06.28l-.02.1-.75 3.01 3.02-.75a.5.5 0 0 1 .19-.01l.09.02.09.04A7 7 0 1 0 10 3Z"/>', label: 'Chat' },
+  { to: '/squads',    name: 'squads',    icon: '<path d="M10 3a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3ZM7.5 4.5a2.5 2.5 0 1 1 5 0 2.5 2.5 0 0 1-5 0Zm8-.5a1 1 0 1 0 0 2 1 1 0 0 0 0-2Zm-2 1a2 2 0 1 1 4 0 2 2 0 0 1-4 0Zm-10 0a1 1 0 1 1 2 0 1 1 0 0 1-2 0Zm1-2a2 2 0 1 0 0 4 2 2 0 0 0 0-4Zm.6 12H5a2 2 0 0 1-2-2V9.25c0-.14.11-.25.25-.25h1.76c.04-.37.17-.7.37-1H3.25C2.56 8 2 8.56 2 9.25V13a3 3 0 0 0 3.4 2.97 4.96 4.96 0 0 1-.3-.97Zm9.5.97A3 3 0 0 0 18 13V9.25C18 8.56 17.44 8 16.75 8h-2.13c.2.3.33.63.37 1h1.76c.14 0 .25.11.25.25V13a2 2 0 0 1-2.1 2c-.07.34-.17.66-.3.97ZM7.25 8C6.56 8 6 8.56 6 9.25V14a4 4 0 0 0 8 0V9.25C14 8.56 13.44 8 12.75 8h-5.5ZM7 9.25c0-.14.11-.25.25-.25h5.5c.14 0 .25.11.25.25V14a3 3 0 1 1-6 0V9.25Z"/>', label: 'Squads' },
+  { to: '/activity',  name: 'activity',  icon: '<path d="M16.52 9c.26 0 .48-.2.48-.46V8.5A6.5 6.5 0 0 0 10.5 2h-.04a.47.47 0 0 0-.46.48V8.5c0 .28.22.5.5.5h6.02ZM11 3.02A5.5 5.5 0 0 1 15.98 8H11V3.02ZM8 9V5.1A5 5 0 0 0 9 15v1a6 6 0 0 1-.5-11.98c.28-.02.5.2.5.48V9a1 1 0 0 0 1 1h4.5c.28 0 .5.22.48.5a6 6 0 0 1-.06.5H10a2 2 0 0 1-2-2Zm9 1a1 1 0 0 0-1 1v7a1 1 0 1 0 2 0v-7a1 1 0 0 0-1-1Zm-3 2a1 1 0 0 0-1 1v5a1 1 0 1 0 2 0v-5a1 1 0 0 0-1-1Zm-4 3a1 1 0 1 1 2 0v3a1 1 0 1 1-2 0v-3Z"/>', label: 'Activity' },
+  { to: '/schedules', name: 'schedules', icon: '<path d="M7 11a1 1 0 1 0 0-2 1 1 0 0 0 0 2Zm1 2a1 1 0 1 1-2 0 1 1 0 0 1 2 0Zm2-2a1 1 0 1 0 0-2 1 1 0 0 0 0 2Zm1 2a1 1 0 1 1-2 0 1 1 0 0 1 2 0Zm2-2a1 1 0 1 0 0-2 1 1 0 0 0 0 2Zm4-5.5A2.5 2.5 0 0 0 14.5 3h-9A2.5 2.5 0 0 0 3 5.5v9A2.5 2.5 0 0 0 5.5 17h9a2.5 2.5 0 0 0 2.5-2.5v-9ZM4 7h12v7.5c0 .83-.67 1.5-1.5 1.5h-9A1.5 1.5 0 0 1 4 14.5V7Zm1.5-3h9c.83 0 1.5.67 1.5 1.5V6H4v-.5C4 4.67 4.67 4 5.5 4Z"/>', label: 'Schedules' },
+  { to: '/skills',    name: 'skills',    icon: '<path d="M9 6.5a4.5 4.5 0 0 1 6.35-4.1.5.5 0 0 1 .15.8l-2.3 2.3 1.3 1.3 2.3-2.3a.5.5 0 0 1 .8.15A4.49 4.49 0 0 1 13.5 11a4.5 4.5 0 0 1-1.1-.14l-6.37 6.45a2.36 2.36 0 0 1-3.37-3.3l6.42-6.65A4.52 4.52 0 0 1 9 6.5Z"/>', label: 'Skills' },
+  { to: '/wiki',      name: 'wiki',      icon: '<path d="M10 16c-.46.6-1.18 1-2 1H3.5A1.5 1.5 0 0 1 2 15.5v-11C2 3.67 2.67 3 3.5 3H8c.82 0 1.54.4 2 1 .46-.6 1.18-1 2-1h4.5c.83 0 1.5.67 1.5 1.5v11c0 .83-.67 1.5-1.5 1.5H12a2.5 2.5 0 0 1-2-1ZM3 4.5v11c0 .28.22.5.5.5H8c.83 0 1.5-.67 1.5-1.5v-9C9.5 4.67 8.83 4 8 4H3.5a.5.5 0 0 0-.5.5Zm7.5 10c0 .83.67 1.5 1.5 1.5h4.5a.5.5 0 0 0 .5-.5v-11a.5.5 0 0 0-.5-.5H12c-.83 0-1.5.67-1.5 1.5v9Z"/>', label: 'Wiki' },
+  { to: '/mcp',       name: 'mcp',       icon: '<path d="M13.5 5a1.5 1.5 0 1 1 0 3h-1v1.5a.5.5 0 0 1-1 0V8h-3v1.5a.5.5 0 0 1-1 0V8h-1a1.5 1.5 0 1 1 0-3h1V3.5a.5.5 0 0 1 1 0V5h3V3.5a.5.5 0 0 1 1 0V5h1Zm0 1h-7a.5.5 0 0 0 0 1h7a.5.5 0 0 0 0-1ZM4 12.5A2.5 2.5 0 0 1 6.5 10h7a2.5 2.5 0 0 1 2.5 2.5v2a2.5 2.5 0 0 1-2.5 2.5h-7A2.5 2.5 0 0 1 4 14.5v-2Zm2.5-1.5A1.5 1.5 0 0 0 5 12.5v2A1.5 1.5 0 0 0 6.5 16h7a1.5 1.5 0 0 0 1.5-1.5v-2a1.5 1.5 0 0 0-1.5-1.5h-7Z"/>', label: 'MCP' },
+  { to: '/inbox',     name: 'inbox',     icon: '<path d="M2 6.25A2.25 2.25 0 0 1 4.25 4h11.5A2.25 2.25 0 0 1 18 6.25v7.5A2.25 2.25 0 0 1 15.75 16H4.25A2.25 2.25 0 0 1 2 13.75v-7.5Zm2.25-1a1 1 0 0 0-1 1v.388l6.75 4.5 6.75-4.5V6.25a1 1 0 0 0-1-1H4.25Zm12.5 2.834-6.294 4.196a.75.75 0 0 1-.812 0L3.25 8.084v5.666a1 1 0 0 0 1 1h11.5a1 1 0 0 0 1-1V8.084Z"/>', label: 'Inbox' },
+]
+
+function isActive(name: string): boolean {
+  return route.name === name
+}
+
+onMounted(async () => {
+  await auth.init()
+  if (auth.authEnabled && !auth.user) return
+  try {
+    const res = await apiFetch('/api/inbox/count')
+    if (res.ok) {
+      const data = (await res.json()) as { count?: number }
+      inboxCount.value = data.count ?? 0
+    }
+  } catch { /* best effort */ }
+})
+</script>

--- a/web/src/components/AppStatusBar.vue
+++ b/web/src/components/AppStatusBar.vue
@@ -1,0 +1,72 @@
+<template>
+  <footer class="shrink-0 h-[30px] flex items-center justify-between px-4 bg-bg-surface border-t border-border text-xs select-none">
+    <!-- Left -->
+    <div class="flex items-center gap-3 text-text-muted">
+      <span class="flex items-center gap-1.5">
+        <span class="w-2 h-2 rounded-full bg-accent-green"></span>
+        Connected
+      </span>
+      <span>·</span>
+      <span>{{ squadCount }} squads · {{ agentCount }} agents</span>
+      <template v-if="instanceInfo">
+        <span>·</span>
+        <span class="text-accent-purple">{{ instanceInfo }}</span>
+      </template>
+    </div>
+    <!-- Right -->
+    <div class="flex items-center gap-1.5 text-text-muted">
+      <svg viewBox="0 0 20 20" fill="currentColor" class="w-3.5 h-3.5"><path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm.75-13a.75.75 0 0 0-1.5 0v4.5c0 .2.08.39.22.53l3 3a.75.75 0 1 0 1.06-1.06l-2.78-2.78V5Z" clip-rule="evenodd"/></svg>
+      <span>Last sync: {{ lastSyncText }}</span>
+    </div>
+  </footer>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+import { apiFetch } from '../lib/api'
+import { useAuthStore } from '../stores/auth'
+
+const auth = useAuthStore()
+const squadCount = ref(0)
+const agentCount = ref(0)
+const instanceInfo = ref('')
+const lastSyncText = ref('just now')
+let lastSyncTime = Date.now()
+let ticker: ReturnType<typeof setInterval> | null = null
+
+function updateSyncText() {
+  const secs = Math.floor((Date.now() - lastSyncTime) / 1000)
+  if (secs < 10) lastSyncText.value = 'just now'
+  else if (secs < 60) lastSyncText.value = `${secs}s ago`
+  else lastSyncText.value = `${Math.floor(secs / 60)}m ago`
+}
+
+async function fetchStatus() {
+  try {
+    const res = await apiFetch('/api/squads')
+    if (res.ok) {
+      const data = (await res.json()) as { squads?: Array<{ agents_count?: number; instances_active?: number; instances_total?: number }> }
+      const squads = data.squads ?? []
+      squadCount.value = squads.length
+      agentCount.value = squads.reduce((sum, s) => sum + (s.agents_count ?? 0), 0)
+      const activeInst = squads.reduce((sum, s) => sum + (s.instances_active ?? 0), 0)
+      const totalInst = squads.reduce((sum, s) => sum + (s.instances_total ?? 0), 0)
+      if (totalInst > 0) instanceInfo.value = `${activeInst}/${totalInst} instances active`
+      else instanceInfo.value = ''
+    }
+  } catch { /* best effort */ }
+  lastSyncTime = Date.now()
+  updateSyncText()
+}
+
+onMounted(async () => {
+  await auth.init()
+  if (auth.authEnabled && !auth.user) return
+  fetchStatus()
+  ticker = setInterval(updateSyncText, 10000)
+})
+
+onUnmounted(() => {
+  if (ticker) clearInterval(ticker)
+})
+</script>

--- a/web/src/components/CommandBar.vue
+++ b/web/src/components/CommandBar.vue
@@ -1,0 +1,46 @@
+<template>
+  <div
+    v-if="!chatOpen"
+    class="fixed bottom-12 left-1/2 -translate-x-1/2 z-40"
+  >
+    <button
+      @click="openChat"
+      class="flex items-center gap-2 w-[360px] max-w-[calc(100vw-2rem)] px-4 py-2
+             rounded-full bg-bg-surface border border-border shadow-lg
+             hover:border-border-bright hover:shadow-glow-sm transition-all duration-200"
+    >
+      <svg viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4 text-text-muted shrink-0"><path fill-rule="evenodd" d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11ZM2 9a7 7 0 1 1 12.45 4.39l3.58 3.58a.75.75 0 1 1-1.06 1.06l-3.58-3.58A7 7 0 0 1 2 9Z" clip-rule="evenodd"/></svg>
+      <span class="flex-1 text-left text-sm text-text-muted">Command IO...</span>
+      <kbd class="text-[10px] text-text-muted bg-bg-elevated px-1.5 py-0.5 rounded border border-border font-mono">{{ isMac ? '⌘K' : 'Ctrl+K' }}</kbd>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+
+const props = defineProps<{ chatOpen: boolean }>()
+const emit = defineEmits<{ open: [] }>()
+
+const isMac = ref(false)
+
+function openChat() {
+  emit('open')
+}
+
+function handleKey(e: KeyboardEvent) {
+  if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+    e.preventDefault()
+    if (!props.chatOpen) openChat()
+  }
+}
+
+onMounted(() => {
+  isMac.value = navigator.platform.toUpperCase().includes('MAC')
+  document.addEventListener('keydown', handleKey)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleKey)
+})
+</script>

--- a/web/src/components/FloatingChat.vue
+++ b/web/src/components/FloatingChat.vue
@@ -1,32 +1,32 @@
 <template>
-  <div class="fixed bottom-4 right-4 z-50 flex flex-col items-end">
-    <!-- Expanded panel -->
-    <Transition
-      enter-active-class="transition-all duration-200 ease-out"
-      enter-from-class="opacity-0 scale-90 translate-y-4"
-      enter-to-class="opacity-100 scale-100 translate-y-0"
-      leave-active-class="transition-all duration-150 ease-in"
-      leave-from-class="opacity-100 scale-100 translate-y-0"
-      leave-to-class="opacity-0 scale-90 translate-y-4"
-    >
-      <div
-        v-if="isOpen"
-        class="mb-3 w-[400px] h-[500px] max-w-[calc(100vw-2rem)] max-h-[calc(100vh-6rem)] flex flex-col rounded-2xl bg-surface-2 border border-edge shadow-card overflow-hidden"
-      >
+  <!-- Overlay backdrop -->
+  <Transition
+    enter-active-class="transition-opacity duration-150"
+    enter-from-class="opacity-0"
+    enter-to-class="opacity-100"
+    leave-active-class="transition-opacity duration-100"
+    leave-from-class="opacity-100"
+    leave-to-class="opacity-0"
+  >
+    <div v-if="isOpen" class="fixed inset-0 z-50 flex items-center justify-center p-4" @click.self="isOpen = false">
+      <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" aria-hidden="true"></div>
+
+      <!-- Chat panel -->
+      <div class="relative w-full max-w-lg h-[70vh] max-h-[600px] flex flex-col rounded-2xl bg-bg-surface border border-border shadow-card overflow-hidden">
         <!-- Header -->
-        <div class="flex items-center justify-between px-4 py-2.5 border-b border-edge/50 bg-surface-3/50">
+        <div class="flex items-center justify-between px-4 py-2.5 border-b border-border bg-bg-card">
           <div class="flex items-center gap-2">
             <div class="w-5 h-5 rounded-md bg-accent/10 border border-accent/20 flex items-center justify-center">
-              <span class="text-accent text-[9px] font-bold font-mono">IO</span>
+              <span class="text-accent-cyan text-[9px] font-bold font-mono">IO</span>
             </div>
-            <span class="text-xs font-semibold text-txt-primary">Chat</span>
+            <span class="text-sm font-semibold text-text">IO Chat</span>
           </div>
           <button
             @click="isOpen = false"
-            class="p-1 rounded-lg text-txt-muted hover:text-txt-primary hover:bg-surface-2 transition-all duration-150"
-            title="Minimize"
+            class="p-1.5 rounded-lg text-text-muted hover:text-text hover:bg-bg-elevated transition-colors duration-150"
+            title="Close"
           >
-            <FluentIcon :paths='`<path d="M3.5 10a.5.5 0 0 0 0 1h13a.5.5 0 0 0 0-1h-13Z"/>`' :size="14" />
+            <svg viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4"><path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z"/></svg>
           </button>
         </div>
 
@@ -35,9 +35,9 @@
           <!-- Empty state -->
           <div v-if="store.messages.length === 0" class="flex flex-col items-center justify-center h-full select-none">
             <div class="w-10 h-10 rounded-xl bg-accent/10 border border-accent/20 flex items-center justify-center mb-3">
-              <span class="text-accent font-bold text-sm font-mono">IO</span>
+              <span class="text-accent-cyan font-bold text-sm font-mono">IO</span>
             </div>
-            <p class="text-txt-muted text-xs">Send a message to start</p>
+            <p class="text-text-muted text-xs">Send a message to start</p>
           </div>
 
           <!-- Messages -->
@@ -50,14 +50,14 @@
             >
               <div
                 v-if="msg.role === 'user'"
-                class="max-w-[80%] px-3 py-2 rounded-xl rounded-br-sm text-xs whitespace-pre-wrap bg-accent/[0.12] text-txt-primary border border-accent/20"
+                class="max-w-[80%] px-3 py-2 rounded-xl rounded-br-sm text-xs whitespace-pre-wrap bg-accent-cyan/[0.12] text-text border border-accent-cyan/20"
               >{{ msg.content }}</div>
               <div v-else class="max-w-[85%] flex gap-2 items-start">
-                <div class="shrink-0 w-5 h-5 rounded-md bg-surface-3/60 border border-edge flex items-center justify-center mt-0.5">
-                  <span class="text-accent text-[8px] font-bold font-mono">IO</span>
+                <div class="shrink-0 w-5 h-5 rounded-md bg-bg-elevated border border-border flex items-center justify-center mt-0.5">
+                  <span class="text-accent-cyan text-[8px] font-bold font-mono">IO</span>
                 </div>
                 <div
-                  class="floating-chat-md min-w-0 px-3 py-2 rounded-xl rounded-tl-sm text-xs bg-surface-0/60 text-txt-primary border border-edge/50"
+                  class="floating-chat-md min-w-0 px-3 py-2 rounded-xl rounded-tl-sm text-xs bg-bg-card text-text border border-border"
                   v-html="renderMarkdown(msg.content) + (msg.streaming ? streamCursorHtml : '')"
                 ></div>
               </div>
@@ -66,10 +66,10 @@
             <!-- Thinking indicator -->
             <div v-if="store.isLoading && !isStreaming" class="flex justify-start">
               <div class="flex gap-2 items-start">
-                <div class="shrink-0 w-5 h-5 rounded-md bg-surface-3/60 border border-edge flex items-center justify-center">
-                  <span class="text-accent text-[8px] font-bold font-mono">IO</span>
+                <div class="shrink-0 w-5 h-5 rounded-md bg-bg-elevated border border-border flex items-center justify-center">
+                  <span class="text-accent-cyan text-[8px] font-bold font-mono">IO</span>
                 </div>
-                <div class="px-3 py-2 rounded-xl rounded-tl-sm bg-surface-0/60 border border-edge/50 flex items-center gap-1">
+                <div class="px-3 py-2 rounded-xl rounded-tl-sm bg-bg-card border border-border flex items-center gap-1">
                   <span class="thinking-dot" style="animation-delay: 0s"></span>
                   <span class="thinking-dot" style="animation-delay: 0.15s"></span>
                   <span class="thinking-dot" style="animation-delay: 0.3s"></span>
@@ -80,7 +80,7 @@
         </div>
 
         <!-- Input -->
-        <div class="shrink-0 border-t border-edge/50 p-2.5 bg-surface-3/30">
+        <div class="shrink-0 border-t border-border p-2.5 bg-bg-card">
           <form @submit.prevent="sendMessage" class="flex gap-2 items-end">
             <textarea
               ref="inputEl"
@@ -88,7 +88,7 @@
               placeholder="Message IO…"
               :disabled="store.isLoading"
               rows="1"
-              class="flex-1 bg-surface-0/50 border border-edge rounded-lg px-3 py-2 text-xs text-txt-primary placeholder:text-txt-muted/60 resize-none overflow-hidden focus:outline-none focus:border-accent/40 disabled:opacity-40 transition-all duration-150"
+              class="flex-1 bg-bg-app border border-border rounded-lg px-3 py-2 text-xs text-text placeholder:text-text-muted resize-none overflow-hidden focus:outline-none focus:border-accent-cyan/40 disabled:opacity-40 transition-all duration-150"
               @keydown="handleKeydown"
               @input="autoResize"
             />
@@ -96,54 +96,29 @@
               v-if="store.isLoading"
               type="button"
               @click="stopOrchestrator"
-              class="shrink-0 w-8 h-8 rounded-lg flex items-center justify-center bg-red-500/15 text-red-400 border border-red-500/25 hover:bg-red-500/25 transition-all duration-150"
+              class="shrink-0 w-8 h-8 rounded-lg flex items-center justify-center bg-accent-red/15 text-accent-red border border-accent-red/25 hover:bg-accent-red/25 transition-all duration-150"
               title="Stop"
             >
-              <span class="w-2 h-2 rounded-[2px] bg-red-400"></span>
+              <span class="w-2 h-2 rounded-[2px] bg-accent-red"></span>
             </button>
             <button
               v-else
               type="submit"
               :disabled="!input.trim()"
-              class="shrink-0 w-8 h-8 rounded-lg flex items-center justify-center bg-accent/15 text-accent border border-accent/25 hover:bg-accent/25 disabled:opacity-25 disabled:cursor-not-allowed transition-all duration-150"
+              class="shrink-0 w-8 h-8 rounded-lg flex items-center justify-center bg-accent-cyan/15 text-accent-cyan border border-accent-cyan/25 hover:bg-accent-cyan/25 disabled:opacity-25 disabled:cursor-not-allowed transition-all duration-150"
               title="Send"
             >
-              <FluentIcon :paths='`<path d="M2.18 2.11a.5.5 0 0 1 .54-.06l15 7.5a.5.5 0 0 1 0 .9l-15 7.5a.5.5 0 0 1-.7-.58L3.98 10 2.02 2.63a.5.5 0 0 1 .16-.52Zm2.7 8.39-1.61 6.06L16.38 10 3.27 3.44 4.88 9.5h6.62a.5.5 0 1 1 0 1H4.88Z"/>`' :size="14" />
+              <svg viewBox="0 0 20 20" fill="currentColor" class="w-3.5 h-3.5"><path d="M2.18 2.11a.5.5 0 0 1 .54-.06l15 7.5a.5.5 0 0 1 0 .9l-15 7.5a.5.5 0 0 1-.7-.58L3.98 10 2.02 2.63a.5.5 0 0 1 .16-.52Zm2.7 8.39-1.61 6.06L16.38 10 3.27 3.44 4.88 9.5h6.62a.5.5 0 1 1 0 1H4.88Z"/></svg>
             </button>
           </form>
         </div>
       </div>
-    </Transition>
-
-    <!-- Collapsed: floating bubble -->
-    <button
-      v-if="!isOpen"
-      @click="openChat"
-      class="w-12 h-12 rounded-full bg-accent/15 border border-accent/25 text-accent flex items-center justify-center shadow-glow-sm hover:bg-accent/25 hover:border-accent/40 hover:shadow-glow transition-all duration-200 relative"
-      title="Open chat"
-    >
-      <FluentIcon :paths='`<path d="M10 2a8 8 0 1 1-3.61 15.14l-3.05.92a.75.75 0 0 1-.92-.93l.94-3.05A8 8 0 0 1 10 2Zm0 1a7 7 0 0 0-5.87 10.77.75.75 0 0 1 .07.56l-.72 2.34 2.32-.7a.75.75 0 0 1 .57.07A7 7 0 1 0 10 3Z"/>`' :size="22" />
-      <!-- Unread dot -->
-      <span
-        v-if="hasUnread"
-        class="absolute top-0 right-0 w-3 h-3 rounded-full bg-accent border-2 border-surface-2 shadow-glow-sm"
-      ></span>
-      <!-- Activity pulse ring (visible when IO is thinking) -->
-      <span
-        v-if="store.isLoading"
-        class="absolute inset-0 rounded-full border-2 border-accent/60 animate-ping pointer-events-none"
-      ></span>
-      <span
-        v-if="store.isLoading"
-        class="absolute inset-0 rounded-full border border-accent/30 animate-pulse pointer-events-none"
-      ></span>
-    </button>
-  </div>
+    </div>
+  </Transition>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, watch, nextTick } from 'vue'
-import FluentIcon from './FluentIcon.vue'
 import { useChatStore } from '../stores/chat'
 import { renderMarkdown } from '../lib/markdown'
 import { apiFetch, authenticatedUrl } from '../lib/api'
@@ -162,12 +137,15 @@ const isStreaming = computed(() =>
   store.messages.some((m) => m.streaming)
 )
 
-function openChat() {
+// Exposed so App.vue / CommandBar can control open state
+function open() {
   isOpen.value = true
   hasUnread.value = false
   lastSeenCount.value = store.messages.length
   nextTick(() => scrollToBottom())
 }
+
+defineExpose({ open, isOpen, hasUnread })
 
 function scrollToBottom() {
   nextTick(() => {
@@ -177,7 +155,6 @@ function scrollToBottom() {
   })
 }
 
-// Auto-scroll on new messages when open; only mark unread for new assistant messages
 watch(() => store.messages.length, (newLen) => {
   if (isOpen.value) {
     scrollToBottom()
@@ -190,12 +167,9 @@ watch(() => store.messages.length, (newLen) => {
   }
 })
 
-// Also scroll when streaming appends content
 watch(
   () => store.messages[store.messages.length - 1]?.content,
-  () => {
-    if (isOpen.value) scrollToBottom()
-  }
+  () => { if (isOpen.value) scrollToBottom() }
 )
 
 function handleKeydown(e: KeyboardEvent) {
@@ -223,14 +197,11 @@ async function sendMessage() {
   if (!text || store.isLoading) return
 
   input.value = ''
-  nextTick(() => {
-    if (inputEl.value) inputEl.value.style.height = 'auto'
-  })
+  nextTick(() => { if (inputEl.value) inputEl.value.style.height = 'auto' })
   store.isLoading = true
 
   store.addMessage({ id: crypto.randomUUID(), role: 'user', content: text })
   store.addMessage({ id: crypto.randomUUID(), role: 'assistant', content: '', streaming: true })
-
   scrollToBottom()
 
   const evtSource = new EventSource(await authenticatedUrl('/api/events'))
@@ -244,7 +215,7 @@ async function sendMessage() {
         store.isLoading = false
         evtSource.close()
       }
-    } catch { /* ignore parse errors */ }
+    } catch { /* ignore */ }
   }
   evtSource.onerror = () => {
     store.setLastStreaming(false)
@@ -277,7 +248,7 @@ async function sendMessage() {
   width: 5px;
   height: 5px;
   border-radius: 50%;
-  background-color: #22d3ee;
+  background-color: #00d9ff;
   animation: thinking 1.4s ease-in-out infinite;
 }
 
@@ -286,7 +257,7 @@ async function sendMessage() {
   width: 2px;
   height: 0.9em;
   margin-left: 1px;
-  background-color: #22d3ee;
+  background-color: #00d9ff;
   vertical-align: text-bottom;
   animation: cursor-blink 0.8s steps(2) infinite;
 }
@@ -298,12 +269,12 @@ async function sendMessage() {
 .floating-chat-md :deep(p) { margin: 0.1rem 0; }
 .floating-chat-md :deep(pre) {
   font-size: 0.65rem;
-  background: #060a13;
-  border-color: #1e2d4a;
+  background: #0a0a0f;
+  border-color: #252530;
   border-radius: 0.5rem;
 }
 .floating-chat-md :deep(code) { font-family: 'JetBrains Mono', monospace; }
-.floating-chat-md :deep(a) { color: #22d3ee; }
+.floating-chat-md :deep(a) { color: #00d9ff; }
 .floating-chat-md :deep(a:hover) { text-decoration: underline; }
 .floating-chat-md :deep(ol) { list-style-type: decimal; padding-left: 1.5em; margin: 0.5em 0; }
 .floating-chat-md :deep(ul) { list-style-type: disc; padding-left: 1.5em; margin: 0.5em 0; }

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -9,7 +9,7 @@ html {
 }
 
 body {
-  @apply bg-surface-0 text-txt-primary font-sans antialiased;
+  @apply bg-bg-app text-text font-sans antialiased;
 }
 
 /* ── Scrollbar ─────────────────────────────────── */
@@ -24,30 +24,30 @@ body {
 }
 
 ::-webkit-scrollbar-thumb {
-  @apply bg-edge rounded-full;
+  @apply bg-border rounded-full;
   border: 1px solid transparent;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  @apply bg-edge-bright;
+  @apply bg-border-bright;
 }
 
 /* Firefox */
 * {
   scrollbar-width: thin;
-  scrollbar-color: #1e2d4a transparent;
+  scrollbar-color: #252530 transparent;
 }
 
 /* ── Selection ─────────────────────────────────── */
 
 ::selection {
-  @apply bg-accent/20 text-accent;
+  @apply bg-accent-cyan/20 text-accent-cyan;
 }
 
 /* ── Focus ring ────────────────────────────────── */
 
 *:focus-visible {
-  @apply outline-none ring-1 ring-accent/50 ring-offset-1 ring-offset-surface-0;
+  @apply outline-none ring-1 ring-accent-cyan/50 ring-offset-1 ring-offset-bg-app;
 }
 
 /* ── Global link style ─────────────────────────── */
@@ -77,37 +77,7 @@ a {
 
 @layer utilities {
   .glass {
-    @apply bg-surface-2/80 backdrop-blur-sm border border-edge;
-  }
-}
-
-/* ── Background texture ────────────────────────── */
-
-/* Very subtle dot-grid — reinforces depth without competing with content */
-body {
-  background-image: radial-gradient(
-    circle,
-    rgba(30, 45, 74, 0.25) 1px,
-    transparent 1px
-  );
-  background-size: 24px 24px;
-}
-
-/* ── Gradient utilities ────────────────────────── */
-
-@layer utilities {
-  /* Gradient top border line for section headers */
-  .gradient-border-t {
-    border-top: 1px solid transparent;
-    background-image: linear-gradient(#0c1220, #0c1220),
-      linear-gradient(90deg, transparent 0%, #1e2d4a 20%, #2a3f65 50%, #1e2d4a 80%, transparent 100%);
-    background-origin: border-box;
-    background-clip: padding-box, border-box;
-  }
-
-  /* Subtle inner glow on cards — gives depth to surface-2 containers */
-  .glow-inner {
-    box-shadow: inset 0 1px 0 rgba(34, 211, 238, 0.04), inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+    @apply bg-bg-card/80 backdrop-blur-sm border border-border;
   }
 }
 

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -7,29 +7,47 @@ export default {
   theme: {
     extend: {
       colors: {
-        /* Layered surfaces — deep blue-black base */
+        /* ── NEW design tokens ── */
+        bg: {
+          app: '#0a0a0f',
+          surface: '#0f0f16',
+          card: '#121218',
+          elevated: '#1a1a24',
+        },
+        border: {
+          DEFAULT: '#252530',
+          bright: '#3a3a48',
+        },
+        'accent-cyan': '#00d9ff',
+        'accent-purple': '#c4a7ff',
+        'accent-red': '#ff3864',
+        'accent-green': '#5fff87',
+        text: {
+          DEFAULT: '#ffffff',
+          secondary: '#e8e8ed',
+          muted: '#8a8a99',
+        },
+
+        /* ── Compatibility aliases (old tokens) ── */
         surface: {
-          0: '#060a13',
-          1: '#0c1220',
-          2: '#131b2e',
-          3: '#1a2540',
+          0: '#0a0a0f',
+          1: '#0f0f16',
+          2: '#121218',
+          3: '#1a1a24',
         },
-        /* Borders with blue undertone */
         edge: {
-          DEFAULT: '#1e2d4a',
-          bright: '#2a3f65',
+          DEFAULT: '#252530',
+          bright: '#3a3a48',
         },
-        /* Cyan accent — terminal-cursor glow */
         accent: {
-          DEFAULT: '#22d3ee',
-          dim: '#0e7490',
-          glow: '#06b6d4',
+          DEFAULT: '#00d9ff',
+          dim: '#0080a0',
+          glow: '#00d9ff',
         },
-        /* Text hierarchy */
         txt: {
-          primary: '#e2e8f0',
-          secondary: '#8b9dc3',
-          muted: '#4a5f88',
+          primary: '#ffffff',
+          secondary: '#e8e8ed',
+          muted: '#8a8a99',
         },
       },
       fontFamily: {
@@ -41,10 +59,10 @@ export default {
         '2xl': '1rem',
       },
       boxShadow: {
-        glow: '0 0 20px -4px rgba(34, 211, 238, 0.15)',
-        'glow-sm': '0 0 10px -2px rgba(34, 211, 238, 0.1)',
-        card: '0 1px 3px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(30, 45, 74, 0.5)',
-        'card-hover': '0 4px 16px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(42, 63, 101, 0.7)',
+        glow: '0 0 20px -4px rgba(0, 217, 255, 0.15)',
+        'glow-sm': '0 0 10px -2px rgba(0, 217, 255, 0.1)',
+        card: '0 1px 3px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(37, 37, 48, 0.5)',
+        'card-hover': '0 4px 16px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(58, 58, 72, 0.7)',
       },
       animation: {
         'fade-in': 'fadeIn 0.3s ease-out',


### PR DESCRIPTION
Closes #289

## Summary
Complete visual rebuild of the IO web app to match the new Figma designs (file `Nx1j669CHNiupsPwfajoIF`, Page 10).

### New Layout
- **AppHeader** (44px) — IO logo, subtitle, Feed button with unread badge
- **AppSidebar** (39px) — Icon-only vertical nav with cyan active indicator bar
- **AppStatusBar** (30px) — Connection status, squad/instance counts, last sync time
- **CommandBar** — Floating command palette trigger (⌘K / Ctrl+K) opens chat
- **FloatingChat** — Redesigned as centered modal overlay with backdrop blur

### Design Tokens
New color system from Figma:
| Token | Value |
|-------|-------|
| bg-app | #0a0a0f |
| bg-surface | #0f0f16 |
| bg-card | #121218 |
| border | #252530 |
| accent-cyan | #00d9ff |
| accent-purple | #c4a7ff |
| accent-red | #ff3864 |
| accent-green | #5fff87 |
| text-muted | #8a8a99 |

Backward-compatible aliases (surface/edge/txt/accent) preserved so existing views render correctly.

### What's Preserved
- All Pinia stores (chat, auth, feed, etc.)
- All API integrations + SSE streaming
- All existing views (ChatView, SquadsView, FeedView, etc.)
- Router config unchanged
- File attachment support from PR #288
- Mobile responsive (sidebar hidden on mobile, hamburger in header)

### Testing
- 267 backend tests ✔
- 49 web tests ✔
- TypeScript clean ✔