### PR TITLE
fix: add background color to Feed flyout (#330)

### DIFF
--- a/web/src/components/FeedFlyout.vue
+++ b/web/src/components/FeedFlyout.vue
@@ -90,7 +90,7 @@ watch(() => props.open, (value) => {
     </transition>
 
     <transition enter-active-class="transition-transform duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]" enter-from-class="translate-x-full" enter-to-class="translate-x-0" leave-active-class="transition-transform duration-200 ease-in" leave-from-class="translate-x-0" leave-to-class="translate-x-full">
-      <aside v-if="open" class="fixed inset-y-0 right-0 z-50 flex w-full flex-col border-l border-border bg-sidebar md:w-[420px]">
+      <aside v-if="open" class="fixed inset-y-0 right-0 z-50 flex w-full flex-col border-l border-border bg-gray-950 md:w-[420px]">
         <div class="flex shrink-0 items-center justify-between border-b border-border px-5 py-4">
           <div class="flex items-center gap-2">
             <AppIcon name="message" class="h-4 w-4 text-primary" />
@@ -107,7 +107,7 @@ watch(() => props.open, (value) => {
           <div v-else-if="!groupedEntries.length" class="px-5 py-8 font-mono text-xs uppercase tracking-[0.22em] text-muted-foreground/50">No feed activity.</div>
           <div v-else>
             <section v-for="group in groupedEntries" :key="group.key" class="border-b border-border/40 last:border-b-0">
-              <div class="sticky top-0 z-10 border-b border-border/40 bg-sidebar/95 px-5 py-2 backdrop-blur">
+              <div class="sticky top-0 z-10 border-b border-border/40 bg-gray-950 px-5 py-2 backdrop-blur">
                 <span class="rounded px-1.5 py-0.5 font-mono text-[10px]" :style="{ color: group.color, backgroundColor: withAlpha(group.color, 0.15) }">{{ group.label }}</span>
               </div>
               <div>


### PR DESCRIPTION
## Issue #330: Feed Flyout Background Transparent Bug

Fixes the Feed flyout panel rendering with a transparent background, causing content from behind the flyout to bleed through.

### Root Cause

The Feed flyout container was using `bg-sidebar` which appeared to not be rendering properly, leaving the flyout panel transparent and making feed items unreadable.

### Fix

- Replaced `bg-sidebar` with `bg-gray-950` (standard Tailwind dark color) on the main `<aside>` element
- Applied the same background to the sticky group header (was `bg-sidebar/95`)
- Ensures solid opaque background so content behind the flyout doesn't bleed through

### Testing

- All 49 web tests pass ✓
- TypeScript clean (no errors) ✓
- Vite build successful (6.09s) ✓

### Result

Feed items are now clearly readable with proper background color and no transparency issues.

### Branch

`panthro/issue-330-feed-flyout-bg`