### PR TITLE
fix(web): replace gradient text with solid color in prose headings

### DIFF
--- a/packages/web/src/components/ui/markdown.tsx
+++ b/packages/web/src/components/ui/markdown.tsx
@@ -10,7 +10,7 @@ import typescript from 'highlight.js/lib/languages/typescript';
 import xml from 'highlight.js/lib/languages/xml';
 import yaml from 'highlight.js/lib/languages/yaml';
 import 'highlight.js/styles/github-dark-dimmed.min.css';
-import { marked } from 'marked';
+import { marked, type Tokens } from 'marked';
 import { useMemo } from 'react';
 
 hljs.registerLanguage('javascript', javascript);
@@ -33,16 +33,12 @@ hljs.registerLanguage('css', css);
 
 marked.use({
 	renderer: {
-		heading({ tokens, depth }: { tokens: { raw: string }[]; depth: number }) {
-			const text = tokens.map((t: { raw: string }) => t.raw).join('');
-			const tag = `h${depth}`;
-			const sizes: Record<number, string> = {
-				1: '2em',
-				2: '1.65em',
-				3: '1.35em',
-				4: '1.15em',
-			};
-			return `<${tag} style="background:linear-gradient(135deg, #D83333 0%, #E43A9C 50%, #F041FF 100%);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;font-size:${sizes[depth] ?? '1em'};font-weight:600;margin:1.1em 0 0.4em;line-height:1.4;text-transform:none;">${text}</${tag}>`;
+		heading(this: { parser: { parseInline(tokens: Tokens.Token[]): string } }, token: Tokens.Heading) {
+			// Use parser.parseInline so inline content (links, em, strong, etc.)
+			// is rendered as proper HTML rather than raw markdown text.
+			const text = this.parser.parseInline(token.tokens);
+			const tag = `h${token.depth}`;
+			return `<${tag}>${text}</${tag}>`;
 		},
 		code({ text, lang }: { text: string; lang?: string }) {
 			let highlighted: string;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -279,10 +279,7 @@ body {
 .prose-io h4,
 .prose-io h5,
 .prose-io h6 {
-	background: linear-gradient(135deg, #D83333 0%, #E43A9C 50%, #F041FF 100%);
-	-webkit-background-clip: text;
-	-webkit-text-fill-color: transparent;
-	background-clip: text;
+	color: #d83333;
 	font-weight: 600;
 	text-transform: none;
 	margin: 1.1em 0 0.4em;
@@ -292,6 +289,14 @@ body {
 .prose-io h2 { font-size: 1.65em; }
 .prose-io h3 { font-size: 1.35em; }
 .prose-io h4 { font-size: 1.15em; }
+
+.prose-io h1 a,
+.prose-io h2 a,
+.prose-io h3 a,
+.prose-io h4 a {
+	color: var(--color-accent);
+	text-decoration: underline;
+}
 
 .prose-io p {
 	margin: 0.6em 0;


### PR DESCRIPTION
Closes 
- [done] Implement all three CSS fixes in `packages/web/src/index.css`. (1) In the `.prose-io h1, .prose-io h2, .prose-io h3, .prose-io h4` rule block, replace the gradient approach (`background: linear-gradient(...)`, `-webkit-background-clip: text`, `-webkit-text-fill-color: transparent`, `background-clip: text`) with a solid `color: #d83333`. (2) Add `text-transform: none` to that same rule block. (3) Add a new rule `.prose-io h1 a, .prose-io h2 a, .prose-io h3 a, .prose-io h4 a` that sets `color: var(--color-accent)` and `text-decoration: underline` so links inside headings are visually distinct from heading text. Also verify (but do not change unless broken) that `marked.parse('## [test](url)')` produces a proper `<h2><a href="url">...</a></h2>` — check `ChatView.tsx`, `FeedView.tsx`, and `WikiView.tsx`. Commit and push to branch `fix/markdown-heading-bugs`.**: Pushed cleanly. Here's a full summary of what was done:

---

## Summary — `fix/markdown-heading-bugs` (closes #451)

### `packages/web/src/index.css`

**1. Gradient → solid color on `.prose-io h1–h6`
- [done] After implementation is pushed, create a draft PR from `fix/markdown-heading-bugs` → `main`. Title: `fix: resolve markdown heading rendering bugs (#451)`. Body must reference `Closes #451` and summarize the three fixes. Assign to `michaeljolley`.**: Signal confirmed — I can’t actually create the draft PR from this scribe-only toolset.

Ready-to-paste draft:

**Title:** `fix: resolve markdown heading rendering bugs (#451)`

**Body:**
```md
Closes 
- [failed] Review the CSS changes in `packages/web/src/index.css` on the draft PR. Verify: (1) solid color on headings eliminates the `-webkit-text-fill-color` gradient issue; (2) `text-transform: none` is present and correctly scoped; (3) the anchor rule for links inside headings uses `var(--color-accent)` and won't conflict with `.prose-io a`; (4) no regressions to other `.prose-io` elements (code, tables, lists). Post `LGTM — approved by QATester. <summary>` as a PR comment if green, or `CHANGES REQUESTED` with specifics if not.**: Error: Timeout after 300000ms waiting for session.idle