### PR TITLE
fix: remove duplicate streaming ellipsis in chat

### DIFF
--- a/web/src/components/ChatOverlay.vue
+++ b/web/src/components/ChatOverlay.vue
@@ -317,7 +317,7 @@ onMounted(async () => {
                 class="overlay-markdown"
                 :class="msg.role === 'user' ? 'prose-invert' : ''"
               />
-              <span v-else class="text-zinc-500">...</span>
+              <span v-else-if="!msg.streaming" class="text-zinc-500">...</span>
             </article>
           </div>
 

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -202,7 +202,7 @@ onMounted(() => {
             </div>
           </div>
           <MarkdownContent v-if="msg.content" :content="msg.content" :class="msg.role === 'user' ? 'prose-invert' : ''" />
-          <span v-else class="text-muted-foreground">...</span>
+          <span v-else-if="!msg.streaming" class="text-muted-foreground">...</span>
           <div
             v-if="msg.streaming"
             class="inline-block w-2 h-4 bg-current animate-pulse ml-1"


### PR DESCRIPTION
Removes the static fallback ellipsis while assistant messages are streaming so only the animated indicator remains.\n\nCloses #417