### PR TITLE
fix: add missing SVG icon definitions (#330)

### DIFF
--- a/web/src/components/AppIcon.vue
+++ b/web/src/components/AppIcon.vue
@@ -87,5 +87,22 @@ defineProps<{ name: string }>()
     <template v-else-if="name === 'circle'">
       <circle cx="12" cy="12" r="4.25" fill="currentColor" stroke="none" />
     </template>
+    <template v-else-if="name === 'log-out'">
+      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+      <polyline points="16 17 21 12 16 7" />
+      <line x1="21" y1="12" x2="9" y2="12" />
+    </template>
+    <template v-else-if="name === 'pencil'">
+      <path d="M17 3a2.85 2.85 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
+      <path d="m15 5 4 4" />
+    </template>
+    <template v-else-if="name === 'alert-circle'">
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="8" x2="12" y2="12" />
+      <line x1="12" y1="16" x2="12.01" y2="16" />
+    </template>
+    <template v-else>
+      <circle cx="12" cy="12" r="8" stroke-dasharray="2 2" />
+    </template>
   </svg>
 </template>


### PR DESCRIPTION
## Bug Fix: Missing SVG Icons in AppIcon.vue

Fixes broken icon rendering for the sign-out button (#325) and wiki edit UI (#312).

### Icons Added

1. **log-out** — Standard logout/door icon for sign-out button
2. **pencil** — Edit/pencil icon for wiki edit button  
3. **alert-circle** — Alert circle icon for error state display

### Additional Improvements

- Added fallback template for unrecognized icon names (dashed circle)
- Prevents empty SVG rendering when icon name is not found
- Follows existing SVG pattern with stroke-based rendering

### Affected Components

- App.vue:133 — sign-out button (was rendering blank)
- WikiView.vue:181 — edit wiki button (was rendering blank)
- WikiView.vue:196 — error state icon (was rendering blank)

### Testing

- All 49 web tests pass ✓
- TypeScript clean (no errors) ✓
- Vite build successful (6.7s) ✓

### Branch

`snarf/fix-svg-rendering`

This PR ensures icons render correctly in all affected surfaces.