### PR TITLE
fix: use billed usage costs for token tracking

### DIFF
--- a/src/copilot/token-tracker.test.ts
+++ b/src/copilot/token-tracker.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test, { after, beforeEach } from "node:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tempHome = mkdtempSync(join(tmpdir(), "io-token-tracker-"));
+const originalHome = process.env.HOME;
+process.env.HOME = tempHome;
+
+const { attachTokenTracker } = await import("./token-tracker.js");
+const { closeDb } = await import("../store/db.js");
+const { getTokenUsageSummary } = await import("../store/token-usage.js");
+
+beforeEach(() => {
+  closeDb();
+  rmSync(join(tempHome, ".io"), { recursive: true, force: true });
+});
+
+after(() => {
+  closeDb();
+  process.env.HOME = originalHome;
+  rmSync(tempHome, { recursive: true, force: true });
+});
+
+test("attachTokenTracker uses billed AIU cost from Copilot usage events when present", () => {
+  const handlers: Array<(event: any) => void> = [];
+  const session = {
+    on: (_event: string, handler: (event: any) => void) => {
+      handlers.push(handler);
+      return () => {};
+    },
+  } as any;
+
+  const flush = attachTokenTracker(session, {});
+
+  handlers[0]({
+    data: {
+      model: "gpt-4.1",
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      copilotUsage: {
+        totalNanoAiu: 1_250_000_000_000_000,
+      },
+    },
+  });
+
+  const totals = flush();
+
+  assert.equal(totals.totalInputTokens, 1_000_000);
+  assert.equal(totals.totalOutputTokens, 1_000_000);
+  assert.equal(totals.totalCostUsd, 12.5);
+
+  const summary = getTokenUsageSummary();
+  assert.equal(summary.total_records, 1);
+  assert.equal(summary.total_cost_usd, 12.5);
+});
+
+test("attachTokenTracker falls back to estimated pricing when billed AIU data is absent", () => {
+  const handlers: Array<(event: any) => void> = [];
+  const session = {
+    on: (_event: string, handler: (event: any) => void) => {
+      handlers.push(handler);
+      return () => {};
+    },
+  } as any;
+
+  const flush = attachTokenTracker(session, {});
+
+  handlers[0]({
+    data: {
+      model: "gpt-4.1",
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+    },
+  });
+
+  const totals = flush();
+
+  assert.equal(totals.totalCostUsd, 10);
+
+  const summary = getTokenUsageSummary();
+  assert.equal(summary.total_records, 1);
+  assert.equal(summary.total_cost_usd, 10);
+});

--- a/src/copilot/token-tracker.ts
+++ b/src/copilot/token-tracker.ts
@@ -3,6 +3,8 @@ import { loadConfig } from "../config.js";
 import { recordTokenUsage } from "../store/token-usage.js";
 import { postFeedItem } from "../store/feed.js";
 
+const NANO_AIU_TO_USD = 1e-14;
+
 /**
  * Default model pricing (USD per 1M tokens).
  * Used when modelPricing is not configured.
@@ -36,7 +38,16 @@ export function estimateCost(model: string, inputTokens: number, outputTokens: n
 }
 
 interface UsageAccumulator {
-  [model: string]: { inputTokens: number; outputTokens: number };
+  [model: string]: { inputTokens: number; outputTokens: number; costUsd: number };
+}
+
+function resolveCostUsd(data: any, model: string, inputTokens: number, outputTokens: number): number {
+  const totalNanoAiu = data?.copilotUsage?.totalNanoAiu;
+  if (typeof totalNanoAiu === "number" && Number.isFinite(totalNanoAiu)) {
+    return totalNanoAiu * NANO_AIU_TO_USD;
+  }
+
+  return estimateCost(model, inputTokens, outputTokens);
 }
 
 /**
@@ -62,9 +73,10 @@ export function attachTokenTracker(
     const model: string = data.model;
     const input: number = data.inputTokens ?? 0;
     const output: number = data.outputTokens ?? 0;
-    if (!accumulator[model]) accumulator[model] = { inputTokens: 0, outputTokens: 0 };
+    if (!accumulator[model]) accumulator[model] = { inputTokens: 0, outputTokens: 0, costUsd: 0 };
     accumulator[model].inputTokens += input;
     accumulator[model].outputTokens += output;
+    accumulator[model].costUsd += resolveCostUsd(data, model, input, output);
   });
 
   return () => {
@@ -76,7 +88,7 @@ export function attachTokenTracker(
 
     for (const [model, usage] of Object.entries(accumulator)) {
       if (usage.inputTokens === 0 && usage.outputTokens === 0) continue;
-      const costUsd = estimateCost(model, usage.inputTokens, usage.outputTokens);
+      const costUsd = usage.costUsd ?? estimateCost(model, usage.inputTokens, usage.outputTokens);
       recordTokenUsage({
         squadId: context.squadId,
         agentId: context.agentId,


### PR DESCRIPTION
Uses Copilot usage billing metadata when available and falls back to configured pricing. Adds regression coverage for billed AIU totals.