### PR TITLE
The CI is failing on PR #453 (branch: fix/markdown-heading-bugs). Invest

### DIFF
--- a/packages/web/src/components/ui/markdown.tsx
+++ b/packages/web/src/components/ui/markdown.tsx
@@ -10,7 +10,7 @@ import typescript from 'highlight.js/lib/languages/typescript';
 import xml from 'highlight.js/lib/languages/xml';
 import yaml from 'highlight.js/lib/languages/yaml';
 import 'highlight.js/styles/github-dark-dimmed.min.css';
-import { marked } from 'marked';
+import { marked, type Token } from 'marked';
 import { useMemo } from 'react';
 
 hljs.registerLanguage('javascript', javascript);
@@ -33,8 +33,8 @@ hljs.registerLanguage('css', css);
 
 marked.use({
 	renderer: {
-		heading({ tokens, depth }: { tokens: { raw: string }[]; depth: number }) {
-			const text = tokens.map((t: { raw: string }) => t.raw).join('');
+		heading({ tokens, depth }: { tokens: Token[]; depth: number }) {
+			const text = tokens.map((t) => t.raw).join('');
 			const tag = `h${depth}`;
 			const sizes: Record<number, string> = {
 				1: '2em',


### PR DESCRIPTION
## 🤖 Generated by IO Squad: io-squad

Closes #453

### Tasks Completed
✅ Fix TypeScript error in `packages/web/src/components/ui/markdown.tsx`. The `Tokens.Token` type doesn't exist in marked v18 — `Token` is a top-level export. Change line 13 from `import { marked, type Tokens } from 'marked'` to `import { marked, type Tokens, type Token } from 'marked'`. Then on line 36, change `Tokens.Token[]` to `Token[]`. Verify the build passes with `cd packages/web && npx tsc -b --noEmit`. Commit and push to branch `fix/markdown-heading-bugs`. — *senior-react-vite-frontend-engineer*

<details><summary>Meeting Discussion</summary>

> [technical-pm] Plan:
Good — I've identified the root cause. Clear and simple. Here's the sitrep:

**Root Cause:** TypeScript build failure in `packages/web/src/components/ui/markdown.tsx` line 36. The

</details>