### PR TITLE
fix: remove top sidebar Chat link

### DIFF
--- a/web/src/components/AppSidebar.vue
+++ b/web/src/components/AppSidebar.vue
@@ -25,7 +25,6 @@ const route = useRoute();
 const collapsed = ref(false);
 
 const navItems = [
-  { name: "Chat", icon: MessageSquare, path: "/" },
   { name: "History", icon: History, path: "/history" },
   { name: "Squads", icon: Users, path: "/squads" },
   { name: "Health", icon: Activity, path: "/squads/health" },


### PR DESCRIPTION
Removes the top Chat link from the main sidebar navigation while preserving the bottom Chat link in the footer.