### PR TITLE
Show human-readable cron descriptions on schedule cards

### DIFF
--- a/web/src/lib/cron.ts
+++ b/web/src/lib/cron.ts
@@ -1,0 +1,158 @@
+const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+const MONTH_NAMES = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+
+function parseCronField(spec: string, min: number, max: number): number[] {
+  const values = new Set<number>();
+
+  if (spec === "*") {
+    for (let i = min; i <= max; i += 1) values.add(i);
+    return Array.from(values);
+  }
+
+  if (spec.startsWith("*/")) {
+    const step = Number.parseInt(spec.slice(2), 10);
+    if (Number.isNaN(step) || step <= 0) return [];
+    for (let i = min; i <= max; i += step) values.add(i);
+    return Array.from(values);
+  }
+
+  const parsedSegments = spec.split(",").map((segment) => segment.trim()).filter(Boolean);
+  for (const segment of parsedSegments) {
+    if (segment.includes("-")) {
+      const [startRaw, endRaw] = segment.split("-");
+      const start = Number.parseInt(startRaw, 10);
+      const end = Number.parseInt(endRaw, 10);
+      if (Number.isNaN(start) || Number.isNaN(end)) continue;
+      for (let i = Math.min(start, end); i <= Math.max(start, end); i += 1) {
+        if (i >= min && i <= max) values.add(i);
+      }
+      continue;
+    }
+
+    const exact = Number.parseInt(segment, 10);
+    if (!Number.isNaN(exact) && exact >= min && exact <= max) values.add(exact);
+  }
+
+  return Array.from(values);
+}
+
+function formatTime(hourValue: number, minuteValue: number): string {
+  const hour12 = ((hourValue + 11) % 12) + 1;
+  const amPm = hourValue < 12 ? "AM" : "PM";
+  const minute = minuteValue.toString().padStart(2, "0");
+
+  return `${hour12}:${minute} ${amPm}`;
+}
+
+function formatDayList(values: number[], labels: string[]): string {
+  if (values.length === 0) return "";
+  if (values.length === 1) return labels[values[0]];
+
+  const mapped = values.map((value) => labels[value]);
+  if (mapped.length === 2) return `${mapped[0]} and ${mapped[1]}`;
+
+  return `${mapped.slice(0, -1).join(", ")}, and ${mapped[mapped.length - 1]}`;
+}
+
+function describeDayOfWeek(spec: string): string {
+  const values = parseCronField(spec, 0, 6);
+  if (values.length === 0) return "";
+
+  const normalized = values.map((value) => (value === 7 ? 0 : value));
+  const sorted = Array.from(new Set(normalized)).sort((a, b) => a - b);
+
+  if (sorted.length === 7) return "every day";
+
+  const weekdays = [1, 2, 3, 4, 5];
+  const weekend = [0, 6];
+  const weekdaysMatch = weekdays.every((day) => sorted.includes(day)) && sorted.length === weekdays.length;
+  const weekendMatch = weekend.every((day) => sorted.includes(day)) && sorted.length === weekend.length;
+
+  if (weekdaysMatch) return "weekdays";
+  if (weekendMatch) return "weekends";
+
+  return formatDayList(sorted, DAY_NAMES);
+}
+
+function describeMonth(spec: string): string {
+  const values = parseCronField(spec, 1, 12);
+  if (values.length === 0) return "";
+  if (values.length === 12) return "";
+  return formatDayList(values.map((value) => value - 1), MONTH_NAMES);
+}
+
+function describeDayOfMonth(spec: string): string {
+  const values = parseCronField(spec, 1, 31);
+  if (values.length === 0) return "";
+  if (values.length === 31) return "";
+
+  const ordinals = values.map((value) => {
+    const suffix = [11, 12, 13].includes(value) ? "th" : [1, 21, 31].includes(value) ? "st" : [2, 22].includes(value) ? "nd" : [3, 23].includes(value) ? "rd" : "th";
+    return `${value}${suffix}`;
+  });
+
+  if (ordinals.length === 1) return `on the ${ordinals[0]} of the month`;
+
+  return `on the ${ordinals.join(", ")}`;
+}
+
+function describeTime(minuteSpec: string, hourSpec: string): string {
+  const minuteValues = parseCronField(minuteSpec, 0, 59);
+  const hourValues = parseCronField(hourSpec, 0, 23);
+
+  if (minuteValues.length === 0 || hourValues.length === 0) return "custom times";
+
+  if (minuteSpec === "*" && hourSpec === "*") return "every minute";
+  if (minuteSpec === "*" && hourSpec.startsWith("*/")) {
+    const step = Number.parseInt(hourSpec.slice(2), 10);
+    if (!Number.isNaN(step) && step > 0) return `every ${step} hours`;
+  }
+  if (minuteSpec.startsWith("*/") && hourSpec === "*") {
+    const step = Number.parseInt(minuteSpec.slice(2), 10);
+    if (!Number.isNaN(step) && step > 0) return `every ${step} minutes`;
+  }
+  if (minuteSpec === "*" && hourValues.length === 24) return "every hour";
+  if (minuteSpec === "*" && hourValues.length === 1) return `once each hour at ${formatTime(hourValues[0], 0)}`;
+
+  if (minuteValues.length === 1 && hourValues.length === 1) {
+    return `at ${formatTime(hourValues[0], minuteValues[0])}`;
+  }
+
+  if (minuteValues.length > 1 && hourValues.length === 1) {
+    return `at ${minuteValues.map((minute) => formatTime(hourValues[0], minute)).join(", ")}`;
+  }
+
+  if (hourValues.length > 1 && minuteValues.length === 1) {
+    return `at ${hourValues.map((hour) => formatTime(hour, minuteValues[0])).join(", ")}`;
+  }
+
+  return "at matching times";
+}
+
+export function describeCronExpression(cron: string): string {
+  const parts = cron.trim().split(/\s+/);
+  if (parts.length !== 5) return "custom schedule";
+
+  const [minuteSpec, hourSpec, dayOfMonthSpec, monthSpec, dayOfWeekSpec] = parts;
+  const timePart = describeTime(minuteSpec, hourSpec);
+  const dayOfWeekPart = describeDayOfWeek(dayOfWeekSpec);
+  const dayOfMonthPart = describeDayOfMonth(dayOfMonthSpec);
+  const monthPart = describeMonth(monthSpec);
+
+  if (timePart === "every minute") return "every minute";
+
+  const dayDescriptor = dayOfWeekSpec !== "*" && dayOfMonthSpec === "*"
+    ? `on ${dayOfWeekPart}`
+    : dayOfMonthSpec !== "*" && dayOfWeekSpec === "*"
+      ? dayOfMonthPart
+      : dayOfWeekSpec === "*" && dayOfMonthSpec === "*"
+        ? "each day"
+        : "on matching days";
+
+  const fragments = [timePart, dayDescriptor].filter((fragment) => fragment && fragment !== "custom times" && fragment !== "at matching times");
+  if (monthPart) fragments.push(`in ${monthPart}`);
+
+  if (fragments.length === 0) return "custom schedule";
+
+  return fragments.join(" ");
+}

