### PR TITLE
fix: apply gradient styling to markdown headings

### DIFF
--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -55,6 +55,22 @@ export default {
         glow: "0 0 20px hsl(var(--gradient-mid) / 0.2)",
         "glow-lg": "0 0 40px hsl(var(--gradient-mid) / 0.3)",
       },
+      typography: {
+        DEFAULT: {
+          css: {
+            "h1, h2, h3, h4, h5, h6": {
+              color: "inherit",
+            },
+          },
+        },
+        invert: {
+          css: {
+            "h1, h2, h3, h4, h5, h6": {
+              color: "inherit",
+            },
+          },
+        },
+      },
     },
   },
   plugins: [require("@tailwindcss/typography")],


### PR DESCRIPTION
## Summary
Fixes the gradient styling for markdown headings that was added in PR #434 but not actually being applied.

## Problem
The `prose dark:prose-invert` classes from `@tailwindcss/typography` were overriding our custom gradient styling with their own heading color rules.

## Solution
Configure the Tailwind typography plugin to set heading colors to `inherit` for both default and invert variants, allowing our custom gradient CSS in `MarkdownContent.vue` to take effect.

## Changes
- Updated `web/tailwind.config.js` to override prose heading colors

## Testing
- Build passes: `npm run build`
- Lint passes: `npm run lint`
- Markdown headings now render with the brand gradient: `linear-gradient(135deg, #D83333 0%, #C0285E 100%)`

Closes #438