### PR TITLE
fix: change working status indicator to green (#311)

### DIFF
--- a/web/src/components/StatusIndicator.vue
+++ b/web/src/components/StatusIndicator.vue
@@ -7,8 +7,8 @@ withDefaults(defineProps<{ status: 'idle' | 'working' | 'error' | 'success' }>()
 <template>
   <div class="relative flex h-3 w-3 shrink-0 items-center justify-center">
     <template v-if="status === 'working'">
-      <div class="status-working-ring absolute h-3 w-3 rounded-full bg-status-working" :style="{ boxShadow: 'var(--glow-cyan)' }" />
-      <div class="h-2 w-2 rounded-full bg-status-working" :style="{ boxShadow: 'var(--glow-cyan)' }" />
+      <div class="status-working-ring absolute h-3 w-3 rounded-full bg-status-working" :style="{ boxShadow: 'var(--glow-success)' }" />
+      <div class="h-2 w-2 rounded-full bg-status-working" :style="{ boxShadow: 'var(--glow-success)' }" />
     </template>
     <div v-else-if="status === 'error'" class="status-error-dot h-2 w-2 rounded-full bg-status-error" :style="{ boxShadow: 'var(--glow-error)' }" />
     <div v-else-if="status === 'success'" class="h-2 w-2 rounded-full bg-status-success" :style="{ boxShadow: 'var(--glow-success)' }" />

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -22,7 +22,7 @@
   --border: #252530;
   --sidebar: #0f0f16;
   --status-idle: #8a8a99;
-  --status-working: #00d9ff;
+  --status-working: #5fff87;
   --status-error: #ff3864;
   --status-success: #5fff87;
   --universe-ateam: #ff6b35;
@@ -51,7 +51,7 @@
   --border-rgb: 37 37 48;
   --sidebar-rgb: 15 15 22;
   --status-idle-rgb: 138 138 153;
-  --status-working-rgb: 0 217 255;
+  --status-working-rgb: 95 255 135;
   --status-error-rgb: 255 56 100;
   --status-success-rgb: 95 255 135;
   --universe-ateam-rgb: 255 107 53;


### PR DESCRIPTION
Closes #311

## Changes
- `StatusIndicator.vue`: working state uses `--glow-success` instead of `--glow-cyan`
- `style.css`: `--status-working` changed from cyan (#00d9ff) to green (#5fff87)
- `style.css`: `--status-working-rgb` updated to match (95 255 135)

## Other status colors (unchanged)
- **Error:** #ff3864 (red)
- **Idle:** #8a8a99 (gray)
- **Success:** #5fff87 (green — same as working now)

## Verified
- `npm run build` ✅ 0 errors
- `npm test` ✅ 49/49 pass