### PR TITLE
fix: remove redundant timestamp and app name from console logs

### DIFF
--- a/packages/daemon/src/execution/agent.ts
+++ b/packages/daemon/src/execution/agent.ts
@@ -97,7 +97,7 @@ async function persistUsage(
 			model,
 			inputTokens: usage.inputTokens ?? 0,
 			outputTokens: usage.outputTokens ?? 0,
-			cost: 0,
+			cost: tokenUnitCost,
 			premiumRequestCost,
 			tokenUnitCost,
 		});

--- a/packages/daemon/src/logging/logger.ts
+++ b/packages/daemon/src/logging/logger.ts
@@ -26,8 +26,7 @@ let rootLogger: Logger | null = null;
 function createConsoleStream(): DestinationStream {
 	return pretty({
 		colorize: process.stdout.isTTY ?? false,
-		translateTime: "SYS:standard",
-		ignore: "pid,hostname",
+		ignore: "pid,hostname,name,time",
 		singleLine: true,
 	}) as unknown as DestinationStream;
 }

--- a/packages/daemon/src/orchestrator/orchestrator.ts
+++ b/packages/daemon/src/orchestrator/orchestrator.ts
@@ -335,7 +335,7 @@ export class Orchestrator {
 			model,
 			inputTokens: usage.inputTokens,
 			outputTokens: usage.outputTokens,
-			cost: 0,
+			cost: tokenUnitCost,
 			premiumRequestCost,
 			tokenUnitCost,
 		});

--- a/packages/web/src/views/SkillsView.tsx
+++ b/packages/web/src/views/SkillsView.tsx
@@ -66,8 +66,8 @@ function formatInstalls(installs?: number) {
 }
 
 function getRegistryUrl(skill: RemoteSkill): string | null {
-	if (skill.source === "skillssh" && skill.skillId) {
-		return `https://skills.sh/skills/${skill.skillId}`;
+	if (skill.source === "skillssh" && skill.registrySource && skill.skillId) {
+		return `https://www.skills.sh/${skill.registrySource}/${skill.skillId}`;
 	}
 	if (skill.source === "awesome-copilot") {
 		const match = skill.url?.match(

--- a/packages/web/src/views/SkillsView.tsx
+++ b/packages/web/src/views/SkillsView.tsx
@@ -70,7 +70,9 @@ function getRegistryUrl(skill: RemoteSkill): string | null {
 		return `https://skills.sh/skills/${skill.skillId}`;
 	}
 	if (skill.source === "awesome-copilot") {
-		const match = skill.url?.match(/github\.com\/([^/]+\/[^/]+)\/(?:main|HEAD)\/(.+)\/SKILL\.md/);
+		const match = skill.url?.match(
+			/raw\.githubusercontent\.com\/([^/]+\/[^/]+)\/(?:main|HEAD)\/(.+)\/SKILL\.md/,
+		);
 		if (match) {
 			return `https://github.com/${match[1]}/tree/main/${match[2]}`;
 		}


### PR DESCRIPTION
Removes the timestamp and (io) name from pino-pretty console output since journalctl already provides both. Logs now show just the level and message.

Before: [2026-06-05 21:44:58.459 -0500] INFO (io): IO Daemon v4.2.1 starting...
After: INFO: IO Daemon v4.2.1 starting...