### PR TITLE
feat: Dynamic model selection per task instead of static per-agent tier

### DIFF
--- a/src/copilot/agents.ts
+++ b/src/copilot/agents.ts
@@ -495,11 +495,10 @@ async function getOrCreateAgentSession(
 ): Promise<CopilotSession> {
   const key = agentSessionKey(squadSlug, agent.character_name);
 
-  // Determine model based on task complexity vs agent's default tier
+  // Determine model: task complexity is sole determinant when task context exists;
+  // stored model_tier is only a fallback for ad-hoc sessions without task context.
   const agentTier = agent.model_tier as Tier;
-  const taskTier = taskDescription ? classifyComplexity(taskDescription) : agentTier;
-  const tierRank: Record<Tier, number> = { high: 3, medium: 2, low: 1 };
-  const effectiveTier = tierRank[taskTier] >= tierRank[agentTier] ? taskTier : agentTier;
+  const effectiveTier = taskDescription ? classifyComplexity(taskDescription) : agentTier;
   const model = getModelForTier(effectiveTier);
 
   // If we have a cached session, check if the model matches AND the agent
@@ -537,7 +536,7 @@ async function getOrCreateAgentSession(
     ? `\n\n## Squad Wiki\n${wikiPages.map(p => `### ${p.path}\n${p.content}`).join("\n\n")}`
     : "";
 
-  console.error(`[io] Agent ${agent.character_name}: using model "${model}" (agent tier: ${agentTier}, task tier: ${taskTier}, effective: ${effectiveTier})`);
+  console.error(`[io] Agent ${agent.character_name}: using model "${model}" (stored tier: ${agentTier}, effective: ${effectiveTier})`);
 
   const universeName = squad.universe
     ? getUniverse(squad.universe)?.name ?? squad.universe

--- a/src/copilot/model-router.test.ts
+++ b/src/copilot/model-router.test.ts
@@ -1,0 +1,87 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { classifyComplexity } from "./model-router.js";
+
+describe("classifyComplexity", () => {
+  describe("high complexity", () => {
+    it("returns high when multiple high keywords are present", () => {
+      assert.equal(classifyComplexity("Refactor and redesign the auth module"), "high");
+    });
+
+    it("returns high with architect + security keywords", () => {
+      assert.equal(classifyComplexity("Architect a security overhaul"), "high");
+    });
+
+    it("returns high with debug + investigate", () => {
+      assert.equal(classifyComplexity("Investigate and debug the memory leak"), "high");
+    });
+
+    it("returns high for performance + optimize", () => {
+      assert.equal(classifyComplexity("Optimize performance of the query engine"), "high");
+    });
+  });
+
+  describe("low complexity", () => {
+    it("returns low when multiple low keywords are present", () => {
+      assert.equal(classifyComplexity("Read the file and check status"), "low");
+    });
+
+    it("returns low for simple rename task", () => {
+      assert.equal(classifyComplexity("Simple rename of the variable"), "low");
+    });
+
+    it("returns low for list + format", () => {
+      assert.equal(classifyComplexity("List all entries and format them"), "low");
+    });
+
+    it("returns low for delete file + remove file", () => {
+      assert.equal(classifyComplexity("Delete file foo.txt and remove file bar.txt"), "low");
+    });
+  });
+
+  describe("medium complexity", () => {
+    it("returns medium for ambiguous description with no keywords", () => {
+      assert.equal(classifyComplexity("Update the user profile page"), "medium");
+    });
+
+    it("returns medium for empty string", () => {
+      assert.equal(classifyComplexity(""), "medium");
+    });
+
+    it("returns medium when one high and one low keyword tie", () => {
+      // highScore=1, lowScore=1 — both weak, neither wins, falls to default
+      assert.equal(classifyComplexity("Debug and check the output"), "medium");
+    });
+  });
+
+  describe("weak signal tiebreaker", () => {
+    it("returns high when single high keyword beats zero low keywords", () => {
+      assert.equal(classifyComplexity("Refactor the utils module"), "high");
+    });
+
+    it("returns low when single low keyword beats zero high keywords", () => {
+      assert.equal(classifyComplexity("Check the build output"), "low");
+    });
+  });
+
+  describe("case insensitivity", () => {
+    it("matches keywords regardless of case", () => {
+      assert.equal(classifyComplexity("REFACTOR and REDESIGN everything"), "high");
+    });
+
+    it("matches low keywords in mixed case", () => {
+      assert.equal(classifyComplexity("FORMAT the List of entries"), "low");
+    });
+  });
+
+  describe("multi-word keywords", () => {
+    it("matches 'delete file' as a single keyword", () => {
+      assert.equal(classifyComplexity("Please delete file and copy file"), "low");
+    });
+
+    it("does not match partial multi-word keywords", () => {
+      // "delete" alone is not a keyword, only "delete file" is
+      assert.equal(classifyComplexity("Delete the branch"), "medium");
+    });
+  });
+});

--- a/src/copilot/tools.ts
+++ b/src/copilot/tools.ts
@@ -804,7 +804,7 @@ export function createTools(deps: ToolDeps) {
       console.error(`[io] squad_add_agent called: ${slug} — ${role_title}`);
       try {
         const agent = deps.addSquadAgent(slug, role_title, charter, model_tier);
-        return `Agent added to squad "${slug}":\n- **${agent.character_name}** — ${agent.role_title}\n- Personality: ${agent.personality}\n- Model tier: ${agent.model_tier}`;
+        return `Agent added to squad "${slug}":\n- **${agent.character_name}** — ${agent.role_title}\n- Personality: ${agent.personality}\n- Model: dynamic (task-based)`;
       } catch (err) {
         return `Error adding agent: ${err instanceof Error ? err.message : String(err)}`;
       }
@@ -854,7 +854,7 @@ export function createTools(deps: ToolDeps) {
         const statsStr = st.task_count === 0
           ? " — 📊 never delegated"
           : ` — 📊 ${st.task_count} ${st.task_count === 1 ? "task" : "tasks"} · last ${formatRelativeTime(st.last_delegated_at)}`;
-        return `- **${a.character_name}**${leadBadge}${qaBadge} — ${a.role_title} (${a.model_tier}) — ${a.status}${statsStr}${a.personality ? `\n  _${a.personality}_` : ""}`;
+        return `- **${a.character_name}**${leadBadge}${qaBadge} — ${a.role_title} (dynamic) — ${a.status}${statsStr}${a.personality ? `\n  _${a.personality}_` : ""}`;
       });
 
       const coverage = assessSquadCoverage(agents);

--- a/web/src/components/AgentRow.vue
+++ b/web/src/components/AgentRow.vue
@@ -10,7 +10,6 @@ const props = defineProps<{
 }>()
 
 const expanded = ref(false)
-const modelLabel = computed(() => (props.agent.model_tier ?? 'medium').toUpperCase())
 const charterText = computed(() => props.agent.charter || props.agent.role_title || 'No charter available.')
 </script>
 
@@ -22,7 +21,6 @@ const charterText = computed(() => props.agent.charter || props.agent.role_title
       <div class="flex shrink-0 gap-1">
         <span v-if="agent.is_lead" class="rounded bg-primary/10 px-1 py-0.5 font-mono text-[9px] leading-none text-primary">LEAD</span>
         <span v-if="agent.is_qa" class="rounded bg-status-success/10 px-1 py-0.5 font-mono text-[9px] leading-none text-status-success">QA</span>
-        <span class="rounded bg-white/5 px-1 py-0.5 font-mono text-[9px] uppercase leading-none text-muted-foreground">{{ modelLabel }}</span>
       </div>
       <div class="min-w-0 flex-1">
         <span v-if="agent.current_task" class="block truncate font-mono text-[11px] text-foreground/60">↳ {{ agent.current_task }}</span>


### PR DESCRIPTION
## Summary

Removes the static per-agent `model_tier` as the primary model selector. Instead, the model is chosen **dynamically at task delegation time** based on task complexity analysis.

### What Changed

**Backend (`src/copilot/`):**
- `agents.ts`: Effective tier is now solely determined by `classifyComplexity(taskDescription)` when a task is provided. The stored `model_tier` is only used as a fallback when no task context is available (ad-hoc sessions).
- `tools.ts`: `squad_add_agent` reports 'Model: dynamic (task-based)'; `squad_agents` list shows '(dynamic)' instead of the stored tier.
- `model-router.ts`: Existing `classifyComplexity()` logic — keywords analysis for high/medium/low classification.

**Web UI:**
- `AgentRow.vue`: Removed the static model tier badge (HIGH/MEDIUM/LOW). LEAD and QA badges remain.

**Tests:**
- Added `src/copilot/model-router.test.ts` — 17 tests covering all branches of `classifyComplexity()`.

### Migration
- `model_tier` column stays in the DB with DEFAULT 'medium' — no migration needed.
- Existing agents continue to work — stored tier is simply no longer displayed or used as primary selector.
- `squad_add_agent` tool still accepts optional `model_tier` parameter (backwards compatible).

### Quality
- ✅ Backend tests: 267/267 pass
- ✅ Web tests: 49/49 pass
- ✅ Model router tests: 17/17 pass
- ✅ Web build: 0 errors