### PR TITLE
fix: Feed flyout, chat overlay, and skill name overflow (#302, #303, #304)

### DIFF
--- a/web/src/components/FeedFlyout.vue
+++ b/web/src/components/FeedFlyout.vue
@@ -89,7 +89,7 @@ watch(() => props.open, (value) => {
       <div v-if="open" class="fixed inset-0 z-40 bg-black/40" @click="emit('close')" />
     </transition>
 
-    <transition enter-active-class="duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]" enter-from-class="translate-x-full" enter-to-class="translate-x-0" leave-active-class="duration-200 ease-in" leave-from-class="translate-x-0" leave-to-class="translate-x-full">
+    <transition enter-active-class="transition-transform duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]" enter-from-class="translate-x-full" enter-to-class="translate-x-0" leave-active-class="transition-transform duration-200 ease-in" leave-from-class="translate-x-0" leave-to-class="translate-x-full">
       <aside v-if="open" class="fixed inset-y-0 right-0 z-50 flex w-full flex-col border-l border-border bg-sidebar md:w-[420px]">
         <div class="flex shrink-0 items-center justify-between border-b border-border px-5 py-4">
           <div class="flex items-center gap-2">

--- a/web/src/components/FloatingChat.vue
+++ b/web/src/components/FloatingChat.vue
@@ -61,7 +61,7 @@ defineExpose({ open, isOpen })
 </script>
 
 <template>
-  <div class="fixed bottom-0 right-0 z-50 flex w-full flex-col md:bottom-4 md:right-4 md:w-[360px]">
+  <div class="fixed bottom-14 right-0 z-50 flex w-full flex-col md:bottom-10 md:right-4 md:w-[360px]">
     <transition enter-active-class="duration-200 ease-out" enter-from-class="translate-y-2 scale-[0.97] opacity-0" enter-to-class="translate-y-0 scale-100 opacity-100" leave-active-class="duration-150 ease-in" leave-from-class="translate-y-0 scale-100 opacity-100" leave-to-class="translate-y-2 scale-[0.97] opacity-0">
       <div v-if="isOpen" class="flex h-[380px] flex-col overflow-hidden rounded-t-xl border border-border border-b-0 bg-sidebar">
         <div class="flex shrink-0 items-center justify-between border-b border-border/50 px-4 py-2.5">

--- a/web/src/views/SkillsView.vue
+++ b/web/src/views/SkillsView.vue
@@ -60,7 +60,7 @@ onMounted(loadSkills)
         </div>
         <div class="overflow-hidden rounded-lg border border-border">
           <div v-for="(skill, index) in entries" :key="skill.slug" class="flex items-center gap-3 bg-card px-4 py-2.5 transition-colors hover:bg-card/80" :class="index > 0 ? 'border-t border-border/50' : ''">
-            <code class="w-40 shrink-0 font-mono text-xs text-foreground/80">{{ skill.name }}</code>
+            <code class="w-36 shrink-0 break-all font-mono text-xs text-foreground/80">{{ skill.name }}</code>
             <span class="flex-1 text-xs leading-relaxed text-muted-foreground">{{ skill.description }}</span>
             <span class="shrink-0 font-mono text-[9px] text-muted-foreground/30">built-in</span>
             <button type="button" class="relative h-4 w-8 shrink-0 rounded-full transition-colors" :class="enabled[skill.slug] ? 'bg-primary' : 'bg-white/10'" @click="toggleSkill(skill.slug)">


### PR DESCRIPTION
Fixes #302, Fixes #303, Fixes #304

## Changes

| Bug | Issue | Fix |
|---|---|---|
| Feed flyout doesn't appear | #302 | Added `transition-transform` to enter/leave-active-class — browser needed an explicit CSS property to animate |
| Chat overlay covers status bar | #303 | Offset to `bottom-14` mobile (clears MobileNav), `md:bottom-10` desktop (clears status bar) |
| Skill names overflow column | #304 | Added `break-all` to skill name `<code>` element to wrap within fixed-width column |

## Quality
- ✅ `npm run build` — 0 errors
- ✅ Web tests — 49/49 pass
- No changes to lib/, stores/, router/, or backend