### PR TITLE
feat: Make web UI fully responsive for mobile and tablet (#298)

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -5,6 +5,7 @@ import AppIcon from '@/components/AppIcon.vue'
 import AppSidebar from '@/components/AppSidebar.vue'
 import FeedFlyout from '@/components/FeedFlyout.vue'
 import FloatingChat from '@/components/FloatingChat.vue'
+import MobileNav from '@/components/MobileNav.vue'
 import { apiFetch } from '@/lib/api'
 import { formatRelativeTime, type SquadSummary } from '@/lib/mission-control'
 import { useAuthStore } from '@/stores/auth'
@@ -89,14 +90,18 @@ onUnmounted(() => {
 <template>
   <div class="dark flex h-full flex-col overflow-hidden bg-background text-foreground">
     <template v-if="shellVisible">
-      <div class="flex shrink-0 items-center justify-between border-b border-border bg-sidebar px-5 py-3">
-        <div class="flex items-center gap-4">
-          <div class="select-none pl-1 font-mono text-xl font-bold tracking-tight text-primary text-glow-cyan">IO</div>
-          <div class="h-4 w-px bg-border" />
-          <div class="font-mono text-xs text-muted-foreground">Mission Control · Developer AI Assistant</div>
+      <!-- Top bar -->
+      <div class="flex shrink-0 items-center justify-between border-b border-border bg-sidebar px-4 py-3 md:px-5">
+        <div class="flex items-center gap-3 md:gap-4">
+          <div class="select-none font-mono text-xl font-bold tracking-tight text-primary text-glow-cyan">IO</div>
+          <div class="hidden h-4 w-px bg-border md:block" />
+          <div class="hidden font-mono text-xs text-muted-foreground md:block">Mission Control · Developer AI Assistant</div>
         </div>
         <div class="flex items-center gap-2">
-          <button class="relative flex items-center gap-2 rounded border border-border px-3 py-1.5 text-sm text-muted-foreground transition-all hover:border-primary/40 hover:bg-primary/5 hover:text-foreground" @click="feedOpen = true">
+          <button
+            class="relative flex items-center gap-2 rounded border border-border px-3 py-1.5 text-sm text-muted-foreground transition-all hover:border-primary/40 hover:bg-primary/5 hover:text-foreground"
+            @click="feedOpen = true"
+          >
             <AppIcon name="message" class="h-4 w-4" />
             <span class="text-xs font-medium">Feed</span>
             <span v-if="unreadCount > 0" class="absolute -right-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-destructive font-mono text-[9px] font-bold text-white">{{ unreadCount }}</span>
@@ -104,16 +109,19 @@ onUnmounted(() => {
         </div>
       </div>
 
+      <!-- Main layout -->
       <div class="flex min-h-0 flex-1 overflow-hidden">
         <AppSidebar />
         <div class="flex min-w-0 flex-1 flex-col overflow-hidden">
-          <div class="min-h-0 flex-1 overflow-hidden">
+          <!-- Content area — bottom padding on mobile to clear MobileNav -->
+          <div class="min-h-0 flex-1 overflow-hidden pb-[calc(env(safe-area-inset-bottom)+3.5rem)] md:pb-0">
             <RouterView />
           </div>
         </div>
       </div>
 
-      <div class="shrink-0 border-t border-border bg-sidebar px-5 py-2">
+      <!-- Status bar — desktop only -->
+      <div class="hidden shrink-0 border-t border-border bg-sidebar px-5 py-2 md:block">
         <div class="flex items-center justify-between font-mono text-[11px]">
           <div class="flex items-center gap-4">
             <div class="flex items-center gap-1.5">
@@ -137,6 +145,9 @@ onUnmounted(() => {
 
       <FeedFlyout :open="feedOpen" @close="feedOpen = false" />
       <FloatingChat ref="floatingChat" />
+
+      <!-- Mobile bottom nav -->
+      <MobileNav />
     </template>
 
     <div v-else class="h-full">

--- a/web/src/components/AppSidebar.vue
+++ b/web/src/components/AppSidebar.vue
@@ -72,7 +72,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <aside class="flex w-12 shrink-0 flex-col items-center border-r border-border bg-sidebar py-3">
+  <aside class="hidden w-12 shrink-0 flex-col items-center border-r border-border bg-sidebar py-3 md:flex">
     <div class="flex flex-col gap-1">
       <RouterLink v-for="item in primaryItems" :key="item.to" :to="item.to" class="group relative flex h-9 w-9 items-center justify-center rounded-lg transition-all" :class="isActive(item) ? 'bg-primary/15 text-primary' : 'text-muted-foreground/50 hover:bg-white/[0.04] hover:text-foreground'">
         <AppIcon :name="item.icon" class="h-4 w-4" />

--- a/web/src/components/FeedFlyout.vue
+++ b/web/src/components/FeedFlyout.vue
@@ -90,7 +90,7 @@ watch(() => props.open, (value) => {
     </transition>
 
     <transition enter-active-class="duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]" enter-from-class="translate-x-full" enter-to-class="translate-x-0" leave-active-class="duration-200 ease-in" leave-from-class="translate-x-0" leave-to-class="translate-x-full">
-      <aside v-if="open" class="fixed inset-y-0 right-0 z-50 flex w-[420px] max-w-[calc(100vw-1rem)] flex-col border-l border-border bg-sidebar">
+      <aside v-if="open" class="fixed inset-y-0 right-0 z-50 flex w-full flex-col border-l border-border bg-sidebar md:w-[420px]">
         <div class="flex shrink-0 items-center justify-between border-b border-border px-5 py-4">
           <div class="flex items-center gap-2">
             <AppIcon name="message" class="h-4 w-4 text-primary" />

--- a/web/src/components/FloatingChat.vue
+++ b/web/src/components/FloatingChat.vue
@@ -61,7 +61,7 @@ defineExpose({ open, isOpen })
 </script>
 
 <template>
-  <div class="fixed bottom-4 right-4 z-50 flex w-[360px] max-w-[calc(100vw-1.5rem)] flex-col">
+  <div class="fixed bottom-0 right-0 z-50 flex w-full flex-col md:bottom-4 md:right-4 md:w-[360px]">
     <transition enter-active-class="duration-200 ease-out" enter-from-class="translate-y-2 scale-[0.97] opacity-0" enter-to-class="translate-y-0 scale-100 opacity-100" leave-active-class="duration-150 ease-in" leave-from-class="translate-y-0 scale-100 opacity-100" leave-to-class="translate-y-2 scale-[0.97] opacity-0">
       <div v-if="isOpen" class="flex h-[380px] flex-col overflow-hidden rounded-t-xl border border-border border-b-0 bg-sidebar">
         <div class="flex shrink-0 items-center justify-between border-b border-border/50 px-4 py-2.5">

--- a/web/src/components/MobileNav.vue
+++ b/web/src/components/MobileNav.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from 'vue'
+import { RouterLink, useRoute } from 'vue-router'
+import AppIcon from '@/components/AppIcon.vue'
+import { apiFetch } from '@/lib/api'
+
+type NavItem = {
+  to: string
+  label: string
+  icon: string
+  match?: string[]
+  badge?: 'feed' | 'inbox'
+}
+
+const route = useRoute()
+const feedCount = ref(0)
+const inboxCount = ref(0)
+let timer = 0
+
+const items: NavItem[] = [
+  { to: '/squads', label: 'Squads', icon: 'grid' },
+  { to: '/chat', label: 'Chat', icon: 'terminal' },
+  { to: '/activity', label: 'Activity', icon: 'activity' },
+  { to: '/feed', label: 'Feed', icon: 'message', badge: 'feed' },
+  { to: '/wiki', label: 'Wiki', icon: 'book' },
+  { to: '/skills', label: 'Settings', icon: 'settings', match: ['/skills', '/mcp'] },
+]
+
+function isActive(item: NavItem) {
+  const matches = item.match ?? [item.to]
+  return matches.some((m) => route.path.startsWith(m))
+}
+
+function badgeValue(item: NavItem) {
+  if (item.badge === 'feed') return feedCount.value
+  if (item.badge === 'inbox') return inboxCount.value
+  return 0
+}
+
+async function refreshCounts() {
+  try {
+    const [feedRes, inboxRes] = await Promise.all([
+      apiFetch('/api/feed/count'),
+      apiFetch('/api/inbox/count'),
+    ])
+    if (feedRes.ok) feedCount.value = Number((await feedRes.json() as { count: number }).count ?? 0)
+    if (inboxRes.ok) inboxCount.value = Number((await inboxRes.json() as { count: number }).count ?? 0)
+  } catch {
+    // ignore
+  }
+}
+
+onMounted(() => {
+  refreshCounts()
+  timer = window.setInterval(refreshCounts, 15000)
+})
+
+onUnmounted(() => {
+  window.clearInterval(timer)
+})
+</script>
+
+<template>
+  <nav class="fixed inset-x-0 bottom-0 z-30 flex items-center justify-around border-t border-border bg-sidebar px-2 pb-[env(safe-area-inset-bottom)] pt-1 md:hidden">
+    <RouterLink
+      v-for="item in items"
+      :key="item.to"
+      :to="item.to"
+      class="relative flex flex-col items-center gap-0.5 rounded-lg px-3 py-1.5 transition-colors"
+      :class="isActive(item) ? 'text-primary' : 'text-muted-foreground/50'"
+    >
+      <span v-if="badgeValue(item) > 0" class="absolute -right-0.5 -top-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-destructive px-0.5 font-mono text-[8px] font-bold leading-none text-white">{{ badgeValue(item) }}</span>
+      <AppIcon :name="item.icon" class="h-5 w-5" />
+      <span class="font-mono text-[10px]">{{ item.label }}</span>
+      <div v-if="isActive(item)" class="absolute bottom-0 left-1/2 h-0.5 w-6 -translate-x-1/2 rounded-full bg-primary" />
+    </RouterLink>
+  </nav>
+</template>

--- a/web/src/components/SettingsTabs.vue
+++ b/web/src/components/SettingsTabs.vue
@@ -8,7 +8,7 @@ defineProps<{
 
 <template>
   <div class="flex h-full flex-col overflow-hidden">
-    <div class="shrink-0 px-6 pb-0 pt-5">
+    <div class="shrink-0 px-4 pb-0 pt-5 md:px-6">
       <h2 class="mb-4 text-base font-semibold">Settings</h2>
       <div class="flex border-b border-border">
         <RouterLink to="/skills" class="-mb-px border-b-2 px-4 py-2 font-mono text-xs font-medium transition-colors" :class="active === 'skills' ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'">
@@ -19,7 +19,7 @@ defineProps<{
         </RouterLink>
       </div>
     </div>
-    <div class="flex-1 overflow-y-auto px-6 py-5">
+    <div class="flex-1 overflow-y-auto px-4 py-5 md:px-6">
       <slot />
     </div>
   </div>

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -53,7 +53,7 @@ watch(signature, async () => {
 </script>
 
 <template>
-  <div class="h-full overflow-y-auto p-5">
+  <div class="h-full overflow-y-auto p-3 md:p-5">
     <section class="mx-auto flex h-full max-w-[980px] flex-col overflow-hidden rounded-lg border border-border bg-card">
       <div class="flex shrink-0 items-center justify-between border-b border-border px-5 py-4">
         <div>

--- a/web/src/views/SquadsView.vue
+++ b/web/src/views/SquadsView.vue
@@ -123,11 +123,11 @@ onMounted(loadSquads)
   <div class="h-full overflow-y-auto p-5">
     <div v-if="error" class="mb-4 rounded-lg border border-destructive/25 bg-destructive/10 px-4 py-3 text-sm text-destructive">{{ error }}</div>
 
-    <div v-if="loading && !squads.length" class="grid grid-cols-1 gap-4 lg:grid-cols-2 xl:grid-cols-3">
+    <div v-if="loading && !squads.length" class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
       <div v-for="index in 6" :key="index" class="h-64 animate-pulse rounded-lg border border-border bg-card/60" />
     </div>
 
-    <div v-else-if="squads.length" class="grid grid-cols-1 gap-4 lg:grid-cols-2 xl:grid-cols-3">
+    <div v-else-if="squads.length" class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
       <SquadCard v-for="squad in squads" :key="squad.id" :squad="squad" />
     </div>
 

--- a/web/src/views/WikiView.vue
+++ b/web/src/views/WikiView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
+import AppIcon from '@/components/AppIcon.vue'
 import WikiTreeNode from '@/components/WikiTreeNode.vue'
 import { apiFetch } from '@/lib/api'
 import { renderMarkdown } from '@/lib/markdown'
@@ -14,6 +15,7 @@ const pages = ref<WikiPageSummary[]>([])
 const selectedPath = ref('')
 const detail = ref<WikiDetail | null>(null)
 const query = ref('')
+const treeOpen = ref(false)
 
 const filteredPages = computed(() => {
   const needle = query.value.trim().toLowerCase()
@@ -39,6 +41,11 @@ async function loadDetail(path: string) {
   detail.value = await response.json() as WikiDetail
 }
 
+function selectPage(path: string) {
+  selectedPath.value = path
+  treeOpen.value = false
+}
+
 watch(selectedPath, (path) => {
   loadDetail(path)
 })
@@ -47,14 +54,43 @@ onMounted(loadPages)
 </script>
 
 <template>
-  <div class="flex h-full overflow-hidden">
-    <aside class="w-52 shrink-0 overflow-y-auto border-r border-border px-2 py-4">
+  <div class="relative flex h-full flex-col overflow-hidden md:flex-row">
+    <!-- Mobile tree toggle -->
+    <div class="flex shrink-0 items-center gap-2 border-b border-border bg-sidebar px-4 py-2 md:hidden">
+      <button
+        class="flex items-center gap-1.5 rounded border border-border px-3 py-1.5 font-mono text-xs text-muted-foreground transition-colors hover:bg-white/5 hover:text-foreground"
+        @click="treeOpen = !treeOpen"
+      >
+        <AppIcon name="book" class="h-3.5 w-3.5" />
+        <span>{{ detail?.path ?? 'Pages' }}</span>
+        <AppIcon name="chevron-down" class="h-3 w-3 transition-transform" :class="treeOpen ? 'rotate-180' : ''" />
+      </button>
+    </div>
+
+    <!-- Mobile tree drawer -->
+    <transition
+      enter-active-class="duration-200 ease-out"
+      enter-from-class="-translate-y-2 opacity-0"
+      enter-to-class="translate-y-0 opacity-100"
+      leave-active-class="duration-150 ease-in"
+      leave-from-class="translate-y-0 opacity-100"
+      leave-to-class="-translate-y-2 opacity-0"
+    >
+      <div v-if="treeOpen" class="absolute left-0 right-0 top-[calc(2.75rem+2.75rem)] z-20 max-h-[60vh] overflow-y-auto border-b border-border bg-sidebar px-2 py-3 md:hidden">
+        <input v-model="query" class="mb-3 w-full rounded border border-border bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/35" placeholder="Filter pages" />
+        <WikiTreeNode v-for="node in tree" :key="node.id" :node="node" :selected-path="selectedPath" @select="selectPage($event)" />
+      </div>
+    </transition>
+
+    <!-- Desktop sidebar -->
+    <aside class="hidden w-52 shrink-0 overflow-y-auto border-r border-border px-2 py-4 md:block">
       <input v-model="query" class="mb-3 w-full rounded border border-border bg-sidebar px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/35" placeholder="Filter pages" />
       <WikiTreeNode v-for="node in tree" :key="node.id" :node="node" :selected-path="selectedPath" @select="selectedPath = $event" />
     </aside>
 
+    <!-- Content -->
     <section class="flex-1 overflow-y-auto">
-      <div v-if="detail" class="max-w-2xl px-8 py-6">
+      <div v-if="detail" class="max-w-2xl px-4 py-5 md:px-8 md:py-6">
         <h2 class="mb-5 text-xl font-semibold">{{ detail.path }}</h2>
         <div class="wiki-content" v-html="renderMarkdown(detail.content)" />
       </div>


### PR DESCRIPTION
Closes #298

## What changed

**New component:**
- `MobileNav.vue` — fixed bottom tab bar visible only on mobile (`md:hidden`), 6 nav items with active indicator and badge counts

**Modified files:**
- `App.vue` — hides subtitle/status bar on mobile; adds bottom padding for MobileNav clearance
- `AppSidebar.vue` — `hidden md:flex` (replaced by MobileNav on < md)
- `FeedFlyout.vue` — `w-full md:w-[420px]` for full-screen on mobile
- `FloatingChat.vue` — full-width `bottom-0 right-0` on mobile, `md:bottom-4 md:right-4 md:w-[360px]`
- `WikiView.vue` — collapsible tree drawer on mobile with toggle button; desktop sidebar unchanged
- `SquadsView.vue` — `md:grid-cols-2` (was `lg:`) so tablets get 2-col layout
- `SettingsTabs.vue` — `px-4 md:px-6` responsive padding
- `ChatView.vue` — `p-3 md:p-5` outer padding

**Protected:** `lib/`, `stores/`, `router/`, backend — untouched

## Quality
- `npm run build` — ✅ 0 errors
- `npm test` — ✅ 49/49 pass