### PR TITLE
Add schedule prompt editing in the web UI

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -18,7 +18,7 @@ import {
   deleteFeedItem,
   getUnreadCount,
 } from "../store/feed.js";
-import { listSchedules, createSchedule, deleteSchedule, toggleSchedule } from "../store/schedules.js";
+import { listSchedules, createSchedule, updateSchedule, deleteSchedule, getSchedule } from "../store/schedules.js";
 import { triggerSchedule } from "../copilot/trigger-schedule.js";
 import { listServers, toggleMcpServer, addMcpServer, removeMcpServer } from "../mcp/index.js";
 import { listSkills, addSkill, createSkill, removeSkill, getSkillContent, updateSkillContent, discoverSkills, installFromSource, fetchRemoteSkillPreview } from "../copilot/skills.js";
@@ -554,11 +554,21 @@ export async function startApiServer(config: Config): Promise<void> {
   });
 
   app.put("/api/schedules/:id", (req, res) => {
-    const { enabled } = req.body;
-    if (typeof enabled === "boolean") {
-      toggleSchedule(req.params.id, enabled);
+    const schedule = getSchedule(req.params.id);
+    if (!schedule) {
+      res.status(404).json({ error: "Schedule not found" });
+      return;
     }
-    res.json({ ok: true });
+
+    const { enabled, cron, agenda, prompt } = req.body ?? {};
+    const updated = updateSchedule(req.params.id, {
+      cron: typeof cron === "string" ? cron : undefined,
+      agenda: typeof agenda === "string" ? agenda : undefined,
+      prompt: typeof prompt === "string" ? prompt : undefined,
+      enabled: typeof enabled === "boolean" ? enabled : undefined,
+    });
+
+    res.json(updated);
   });
 
   app.post("/api/schedules/:id/trigger", (req, res) => {

--- a/src/store/schedules.test.ts
+++ b/src/store/schedules.test.ts
@@ -8,7 +8,7 @@ const tempHome = mkdtempSync(join(tmpdir(), "io-schedules-test-"));
 process.env.HOME = tempHome;
 
 const { createSquad } = await import("./squads.js");
-const { createSchedule, listSchedules } = await import("./schedules.js");
+const { createSchedule, listSchedules, updateSchedule } = await import("./schedules.js");
 const { closeDb } = await import("./db.js");
 
 after(() => {
@@ -49,4 +49,24 @@ test("a squad can have multiple schedules", () => {
     .map((schedule) => schedule.id);
 
   assert.deepEqual(new Set(squadScheduleIds), new Set([first.id, second.id]));
+});
+
+test("updateSchedule persists prompt changes and toggles enabled state", () => {
+  const squad = createSquad("Beta Team", "DC");
+  const schedule = createSchedule({
+    type: "squad",
+    squad_id: squad.id,
+    cron: "0 10 * * 1-5",
+    prompt: "Original prompt",
+  });
+
+  const updated = updateSchedule(schedule.id, { prompt: "Updated prompt", enabled: true });
+
+  assert.equal(updated.prompt, "Updated prompt");
+  assert.equal(updated.enabled, 1);
+
+  const persisted = listSchedules("squad").find((item) => item.id === schedule.id);
+  assert.ok(persisted);
+  assert.equal(persisted?.prompt, "Updated prompt");
+  assert.equal(persisted?.enabled, 1);
 });

--- a/web/src/views/SchedulesView.vue
+++ b/web/src/views/SchedulesView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from "vue";
 import { apiGet, apiPost, apiDelete, apiPut } from "@/lib/api";
-import { Clock, Plus, Trash2, Play } from "lucide-vue-next";
+import { Clock, Plus, Trash2, Play, Pencil } from "lucide-vue-next";
 import { getSquadLabelStyle } from "@/lib/squad-colors";
 import ToggleSwitch from "@/components/ToggleSwitch.vue";
 
@@ -28,6 +28,8 @@ const loading = ref(true);
 const tab = ref<"squad" | "io">("squad");
 const showAdd = ref(false);
 const newSchedule = ref({ type: "squad" as "squad" | "io", cron: "", squad_id: "", prompt: "" });
+const editingScheduleId = ref<string | null>(null);
+const editingPrompt = ref("");
 const triggeredId = ref<string | null>(null);
 
 onMounted(async () => {
@@ -73,8 +75,25 @@ const decoratedSchedules = computed(() =>
 
 async function toggleSchedule(schedule: Schedule) {
   const enabled = !schedule.enabled;
-  await apiPut(`/schedules/${schedule.id}`, { enabled });
-  schedule.enabled = enabled ? 1 : 0;
+  const updated = await apiPut(`/schedules/${schedule.id}`, { enabled });
+  schedule.enabled = updated.enabled;
+}
+
+function startPromptEdit(schedule: Schedule) {
+  editingScheduleId.value = schedule.id;
+  editingPrompt.value = schedule.prompt;
+}
+
+async function savePromptEdit(schedule: Schedule) {
+  const updated = await apiPut(`/schedules/${schedule.id}`, { prompt: editingPrompt.value });
+  schedule.prompt = updated.prompt;
+  editingScheduleId.value = null;
+  editingPrompt.value = "";
+}
+
+function cancelPromptEdit() {
+  editingScheduleId.value = null;
+  editingPrompt.value = "";
 }
 
 async function deleteSchedule(id: string) {
@@ -182,7 +201,38 @@ function getSquadName(squadId: string | null): string {
             </span>
           </div>
           <div class="text-xs text-muted-foreground mt-0.5">
-            {{ schedule.prompt ? schedule.prompt.slice(0, 80) : '(no prompt)' }}
+            <div v-if="editingScheduleId === schedule.id" class="mt-2 space-y-2">
+              <textarea
+                v-model="editingPrompt"
+                rows="3"
+                class="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                placeholder="Schedule prompt"
+              ></textarea>
+              <div class="flex gap-2">
+                <button
+                  @click="savePromptEdit(schedule)"
+                  class="px-3 py-1.5 text-xs rounded-md bg-primary text-primary-foreground hover:bg-primary/90"
+                >
+                  Save
+                </button>
+                <button
+                  @click="cancelPromptEdit()"
+                  class="px-3 py-1.5 text-xs rounded-md border border-border hover:bg-muted/50"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+            <div v-else class="mt-2 flex items-center justify-between gap-3">
+              <span>{{ schedule.prompt ? schedule.prompt : '(no prompt)' }}</span>
+              <button
+                @click="startPromptEdit(schedule)"
+                class="inline-flex items-center gap-1 px-2 py-1 text-xs rounded-md border border-border hover:bg-muted/50"
+              >
+                <Pencil class="w-3 h-3" />
+                Edit prompt
+              </button>
+            </div>
           </div>
           <div class="text-xs text-muted-foreground mt-0.5">
             Squad: {{ getSquadName(schedule.squad_id) }}


### PR DESCRIPTION
Closes #403

- Added inline prompt editing on the Schedules page with save/cancel controls.
- Updated the schedule API to persist prompt, cron, agenda, and enabled changes.
- Added regression coverage for schedule updates.