### PR TITLE
Fix skill description parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "commander": "^14.0.0",
         "express": "^5.2.1",
         "grammy": "^1.40.0",
+        "yaml": "^2.9.0",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -3399,6 +3400,21 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michaeljolley/heyio",
   "version": "0.0.1",
-  "description": "IO \u2014 a personal AI assistant daemon built on the GitHub Copilot SDK",
+  "description": "IO — a personal AI assistant daemon built on the GitHub Copilot SDK",
   "bin": {
     "io": "dist/index.js"
   },
@@ -48,6 +48,7 @@
     "commander": "^14.0.0",
     "express": "^5.2.1",
     "grammy": "^1.40.0",
+    "yaml": "^2.9.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/copilot/skills.test.ts
+++ b/src/copilot/skills.test.ts
@@ -1,6 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { discoverSkills, isGitHubRepoPath } from './skills.ts';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { discoverSkills, isGitHubRepoPath, listSkills } from './skills.ts';
+import { PATHS } from '../paths.ts';
 
 test('isGitHubRepoPath accepts GitHub-style owner/repo paths', () => {
   assert.equal(isGitHubRepoPath('vercel/workflow'), true);
@@ -51,5 +54,232 @@ test('discoverSkills filters unsupported skills.sh sources', async () => {
     assert.equal(skills[0].sourceRepo, 'larksuite/cli');
   } finally {
     global.fetch = originalFetch;
+  }
+});
+
+test('discoverSkills uses remote frontmatter descriptions from SKILL.md content', async () => {
+  const originalFetch = global.fetch;
+
+  global.fetch = async (input: RequestInfo | URL) => {
+    const target = String(input);
+
+    if (target === 'https://skills.sh/api/search?q=standup') {
+      return new Response(
+        JSON.stringify({
+          skills: [
+            {
+              id: 'larksuite/cli/lark-workflow-standup-report',
+              skillId: 'lark-workflow-standup-report',
+              name: 'lark-workflow-standup-report',
+              installs: 1,
+              source: 'larksuite/cli',
+            },
+          ],
+          count: 1,
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      ) as Response;
+    }
+
+    if (target === 'https://api.github.com/repos/larksuite/cli/git/trees/main?recursive=1') {
+      return new Response(
+        JSON.stringify({
+          tree: [
+            {
+              path: 'lark-workflow-standup-report/SKILL.md',
+              type: 'blob',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      ) as Response;
+    }
+
+    if (target === 'https://raw.githubusercontent.com/larksuite/cli/main/lark-workflow-standup-report/SKILL.md') {
+      return new Response(
+        '---\nname: Standup Report\ndescription: Remote frontmatter description\n---\n# Standup Report\n\nBody text.',
+        {
+          status: 200,
+          headers: { 'content-type': 'text/plain; charset=utf-8' },
+        },
+      ) as Response;
+    }
+
+    throw new Error(`Unexpected fetch target: ${target}`);
+  };
+
+  try {
+    const skills = await discoverSkills('skillssh', 'standup');
+
+    assert.equal(skills.length, 1);
+    assert.equal(skills[0].description, 'Remote frontmatter description');
+    assert.notEqual(skills[0].description, '');
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("listSkills handles CRLF line endings in frontmatter", async () => {
+  const testSkillDir = join(PATHS.skills, "test-crlf-skill");
+
+  try {
+    mkdirSync(testSkillDir, { recursive: true });
+
+    const crlfContent =
+      "---\r\nname: Test CRLF Skill\r\ndescription: A skill with CRLF endings\r\n---\r\n# Test CRLF Skill\r\n\r\nThis tests CRLF handling.";
+    writeFileSync(join(testSkillDir, "SKILL.md"), crlfContent);
+
+    const skills = await listSkills();
+    const testSkill = skills.find((s) => s.slug === "test-crlf-skill");
+
+    assert.ok(testSkill, "Test skill should be found");
+    assert.equal(testSkill.name, "Test CRLF Skill");
+    assert.equal(testSkill.description, "A skill with CRLF endings");
+  } finally {
+    if (existsSync(testSkillDir)) {
+      rmSync(testSkillDir, { recursive: true, force: true });
+    }
+  }
+});
+
+test("listSkills handles LF line endings in frontmatter", async () => {
+  const testSkillDir = join(PATHS.skills, "test-lf-skill");
+
+  try {
+    mkdirSync(testSkillDir, { recursive: true });
+
+    const lfContent =
+      "---\nname: Test LF Skill\ndescription: A skill with LF endings\n---\n# Test LF Skill\n\nThis tests LF handling.";
+    writeFileSync(join(testSkillDir, "SKILL.md"), lfContent);
+
+    const skills = await listSkills();
+    const testSkill = skills.find((s) => s.slug === "test-lf-skill");
+
+    assert.ok(testSkill, "Test skill should be found");
+    assert.equal(testSkill.name, "Test LF Skill");
+    assert.equal(testSkill.description, "A skill with LF endings");
+  } finally {
+    if (existsSync(testSkillDir)) {
+      rmSync(testSkillDir, { recursive: true, force: true });
+    }
+  }
+});
+
+test("listSkills extracts description from frontmatter, not body", async () => {
+  const testSkillDir = join(PATHS.skills, "test-fm-desc-skill");
+
+  try {
+    mkdirSync(testSkillDir, { recursive: true });
+
+    const content = `---
+name: Frontmatter Description Test
+description: This is the frontmatter description
+---
+# Frontmatter Description Test
+
+This is the body text which should NOT be used as description.
+`;
+    writeFileSync(join(testSkillDir, "SKILL.md"), content);
+
+    const skills = await listSkills();
+    const testSkill = skills.find((s) => s.slug === "test-fm-desc-skill");
+
+    assert.ok(testSkill, "Test skill should be found");
+    assert.equal(testSkill.description, "This is the frontmatter description");
+  } finally {
+    if (existsSync(testSkillDir)) {
+      rmSync(testSkillDir, { recursive: true, force: true });
+    }
+  }
+});
+
+test("listSkills falls back to body description when frontmatter has none", async () => {
+  const testSkillDir = join(PATHS.skills, "test-no-fm-desc-skill");
+
+  try {
+    mkdirSync(testSkillDir, { recursive: true });
+
+    const content = `---
+name: No Frontmatter Description
+---
+# No Frontmatter Description
+
+Fallback description from body.
+`;
+    writeFileSync(join(testSkillDir, "SKILL.md"), content);
+
+    const skills = await listSkills();
+    const testSkill = skills.find((s) => s.slug === "test-no-fm-desc-skill");
+
+    assert.ok(testSkill, "Test skill should be found");
+    assert.equal(testSkill.description, "Fallback description from body.");
+  } finally {
+    if (existsSync(testSkillDir)) {
+      rmSync(testSkillDir, { recursive: true, force: true });
+    }
+  }
+});
+
+test("listSkills preserves quoted frontmatter descriptions", async () => {
+  const testSkillDir = join(PATHS.skills, "test-quoted-desc-skill");
+
+  try {
+    mkdirSync(testSkillDir, { recursive: true });
+
+    const content = `---
+name: Quoted Description Test
+description: "A quoted description from frontmatter"
+---
+# Quoted Description Test
+
+This body text should not be used.
+`;
+    writeFileSync(join(testSkillDir, "SKILL.md"), content);
+
+    const skills = await listSkills();
+    const testSkill = skills.find((s) => s.slug === "test-quoted-desc-skill");
+
+    assert.ok(testSkill, "Test skill should be found");
+    assert.equal(testSkill.description, "A quoted description from frontmatter");
+  } finally {
+    if (existsSync(testSkillDir)) {
+      rmSync(testSkillDir, { recursive: true, force: true });
+    }
+  }
+});
+
+test("listSkills preserves block-scalar frontmatter descriptions", async () => {
+  const testSkillDir = join(PATHS.skills, "test-block-scalar-desc-skill");
+
+  try {
+    mkdirSync(testSkillDir, { recursive: true });
+
+    const content = `---
+name: Block Scalar Description Test
+description: |
+  First line of the block scalar
+  Second line of the block scalar
+---
+# Block Scalar Description Test
+
+This body text should not be used.
+`;
+    writeFileSync(join(testSkillDir, "SKILL.md"), content);
+
+    const skills = await listSkills();
+    const testSkill = skills.find((s) => s.slug === "test-block-scalar-desc-skill");
+
+    assert.ok(testSkill, "Test skill should be found");
+    assert.equal(testSkill.description, "First line of the block scalar\nSecond line of the block scalar");
+  } finally {
+    if (existsSync(testSkillDir)) {
+      rmSync(testSkillDir, { recursive: true, force: true });
+    }
   }
 });

--- a/src/copilot/skills.ts
+++ b/src/copilot/skills.ts
@@ -3,6 +3,7 @@ import { join, basename, resolve, sep, dirname } from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
+import YAML from "yaml";
 import { PATHS } from "../paths.js";
 
 const execFileAsync = promisify(execFile);
@@ -29,27 +30,12 @@ export async function listSkills(): Promise<SkillInfo[]> {
     if (!existsSync(skillMd)) continue;
 
     const content = readFileSync(skillMd, "utf-8");
+    const { body } = parseSkillFrontmatter(content);
 
-    // Strip YAML frontmatter before extracting name/description
-    let body = content;
-    let fmDescription = "";
-    const trimmed = content.trimStart();
-    if (trimmed.startsWith("---")) {
-      const endIndex = trimmed.indexOf("---", 3);
-      if (endIndex !== -1) {
-        const fmBlock = trimmed.slice(3, endIndex);
-        body = trimmed.slice(endIndex + 3);
-        // Extract description from frontmatter
-        const descMatch = fmBlock.match(/^description:\s*(.+)$/m);
-        if (descMatch) fmDescription = descMatch[1].trim();
-      }
-    }
-
-    const lines = body.split("\n");
+    const lines = body.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
     const firstLine = lines.find((l) => l.startsWith("# "));
     const name = firstLine?.replace(/^#\s+/, "") ?? entry.name;
-    const descLine = lines.find((l) => l.trim() && !l.startsWith("#"));
-    const description = fmDescription || descLine?.trim() || "";
+    const description = extractSkillDescription(content);
 
     skills.push({
       name,
@@ -206,6 +192,38 @@ function validateSlug(slug: string): string {
   return slug;
 }
 
+function parseSkillFrontmatter(content: string) {
+  const trimmed = content.trimStart();
+  if (!trimmed.startsWith("---")) {
+    return { body: content, frontmatter: null };
+  }
+
+  const match = trimmed.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)([\s\S]*)$/);
+  if (!match) {
+    return { body: content, frontmatter: null };
+  }
+
+  const frontmatter = YAML.parseDocument(match[1], { prettyErrors: true });
+  return {
+    body: match[2],
+    frontmatter: frontmatter.toJS() as Record<string, unknown> | null,
+  };
+}
+
+function extractSkillDescription(content: string): string {
+  const { body, frontmatter } = parseSkillFrontmatter(content);
+  const frontmatterDescription =
+    typeof frontmatter?.description === "string"
+      ? frontmatter.description.trim()
+      : "";
+  if (frontmatterDescription) {
+    return frontmatterDescription;
+  }
+
+  const lines = body.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+  return lines.find((line) => line.trim() && !line.startsWith("#"))?.trim() || "";
+}
+
 function parseAwesomeCopilotTable(markdown: string): DiscoveredSkill[] {
   const skills: DiscoveredSkill[] = [];
   for (const line of markdown.split("\n")) {
@@ -256,6 +274,22 @@ interface SkillsShSearchResponse {
   count: number;
 }
 
+async function fetchRemoteSkillDescription(
+  sourceRepo: string,
+  skillId: string,
+): Promise<string> {
+  try {
+    const safeSlug = validateSlug(skillId);
+    const skillPath = await findSkillPathInRepo(sourceRepo, safeSlug);
+    const rawUrl = `https://raw.githubusercontent.com/${sourceRepo}/main/${skillPath}`;
+    const res = await fetch(rawUrl, { signal: AbortSignal.timeout(10_000) });
+    if (!res.ok) return "";
+    return extractSkillDescription(await res.text());
+  } catch {
+    return "";
+  }
+}
+
 async function fetchSkillsShSkills(query?: string): Promise<DiscoveredSkill[]> {
   try {
     const searchQuery = query?.trim() || "";
@@ -266,7 +300,7 @@ async function fetchSkillsShSkills(query?: string): Promise<DiscoveredSkill[]> {
     });
     if (!res.ok) return [];
     const data = (await res.json()) as SkillsShSearchResponse;
-    return data.skills
+    const filtered = data.skills
       .map((item) => ({
         slug: item.skillId || item.name || "",
         name: item.name || item.skillId || "",
@@ -276,6 +310,15 @@ async function fetchSkillsShSkills(query?: string): Promise<DiscoveredSkill[]> {
         installs: item.installs,
       }))
       .filter((item) => item.sourceRepo ? isGitHubRepoPath(item.sourceRepo) : false);
+
+    return await Promise.all(
+      filtered.map(async (item) => {
+        const description = item.sourceRepo
+          ? await fetchRemoteSkillDescription(item.sourceRepo, item.slug)
+          : "";
+        return { ...item, description };
+      }),
+    );
   } catch {
     return [];
   }


### PR DESCRIPTION
## Summary
- parse frontmatter descriptions robustly for skill listings
- fetch remote skill descriptions from SKILL.md for skills.sh results
- add tests covering frontmatter/body description handling and remote fetch behavior

## Verification
- npm test
- npm run build