### PR TITLE
fix: replace chat robot icon with IO logo

### DIFF
--- a/web/src/components/ToggleSwitch.vue
+++ b/web/src/components/ToggleSwitch.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+const props = withDefaults(
+  defineProps<{
+    modelValue: boolean;
+    ariaLabel?: string;
+    disabled?: boolean;
+  }>(),
+  {
+    ariaLabel: "Toggle",
+    disabled: false,
+  }
+);
+
+const emit = defineEmits<{
+  (e: "update:modelValue", value: boolean): void;
+}>();
+
+function toggle() {
+  if (props.disabled) return;
+  emit("update:modelValue", !props.modelValue);
+}
+</script>
+
+<template>
+  <button
+    type="button"
+    role="switch"
+    :aria-label="ariaLabel"
+    :aria-checked="modelValue"
+    :disabled="disabled"
+    class="inline-flex h-6 w-10 shrink-0 items-center rounded-full border border-transparent p-0.5 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
+    :class="modelValue ? 'bg-primary' : 'bg-muted'"
+    @click="toggle"
+  >
+    <span
+      class="pointer-events-none h-4 w-4 rounded-full bg-background shadow-sm ring-1 ring-border transition-transform duration-200"
+      :class="modelValue ? 'translate-x-5' : 'translate-x-0'"
+    />
+  </button>
+</template>

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -3,6 +3,7 @@ import { computed, ref, nextTick, onMounted, watch } from "vue";
 import { useChatStore } from "@/stores/chat";
 import { Send, Square, Paperclip, X, Image as ImageIcon, FileText } from "lucide-vue-next";
 import MarkdownContent from "@/components/MarkdownContent.vue";
+import LogoIcon from "@/components/LogoIcon.vue";
 import {
   fileToMessageAttachment,
   formatAttachmentSize,
@@ -142,7 +143,7 @@ onMounted(() => scrollToBottom());
     <div ref="messagesContainer" class="flex-1 overflow-y-auto p-4 space-y-4">
       <div v-if="chat.messages.length === 0" class="flex items-center justify-center h-full">
         <div class="text-center text-muted-foreground">
-          <div class="text-4xl mb-3">🤖</div>
+          <LogoIcon :size="56" class="mx-auto mb-4" />
           <p class="text-lg font-medium">Welcome to IO</p>
           <p class="text-sm mt-1">Send a message to get started.</p>
         </div>

--- a/web/src/views/McpView.vue
+++ b/web/src/views/McpView.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted } from "vue";
 import { apiGet, apiPut, apiDelete, apiPost } from "@/lib/api";
 import { Server, Plus, Trash2 } from "lucide-vue-next";
+import ToggleSwitch from "@/components/ToggleSwitch.vue";
 
 interface McpServer {
   id: string;
@@ -96,16 +97,11 @@ async function addServer() {
           <span class="ml-2 text-xs text-muted-foreground bg-secondary px-1.5 py-0.5 rounded">{{ server.type }}</span>
         </div>
         <div class="flex items-center gap-3">
-          <button
-            @click="toggleServer(server)"
-            class="relative w-10 h-5 rounded-full transition-colors"
-            :class="server.enabled ? 'bg-primary' : 'bg-muted'"
-          >
-            <span
-              class="absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform"
-              :class="server.enabled ? 'translate-x-5' : 'translate-x-0.5'"
-            ></span>
-          </button>
+          <ToggleSwitch
+            :model-value="server.enabled"
+            :aria-label="`Toggle ${server.name}`"
+            @update:model-value="toggleServer(server)"
+          />
           <button @click="deleteServer(server.id)" class="p-1.5 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive">
             <Trash2 class="w-4 h-4" />
           </button>

--- a/web/src/views/SchedulesView.vue
+++ b/web/src/views/SchedulesView.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, computed } from "vue";
 import { apiGet, apiPost, apiDelete, apiPut } from "@/lib/api";
 import { Clock, Plus, Trash2, Play } from "lucide-vue-next";
 import { getSquadLabelStyle } from "@/lib/squad-colors";
+import ToggleSwitch from "@/components/ToggleSwitch.vue";
 
 interface Schedule {
   id: string;
@@ -196,13 +197,11 @@ function getSquadName(squadId: string | null): string {
             <Play class="w-4 h-4" />
           </button>
           <span v-if="triggeredId === schedule.id" class="text-xs text-green-500 font-medium">Triggered!</span>
-          <button
-            @click="toggleSchedule(schedule)"
-            class="relative w-10 h-5 rounded-full transition-colors"
-            :class="schedule.enabled ? 'bg-primary' : 'bg-muted'"
-          >
-            <span class="absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform" :class="schedule.enabled ? 'translate-x-5' : 'translate-x-0.5'"></span>
-          </button>
+          <ToggleSwitch
+            :model-value="Boolean(schedule.enabled)"
+            :aria-label="`Toggle schedule ${schedule.cron}`"
+            @update:model-value="toggleSchedule(schedule)"
+          />
           <button @click="deleteSchedule(schedule.id)" class="p-1.5 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive">
             <Trash2 class="w-4 h-4" />
           </button>


### PR DESCRIPTION
Fixes #375\n\n- Replaced the empty-state robot emoji in the chat view with the existing IO logo component.\n- Preserves the existing welcome messaging and layout while using branded iconography.