### PR TITLE
feat: squad color assignment on creation (#310) — backend

### DIFF
--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -179,6 +179,7 @@ GROUP BY agent_slug`,
     )`,
     `CREATE INDEX IF NOT EXISTS idx_unified_feed_type ON unified_feed(type, created_at)`,
     `CREATE INDEX IF NOT EXISTS idx_unified_feed_unread ON unified_feed(read_at, created_at)`,
+    `ALTER TABLE squads ADD COLUMN color TEXT`,
     `CREATE TABLE IF NOT EXISTS squad_instances (
       id TEXT PRIMARY KEY,
       master_squad_slug TEXT NOT NULL,
@@ -220,6 +221,7 @@ GROUP BY agent_slug`,
     `DROP TABLE unified_feed_old`,
     `CREATE INDEX IF NOT EXISTS idx_unified_feed_type ON unified_feed(type, created_at)`,
     `CREATE INDEX IF NOT EXISTS idx_unified_feed_unread ON unified_feed(read_at, created_at)`,
+    `ALTER TABLE squads ADD COLUMN color TEXT`,
   ];
 
   for (const migration of migrations) {
@@ -248,6 +250,32 @@ GROUP BY agent_slug`,
     }
   } catch {
     // Migration failed (e.g. old tables don't exist yet on a fresh install) — safe to ignore
+  }
+
+  // One-time migration: assign colors to existing squads that have none
+  try {
+    const colorMigrated = db.prepare("SELECT value FROM io_state WHERE key = 'squad_colors_migrated'").get() as { value: string } | undefined;
+    if (!colorMigrated) {
+      const palette = [
+        "#ff6b35", "#ffd000", "#5fff87", "#c4a7ff", "#00d9ff",
+        "#ff9800", "#9c27b0", "#2196f3", "#e91e63", "#00bcd4",
+        "#8bc34a", "#ff5722",
+      ];
+      const uncolored = db.prepare("SELECT slug FROM squads WHERE color IS NULL ORDER BY id ASC").all() as { slug: string }[];
+      const usedColors = new Set((db.prepare("SELECT color FROM squads WHERE color IS NOT NULL").all() as { color: string }[]).map(r => r.color));
+      const update = db.prepare("UPDATE squads SET color = ? WHERE slug = ?");
+      let idx = 0;
+      for (const { slug } of uncolored) {
+        const available = palette.filter(c => !usedColors.has(c));
+        const color = available.length > 0 ? available[0] : palette[idx % palette.length];
+        update.run(color, slug);
+        usedColors.add(color);
+        idx++;
+      }
+      db.prepare("INSERT OR REPLACE INTO io_state (key, value) VALUES ('squad_colors_migrated', '1')").run();
+    }
+  } catch {
+    // Safe to ignore on fresh install
   }
 
   return db;

--- a/src/store/squads.test.ts
+++ b/src/store/squads.test.ts
@@ -444,3 +444,65 @@ describe("setSquadQA", () => {
     assert.equal(getSquadAgent("test-squad", agent.character_name)?.is_qa, 0);
   });
 });
+
+// ── pickSquadColor / squad color assignment ───────────────────────────────────
+
+import { pickSquadColor, SQUAD_COLOR_PALETTE } from "./squads.js";
+
+describe("pickSquadColor", () => {
+  it("returns a palette color for empty squad list", () => {
+    const color = pickSquadColor([]);
+    assert.ok(SQUAD_COLOR_PALETTE.includes(color as typeof SQUAD_COLOR_PALETTE[number]));
+  });
+
+  it("returns an unused color when some are taken", () => {
+    const taken = [SQUAD_COLOR_PALETTE[0]!, SQUAD_COLOR_PALETTE[1]!];
+    const color = pickSquadColor(taken);
+    assert.ok(!taken.includes(color));
+    assert.ok(SQUAD_COLOR_PALETTE.includes(color as typeof SQUAD_COLOR_PALETTE[number]));
+  });
+
+  it("cycles through palette when all colors are taken", () => {
+    const allTaken = [...SQUAD_COLOR_PALETTE];
+    const color = pickSquadColor(allTaken);
+    // Should fall back to cycling — result is still a valid palette color
+    assert.ok(SQUAD_COLOR_PALETTE.includes(color as typeof SQUAD_COLOR_PALETTE[number]));
+  });
+
+  it("ignores null values in existing colors", () => {
+    const withNulls: (string | null)[] = [null, null, SQUAD_COLOR_PALETTE[0]!];
+    const color = pickSquadColor(withNulls);
+    assert.notEqual(color, SQUAD_COLOR_PALETTE[0]!);
+  });
+});
+
+describe("createSquad — color assignment", () => {
+  it("assigns a non-null color on creation", () => {
+    const squad = createSquad("color-squad-1", "Color Squad 1", "/tmp/test");
+    assert.ok(squad.color !== null && squad.color !== undefined);
+  });
+
+  it("assigns colors from the palette", () => {
+    const squad = createSquad("color-squad-2", "Color Squad 2", "/tmp/test");
+    assert.ok(SQUAD_COLOR_PALETTE.includes(squad.color as typeof SQUAD_COLOR_PALETTE[number]));
+  });
+
+  it("assigns distinct colors to two squads", () => {
+    const a = createSquad("color-squad-3", "Squad A", "/tmp/test");
+    const b = createSquad("color-squad-4", "Squad B", "/tmp/test");
+    assert.notEqual(a.color, b.color);
+  });
+
+  it("all squads up to palette size get distinct colors", () => {
+    const slugs: string[] = [];
+    for (let i = 0; i < SQUAD_COLOR_PALETTE.length; i++) {
+      const slug = `palette-squad-${i}`;
+      slugs.push(slug);
+      createSquad(slug, `Squad ${i}`, "/test");
+    }
+    const squads = slugs.map(s => getSquad(s)!);
+    const colors = squads.map(s => s.color);
+    const uniqueColors = new Set(colors);
+    assert.equal(uniqueColors.size, SQUAD_COLOR_PALETTE.length);
+  });
+});

--- a/src/store/squads.ts
+++ b/src/store/squads.ts
@@ -2,6 +2,38 @@ import { getDb } from "./db.js";
 import { nextCharacter, randomUniverse, getUniverse, getOrCreateUniverse } from "../copilot/universes.js";
 import type { Character, Universe } from "../copilot/universes.js";
 
+// ---------------------------------------------------------------------------
+// Squad color palette — universe-inspired distinct colors
+// ---------------------------------------------------------------------------
+
+export const SQUAD_COLOR_PALETTE: readonly string[] = [
+  "#ff6b35", // A-Team orange
+  "#ffd000", // Thundercats gold
+  "#5fff87", // GI Joe green
+  "#c4a7ff", // Ghostbusters purple
+  "#00d9ff", // Transformers cyan
+  "#ff9800", // extra amber
+  "#9c27b0", // extra violet
+  "#2196f3", // extra blue
+  "#e91e63", // extra pink
+  "#00bcd4", // extra teal
+  "#8bc34a", // extra lime
+  "#ff5722", // extra deep-orange
+] as const;
+
+/**
+ * Pick a color for a new squad. Prefers an unused palette color; when all
+ * are taken, cycles through the palette by position (modular assignment).
+ * This guarantees we never throw and always return a valid hex color.
+ */
+export function pickSquadColor(existingColors: (string | null)[]): string {
+  const used = new Set(existingColors.filter(Boolean) as string[]);
+  const unused = SQUAD_COLOR_PALETTE.filter((c) => !used.has(c));
+  if (unused.length > 0) return unused[0]!;
+  // All palette colors taken — cycle by squad count
+  return SQUAD_COLOR_PALETTE[used.size % SQUAD_COLOR_PALETTE.length]!;
+}
+
 export interface Squad {
   id: number;
   slug: string;
@@ -10,6 +42,7 @@ export interface Squad {
   copilot_session_id: string | null;
   model: string | null;
   universe: string | null;
+  color: string | null;
   status: string;
   created_at: string;
   updated_at: string;
@@ -48,9 +81,11 @@ export function createSquad(
   const universe = universeId
     ? getOrCreateUniverse(universeId).id
     : randomUniverse().id;
+  const existingSquads = listSquads();
+  const color = pickSquadColor(existingSquads.map((s) => s.color));
   db.prepare(
-    "INSERT INTO squads (slug, name, project_path, universe) VALUES (?, ?, ?, ?)",
-  ).run(slug, name, projectPath, universe);
+    "INSERT INTO squads (slug, name, project_path, universe, color) VALUES (?, ?, ?, ?, ?)",
+  ).run(slug, name, projectPath, universe, color);
   return getSquad(slug)!;
 }
 


### PR DESCRIPTION
Part of #310 (backend half — store layer).

## Summary
Assigns a unique color to each squad from a curated palette when it's created.

## Changes

### `src/store/squads.ts`
- `SQUAD_COLOR_PALETTE` — 12 universe-inspired colors (A-Team orange, Thundercats gold, GI Joe green, Ghostbusters purple, Transformers cyan, + 7 extras)
- `pickSquadColor(existingColors)` — exported helper; prefers unused palette colors, cycles on exhaustion (no throws)
- `Squad.color` field added to interface
- `createSquad()` now assigns a color at creation time

### `src/store/db.ts`
- Migration: `ALTER TABLE squads ADD COLUMN color TEXT`
- One-time backfill: assigns palette colors to existing squads without one (idempotent, tracked via `io_state`)

## Tests
8 new tests: `pickSquadColor` unit tests + `createSquad` color integration tests.

## Not included (separate PRs)
- Frontend UI integration (Panthro's domain)
- Changes to squad API response (color field is already included via `SELECT *`)