### PR TITLE
fix: propagate GitHub token to squad agent sessions

### DIFF
--- a/src/copilot/client.test.ts
+++ b/src/copilot/client.test.ts
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loadConfig, resetConfigCache, saveConfig } from "../config.js";
+import { getCopilotClientOptions } from "./client.js";
+import { resetGhTokenCache } from "./gh-token.js";
+
+const originalConfig = loadConfig();
+const originalGhToken = process.env.GH_TOKEN;
+const originalGithubToken = process.env.GITHUB_TOKEN;
+
+function restoreEnvironment(): void {
+  if (originalGhToken === undefined) {
+    delete process.env.GH_TOKEN;
+  } else {
+    process.env.GH_TOKEN = originalGhToken;
+  }
+
+  if (originalGithubToken === undefined) {
+    delete process.env.GITHUB_TOKEN;
+  } else {
+    process.env.GITHUB_TOKEN = originalGithubToken;
+  }
+}
+
+test("getCopilotClientOptions forwards configured github token from config", () => {
+  resetGhTokenCache();
+  resetConfigCache();
+  process.env.GH_TOKEN = "";
+  process.env.GITHUB_TOKEN = "";
+  saveConfig({ githubToken: "test-github-token" });
+
+  try {
+    const options = getCopilotClientOptions();
+    assert.deepEqual(options, { githubToken: "test-github-token" });
+  } finally {
+    resetGhTokenCache();
+    resetConfigCache();
+    restoreEnvironment();
+    saveConfig({ githubToken: originalConfig.githubToken });
+  }
+});

--- a/src/copilot/client.ts
+++ b/src/copilot/client.ts
@@ -1,11 +1,16 @@
 import { CopilotClient } from "@github/copilot-sdk";
-import { PATHS } from "../paths.js";
+import { getGhToken } from "./gh-token.js";
 
 let client: CopilotClient | undefined;
 
+export function getCopilotClientOptions(): ConstructorParameters<typeof CopilotClient>[0] {
+  const githubToken = getGhToken();
+  return githubToken ? { githubToken } : {};
+}
+
 export async function getClient(): Promise<CopilotClient> {
   if (!client) {
-    client = new CopilotClient();
+    client = new CopilotClient(getCopilotClientOptions());
     await client.start();
   }
   return client;

--- a/src/copilot/gh-token.ts
+++ b/src/copilot/gh-token.ts
@@ -9,6 +9,11 @@ import { loadConfig, resetConfigCache } from "../config.js";
 let cachedToken: string | undefined;
 let resolved = false;
 
+export function resetGhTokenCache(): void {
+  cachedToken = undefined;
+  resolved = false;
+}
+
 export function getGhToken(): string | undefined {
   if (resolved && cachedToken) return cachedToken;
 


### PR DESCRIPTION
Fixes #398\n\nThe shared Copilot client now forwards the resolved GitHub token so squad agent sessions inherit authentication from the configured token source. This includes regression coverage for token propagation.