--- a/web/src/views/SchedulesView.vue
+++ b/web/src/views/SchedulesView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from "vue";
 import { apiGet, apiPost, apiDelete, apiPut } from "@/lib/api";
+import { describeCronExpression } from "@/lib/cron";
 import { Clock, Plus, Trash2, Play, Pencil } from "lucide-vue-next";
 import { getSquadLabelStyle } from "@/lib/squad-colors";
 import ToggleSwitch from "@/components/ToggleSwitch.vue";
@@ -45,7 +46,7 @@ onMounted(async () => {
   }
 });
 
-const filteredSchedules = () => schedules.value.filter((s) => s.type === tab.value);
+const filteredSchedules = computed(() => schedules.value.filter((s) => s.type === tab.value));
 
 async function addSchedule() {
   const body: any = {
@@ -67,9 +68,10 @@ function getSquadById(squadId: string | null): Squad | undefined {
 }
 
 const decoratedSchedules = computed(() =>
-  filteredSchedules().map((schedule) => ({
+  filteredSchedules.value.map((schedule) => ({
     ...schedule,
     squad: getSquadById(schedule.squad_id),
+    description: describeCronExpression(schedule.cron),
   }))
 );
 
@@ -186,7 +188,7 @@ function getSquadName(squadId: string | null): string {
 
     <div v-if="loading" class="text-muted-foreground">Loading...</div>
 
-    <div v-else-if="filteredSchedules().length === 0" class="text-center py-12 text-muted-foreground">
+    <div v-else-if="filteredSchedules.length === 0" class="text-center py-12 text-muted-foreground">
       <Clock class="w-12 h-12 mx-auto mb-3 opacity-50" />
       <p>No {{ tab }} schedules configured.</p>
     </div>
@@ -195,6 +197,7 @@ function getSquadName(squadId: string | null): string {
       <div v-for="schedule in decoratedSchedules" :key="schedule.id" class="flex items-center justify-between border border-border rounded-lg px-4 py-3">
         <div>
           <div class="text-sm font-medium font-mono">{{ schedule.cron }}</div>
+          <div class="text-xs text-primary/90 mt-1 font-medium">Runs {{ schedule.description }}</div>
           <div v-if="schedule.squad" class="mt-1">
             <span class="text-xs px-2 py-0.5 rounded-full" :style="getSquadLabelStyle(schedule.squad.color)">
               {{ schedule.squad.name }}


### PR DESCRIPTION
Closes #431\n\nAdds a reusable cron description helper and renders plain-English schedule descriptions on each card so users can understand cron expressions without parsing them manually.