### PR TITLE
fix(web): Fix markdown heading rendering bugs

### DIFF
--- a/packages/web/src/components/ui/markdown.tsx
+++ b/packages/web/src/components/ui/markdown.tsx
@@ -10,7 +10,7 @@ import typescript from 'highlight.js/lib/languages/typescript';
 import xml from 'highlight.js/lib/languages/xml';
 import yaml from 'highlight.js/lib/languages/yaml';
 import 'highlight.js/styles/github-dark-dimmed.min.css';
-import { marked, type Tokens } from 'marked';
+import { marked, type Tokens, type Token } from 'marked';
 import { useMemo } from 'react';
 
 hljs.registerLanguage('javascript', javascript);
@@ -33,7 +33,7 @@ hljs.registerLanguage('css', css);
 
 marked.use({
 	renderer: {
-		heading(this: { parser: { parseInline(tokens: Tokens.Token[]): string } }, token: Tokens.Heading) {
+		heading(this: { parser: { parseInline(tokens: Token[]): string } }, token: Tokens.Heading) {
 			// Use parser.parseInline so inline content (links, em, strong, etc.)
 			// is rendered as proper HTML rather than raw markdown text.
 			const text = this.parser.parseInline(token.tokens);

--- a/packages/web/src/components/ui/markdown.tsx
+++ b/packages/web/src/components/ui/markdown.tsx
@@ -10,7 +10,7 @@ import typescript from 'highlight.js/lib/languages/typescript';
 import xml from 'highlight.js/lib/languages/xml';
 import yaml from 'highlight.js/lib/languages/yaml';
 import 'highlight.js/styles/github-dark-dimmed.min.css';
-import { marked } from 'marked';
+import { marked, type Tokens } from 'marked';
 import { useMemo } from 'react';
 
 hljs.registerLanguage('javascript', javascript);
@@ -33,16 +33,12 @@ hljs.registerLanguage('css', css);
 
 marked.use({
 	renderer: {
-		heading({ tokens, depth }: { tokens: { raw: string }[]; depth: number }) {
-			const text = tokens.map((t: { raw: string }) => t.raw).join('');
-			const tag = `h${depth}`;
-			const sizes: Record<number, string> = {
-				1: '2em',
-				2: '1.65em',
-				3: '1.35em',
-				4: '1.15em',
-			};
-			return `<${tag} style="background:linear-gradient(135deg, #D83333 0%, #E43A9C 50%, #F041FF 100%);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;font-size:${sizes[depth] ?? '1em'};font-weight:600;margin:1.1em 0 0.4em;line-height:1.4;text-transform:none;">${text}</${tag}>`;
+		heading(this: { parser: { parseInline(tokens: Tokens.Token[]): string } }, token: Tokens.Heading) {
+			// Use parser.parseInline so inline content (links, em, strong, etc.)
+			// is rendered as proper HTML rather than raw markdown text.
+			const text = this.parser.parseInline(token.tokens);
+			const tag = `h${token.depth}`;
+			return `<${tag}>${text}</${tag}>`;
 		},
 		code({ text, lang }: { text: string; lang?: string }) {
 			let highlighted: string;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -279,10 +279,7 @@ body {
 .prose-io h4,
 .prose-io h5,
 .prose-io h6 {
-	background: linear-gradient(135deg, #D83333 0%, #E43A9C 50%, #F041FF 100%);
-	-webkit-background-clip: text;
-	-webkit-text-fill-color: transparent;
-	background-clip: text;
+	color: #d83333;
 	font-weight: 600;
 	text-transform: none;
 	margin: 1.1em 0 0.4em;
@@ -292,6 +289,14 @@ body {
 .prose-io h2 { font-size: 1.65em; }
 .prose-io h3 { font-size: 1.35em; }
 .prose-io h4 { font-size: 1.15em; }
+
+.prose-io h1 a,
+.prose-io h2 a,
+.prose-io h3 a,
+.prose-io h4 a {
+	color: var(--color-accent);
+	text-decoration: underline;
+}
 
 .prose-io p {
 	margin: 0.6em 0;


### PR DESCRIPTION
Closes #451

## Changes
- Replaced gradient text with solid color on prose headings to prevent emoji coloring
- Fixed inline link rendering within heading tags
- Removed uppercase text-transform from headings