### PR TITLE
feat: open markdown links in new tabs

### DIFF
--- a/web/src/components/MarkdownContent.vue
+++ b/web/src/components/MarkdownContent.vue
@@ -4,9 +4,16 @@ import { marked } from "marked";
 
 const props = defineProps<{ content: string }>();
 
+const renderer = new marked.Renderer();
+renderer.link = ({ href, title, text }) => {
+  const safeHref = href ?? "";
+  const titleAttr = title ? ` title="${title}"` : "";
+  return `<a href="${safeHref}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`;
+};
+
 const rendered = computed(() => {
   if (!props.content) return "";
-  return marked.parse(props.content, { async: false }) as string;
+  return marked.parse(props.content, { async: false, renderer }) as string;
 });
 </script>
 


### PR DESCRIPTION
Uses the shared markdown renderer to add  and  to generated links so agent-produced content stays in the app.\n\nCloses #420