### PR TITLE
fix: guard Copilot sessions against duplicate tool-call IDs

### DIFF
--- a/src/copilot/agents.ts
+++ b/src/copilot/agents.ts
@@ -37,6 +37,7 @@ import { loadSkillDirectories, loadSquadSkillDirectories } from "./skills.js";
 import { createLeadDelegationTools, createSquadTools } from "./squad-tools.js";
 import { runScribe } from "./scribe.js";
 import { attachTokenTracker } from "./token-tracker.js";
+import { sendAndWaitWithoutDuplicateToolCallIds } from "./tool-call-id-guard.js";
 
 const execAsync = promisify(exec);
 
@@ -340,12 +341,14 @@ ${lead.persona ? `## Personality:\n${lead.persona}` : ""}
 				const savedAttachments = saveAttachmentsToDisk(attachments);
 				const attachmentPathInfo = buildAttachmentPathSummary(savedAttachments);
 
-				const response = await session.sendAndWait(
+				const response = await sendAndWaitWithoutDuplicateToolCallIds(
+					session,
 					{
 						prompt: `Task delegated to you:\n\n${task}${attachmentPathInfo}`,
 						attachments: toCopilotBlobAttachments(attachments),
 					},
 					7_200_000, // 2 hours — watchdog handles stale detection
+					"lead-task-send",
 				);
 				result =
 					response?.data?.content ?? "Task completed (no response content).";

--- a/src/copilot/ceremonies.ts
+++ b/src/copilot/ceremonies.ts
@@ -1,6 +1,12 @@
 import { approveAll } from "@github/copilot-sdk";
 import { getClient } from "./client.js";
-import { getLeadForSquad, getAgentsForSquad, getSquad, updateAgentStatus, type Agent } from "../store/squads.js";
+import {
+	getLeadForSquad,
+	getAgentsForSquad,
+	getSquad,
+	updateAgentStatus,
+	type Agent,
+} from "../store/squads.js";
 import { selectModel, classifyComplexity } from "./model-router.js";
 import { postFeedItem } from "../store/feed.js";
 import { attachTokenTracker } from "./token-tracker.js";
@@ -13,37 +19,42 @@ import { addAuditEntry } from "../store/audit-log.js";
 import { addAgentEvent } from "../store/agent-events.js";
 import { createTask, updateTaskStatus } from "../store/tasks.js";
 import { touchInstanceActivity } from "../store/instances.js";
-import { buildAttachmentSummary, type MessageAttachment, toCopilotBlobAttachments } from "../chat/attachments.js";
+import {
+	buildAttachmentSummary,
+	type MessageAttachment,
+	toCopilotBlobAttachments,
+} from "../chat/attachments.js";
+import { sendAndWaitWithoutDuplicateToolCallIds } from "./tool-call-id-guard.js";
 
 export interface MeetingResult {
-  plan: string;
-  participants: string[];
+	plan: string;
+	participants: string[];
 }
 
 function buildRoster(agents: Agent[]): string {
-  return agents
-    .map(
-      (agent) =>
-        `- ${agent.character_name} (${agent.role_title})${agent.is_lead ? " [LEAD]" : ""}${agent.is_qa ? " [QA]" : ""}${agent.is_test ? " [TEST]" : ""}`
-    )
-    .join("\n");
+	return agents
+		.map(
+			(agent) =>
+				`- ${agent.character_name} (${agent.role_title})${agent.is_lead ? " [LEAD]" : ""}${agent.is_qa ? " [QA]" : ""}${agent.is_test ? " [TEST]" : ""}`,
+		)
+		.join("\n");
 }
 
 function buildMeetingSummary(result: MeetingResult): string {
-  return `## Planning Meeting Complete\n\n**Participants:** ${result.participants.join(", ")}\n\n${result.plan}`;
+	return `## Planning Meeting Complete\n\n**Participants:** ${result.participants.join(", ")}\n\n${result.plan}`;
 }
 
 function buildFacilitatorPrompt(lead: Agent, agents: Agent[]): string {
-  const roster = buildRoster(agents);
-  const specialistPrompts = agents
-    .filter((agent) => !agent.is_lead)
-    .map(
-      (agent) =>
-        `- ${agent.character_name} (${agent.role_title}): Include this perspective when their expertise is relevant.`
-    )
-    .join("\n");
+	const roster = buildRoster(agents);
+	const specialistPrompts = agents
+		.filter((agent) => !agent.is_lead)
+		.map(
+			(agent) =>
+				`- ${agent.character_name} (${agent.role_title}): Include this perspective when their expertise is relevant.`,
+		)
+		.join("\n");
 
-  return `# Planning Meeting Lead: ${lead.character_name}
+	return `# Planning Meeting Lead: ${lead.character_name}
 
 NEVER expose secrets, credentials, or sensitive values in any public-facing content. Use <REDACTED> for placeholders.
 
@@ -81,229 +92,283 @@ ${specialistPrompts || "- No specialist prompts available; plan with the current
 
 ### Assignments
 (Agent -> responsibilities)
-${lead.persona ? `
+${
+	lead.persona
+		? `
 
 ## Your Style
-${lead.persona}` : ""}
+${lead.persona}`
+		: ""
+}
 `;
 }
 
 export async function planningMeeting(
-  squadId: string,
-  task: string,
-  attachments: MessageAttachment[] = []
+	squadId: string,
+	task: string,
+	attachments: MessageAttachment[] = [],
 ): Promise<MeetingResult> {
-  return await squadMeeting(squadId, task, false, attachments);
+	return await squadMeeting(squadId, task, false, attachments);
 }
 
 export async function squadMeeting(
-  squadId: string,
-  task: string,
-  executeAfter: false,
-  attachments?: MessageAttachment[]
+	squadId: string,
+	task: string,
+	executeAfter: false,
+	attachments?: MessageAttachment[],
 ): Promise<MeetingResult>;
 export async function squadMeeting(
-  squadId: string,
-  task: string,
-  executeAfter: true,
-  attachments?: MessageAttachment[]
+	squadId: string,
+	task: string,
+	executeAfter: true,
+	attachments?: MessageAttachment[],
 ): Promise<string>;
 export async function squadMeeting(
-  squadId: string,
-  task: string,
-  executeAfter: boolean,
-  attachments?: MessageAttachment[]
+	squadId: string,
+	task: string,
+	executeAfter: boolean,
+	attachments?: MessageAttachment[],
 ): Promise<string | MeetingResult>;
 export async function squadMeeting(
-  squadId: string,
-  task: string,
-  executeAfter: boolean,
-  attachments: MessageAttachment[] = []
+	squadId: string,
+	task: string,
+	executeAfter: boolean,
+	attachments: MessageAttachment[] = [],
 ): Promise<string | MeetingResult> {
-  const lead = getLeadForSquad(squadId);
-  if (!lead) {
-    throw new Error("Squad has no team lead. Add a lead agent first.");
-  }
+	const lead = getLeadForSquad(squadId);
+	if (!lead) {
+		throw new Error("Squad has no team lead. Add a lead agent first.");
+	}
 
-  const squad = getSquad(squadId);
-  if (!squad) {
-    throw new Error(`Squad not found: ${squadId}`);
-  }
+	const squad = getSquad(squadId);
+	if (!squad) {
+		throw new Error(`Squad not found: ${squadId}`);
+	}
 
-  const agents = getAgentsForSquad(squadId);
-  const squadSlug = squad.slug ?? squadId;
-  const participants = [
-    lead.character_name,
-    ...agents.filter((agent) => !agent.is_lead).map((agent) => agent.character_name),
-  ];
-  const tier = classifyComplexity(task);
-  const model = await selectModel(tier);
-  const taskRecord = createTask(squadId, `Planning meeting: ${task}`, undefined, lead.id);
+	const agents = getAgentsForSquad(squadId);
+	const squadSlug = squad.slug ?? squadId;
+	const participants = [
+		lead.character_name,
+		...agents
+			.filter((agent) => !agent.is_lead)
+			.map((agent) => agent.character_name),
+	];
+	const tier = classifyComplexity(task);
+	const model = await selectModel(tier);
+	const taskRecord = createTask(
+		squadId,
+		`Planning meeting: ${task}`,
+		undefined,
+		lead.id,
+	);
 
-  if (taskRecord.instance_id) {
-    touchInstanceActivity(taskRecord.instance_id);
-  }
+	if (taskRecord.instance_id) {
+		touchInstanceActivity(taskRecord.instance_id);
+	}
 
-  updateAgentStatus(lead.id, "working");
-  addAuditEntry(
-    "planning_meeting_started",
-    `Planning meeting started by ${lead.character_name}`,
-    {
-      task: task.slice(0, 500),
-      executeAfter,
-      model,
-      attachments: attachments.map((attachment) => ({
-        name: attachment.name,
-        mimeType: attachment.mimeType,
-        size: attachment.size,
-      })),
-    },
-    { squad_id: squadId, agent_id: lead.id, task_id: taskRecord.id }
-  );
-  addAgentEvent(taskRecord.id, "status", `Planning meeting started by ${lead.character_name}`, {
-    agent: lead.character_name,
-    task: task.slice(0, 300),
-    executeAfter,
-  });
+	updateAgentStatus(lead.id, "working");
+	addAuditEntry(
+		"planning_meeting_started",
+		`Planning meeting started by ${lead.character_name}`,
+		{
+			task: task.slice(0, 500),
+			executeAfter,
+			model,
+			attachments: attachments.map((attachment) => ({
+				name: attachment.name,
+				mimeType: attachment.mimeType,
+				size: attachment.size,
+			})),
+		},
+		{ squad_id: squadId, agent_id: lead.id, task_id: taskRecord.id },
+	);
+	addAgentEvent(
+		taskRecord.id,
+		"status",
+		`Planning meeting started by ${lead.character_name}`,
+		{
+			agent: lead.character_name,
+			task: task.slice(0, 300),
+			executeAfter,
+		},
+	);
 
-  try {
-    const client = await getClient();
-    const skillDirectories = [...await loadSkillDirectories(), ...loadSquadSkillDirectories(squadSlug)];
-    const mcpServers = getMcpServersForSession();
-    const workingDirectory = await resolveSquadWorkingDirectory(squad);
-    const squadTools = createSquadTools(squadSlug, squadId, workingDirectory);
-    const leadTools = createLeadDelegationTools(
-      squadId,
-      squadSlug,
-      squad,
-      workingDirectory,
-      taskRecord.id
-    );
+	try {
+		const client = await getClient();
+		const skillDirectories = [
+			...(await loadSkillDirectories()),
+			...loadSquadSkillDirectories(squadSlug),
+		];
+		const mcpServers = getMcpServersForSession();
+		const workingDirectory = await resolveSquadWorkingDirectory(squad);
+		const squadTools = createSquadTools(squadSlug, squadId, workingDirectory);
+		const leadTools = createLeadDelegationTools(
+			squadId,
+			squadSlug,
+			squad,
+			workingDirectory,
+			taskRecord.id,
+		);
 
-    const session = await client.createSession({
-      model,
-      streaming: true,
-      workingDirectory,
-      systemMessage: { content: buildFacilitatorPrompt(lead, agents) },
-      tools: [...squadTools, ...leadTools],
-      skillDirectories,
-      mcpServers,
-      onPermissionRequest: approveAll,
-      infiniteSessions: {
-        enabled: true,
-        backgroundCompactionThreshold: 0.6,
-        bufferExhaustionThreshold: 0.95,
-      },
-    });
+		const session = await client.createSession({
+			model,
+			streaming: true,
+			workingDirectory,
+			systemMessage: { content: buildFacilitatorPrompt(lead, agents) },
+			tools: [...squadTools, ...leadTools],
+			skillDirectories,
+			mcpServers,
+			onPermissionRequest: approveAll,
+			infiniteSessions: {
+				enabled: true,
+				backgroundCompactionThreshold: 0.6,
+				bufferExhaustionThreshold: 0.95,
+			},
+		});
 
-    const flushTokens = attachTokenTracker(session, {
-      squadId,
-      agentId: lead.id,
-      taskId: taskRecord.id,
-    });
+		const flushTokens = attachTokenTracker(session, {
+			squadId,
+			agentId: lead.id,
+			taskId: taskRecord.id,
+		});
 
-    try {
-      updateTaskStatus(taskRecord.id, "in_progress");
+		try {
+			updateTaskStatus(taskRecord.id, "in_progress");
 
-      const planResponse = await session.sendAndWait(
-        {
-          prompt: `Plan this task: ${task}${buildAttachmentSummary(attachments)}`,
-          attachments: toCopilotBlobAttachments(attachments),
-        },
-        7_200_000
-      );
+			const planResponse = await sendAndWaitWithoutDuplicateToolCallIds(
+				session,
+				{
+					prompt: `Plan this task: ${task}${buildAttachmentSummary(attachments)}`,
+					attachments: toCopilotBlobAttachments(attachments),
+				},
+				7_200_000,
+				"planning-meeting-plan",
+			);
 
-      const plan = planResponse?.data?.content ?? "Planning meeting completed but no plan was produced.";
-      const result: MeetingResult = { plan, participants };
-      const summary = buildMeetingSummary(result);
+			const plan =
+				planResponse?.data?.content ??
+				"Planning meeting completed but no plan was produced.";
+			const result: MeetingResult = { plan, participants };
+			const summary = buildMeetingSummary(result);
 
-      addAgentEvent(taskRecord.id, "message", `Plan created by ${lead.character_name}`, {
-        phase: "planning",
-        content: plan,
-      });
+			addAgentEvent(
+				taskRecord.id,
+				"message",
+				`Plan created by ${lead.character_name}`,
+				{
+					phase: "planning",
+					content: plan,
+				},
+			);
 
-      if (!executeAfter) {
-        postFeedItem(`squad-${squadSlug}`, "Planning meeting complete — awaiting approval", summary);
-        updateTaskStatus(taskRecord.id, "done", plan);
-        addAuditEntry(
-          "planning_meeting_completed",
-          `Planning meeting completed by ${lead.character_name}`,
-          { result: plan.slice(0, 500), executeAfter: false },
-          { squad_id: squadId, agent_id: lead.id, task_id: taskRecord.id }
-        );
-        addAgentEvent(taskRecord.id, "status", `Planning meeting completed by ${lead.character_name}`, {
-          phase: "planning",
-          result: plan.slice(0, 500),
-        });
+			if (!executeAfter) {
+				postFeedItem(
+					`squad-${squadSlug}`,
+					"Planning meeting complete — awaiting approval",
+					summary,
+				);
+				updateTaskStatus(taskRecord.id, "done", plan);
+				addAuditEntry(
+					"planning_meeting_completed",
+					`Planning meeting completed by ${lead.character_name}`,
+					{ result: plan.slice(0, 500), executeAfter: false },
+					{ squad_id: squadId, agent_id: lead.id, task_id: taskRecord.id },
+				);
+				addAgentEvent(
+					taskRecord.id,
+					"status",
+					`Planning meeting completed by ${lead.character_name}`,
+					{
+						phase: "planning",
+						result: plan.slice(0, 500),
+					},
+				);
 
-        // Fire-and-forget: run Scribe to merge decisions and log the session
-        runScribe({
-          squadId,
-          squadSlug,
-          workDir: workingDirectory,
-          taskSummary: plan.slice(0, 2000),
-          agentName: lead.character_name,
-          taskId: taskRecord.id,
-        }).catch(() => {});
+				// Fire-and-forget: run Scribe to merge decisions and log the session
+				runScribe({
+					squadId,
+					squadSlug,
+					workDir: workingDirectory,
+					taskSummary: plan.slice(0, 2000),
+					agentName: lead.character_name,
+					taskId: taskRecord.id,
+				}).catch(() => {});
 
-        return result;
-      }
+				return result;
+			}
 
-      const executionResponse = await session.sendAndWait(
-        {
-          prompt: `Now execute this plan by delegating work to the appropriate specialists.\n\n${buildAttachmentSummary(attachments)}`,
-          attachments: toCopilotBlobAttachments(attachments),
-        },
-        7_200_000
-      );
+			const executionResponse = await sendAndWaitWithoutDuplicateToolCallIds(
+				session,
+				{
+					prompt: `Now execute this plan by delegating work to the appropriate specialists.\n\n${buildAttachmentSummary(attachments)}`,
+					attachments: toCopilotBlobAttachments(attachments),
+				},
+				7_200_000,
+				"planning-meeting-execute",
+			);
 
-      const executionResult =
-        executionResponse?.data?.content ?? "Execution completed but no result was produced.";
-      const combinedResult = `${summary}\n\n---\n## Execution Result\n${executionResult}`;
+			const executionResult =
+				executionResponse?.data?.content ??
+				"Execution completed but no result was produced.";
+			const combinedResult = `${summary}\n\n---\n## Execution Result\n${executionResult}`;
 
-      postFeedItem(`squad-${squadSlug}`, "Planning meeting complete — execution finished", combinedResult);
-      updateTaskStatus(taskRecord.id, "done", combinedResult);
-      addAuditEntry(
-        "planning_meeting_completed",
-        `Planning meeting executed by ${lead.character_name}`,
-        { result: combinedResult.slice(0, 500), executeAfter: true },
-        { squad_id: squadId, agent_id: lead.id, task_id: taskRecord.id }
-      );
-      addAgentEvent(taskRecord.id, "status", `Planning and execution completed by ${lead.character_name}`, {
-        phase: "execution",
-        result: executionResult.slice(0, 500),
-      });
+			postFeedItem(
+				`squad-${squadSlug}`,
+				"Planning meeting complete — execution finished",
+				combinedResult,
+			);
+			updateTaskStatus(taskRecord.id, "done", combinedResult);
+			addAuditEntry(
+				"planning_meeting_completed",
+				`Planning meeting executed by ${lead.character_name}`,
+				{ result: combinedResult.slice(0, 500), executeAfter: true },
+				{ squad_id: squadId, agent_id: lead.id, task_id: taskRecord.id },
+			);
+			addAgentEvent(
+				taskRecord.id,
+				"status",
+				`Planning and execution completed by ${lead.character_name}`,
+				{
+					phase: "execution",
+					result: executionResult.slice(0, 500),
+				},
+			);
 
-      // Fire-and-forget: run Scribe to merge decisions and log the session
-      runScribe({
-        squadId,
-        squadSlug,
-        workDir: workingDirectory,
-        taskSummary: combinedResult.slice(0, 2000),
-        agentName: lead.character_name,
-        taskId: taskRecord.id,
-      }).catch(() => {});
+			// Fire-and-forget: run Scribe to merge decisions and log the session
+			runScribe({
+				squadId,
+				squadSlug,
+				workDir: workingDirectory,
+				taskSummary: combinedResult.slice(0, 2000),
+				agentName: lead.character_name,
+				taskId: taskRecord.id,
+			}).catch(() => {});
 
-      return combinedResult;
-    } finally {
-      flushTokens();
-      await session.disconnect();
-    }
-  } catch (err) {
-    const errMsg = err instanceof Error ? err.message : "Unknown error";
-    updateTaskStatus(taskRecord.id, "failed", errMsg);
-    addAuditEntry(
-      "planning_meeting_failed",
-      `Planning meeting failed: ${errMsg.slice(0, 200)}`,
-      { error: errMsg, executeAfter },
-      { squad_id: squadId, agent_id: lead.id, task_id: taskRecord.id }
-    );
-    addAgentEvent(taskRecord.id, "status", `Planning meeting failed: ${errMsg}`, {
-      error: errMsg,
-      executeAfter,
-    });
-    throw err;
-  } finally {
-    updateAgentStatus(lead.id, "idle");
-  }
+			return combinedResult;
+		} finally {
+			flushTokens();
+			await session.disconnect();
+		}
+	} catch (err) {
+		const errMsg = err instanceof Error ? err.message : "Unknown error";
+		updateTaskStatus(taskRecord.id, "failed", errMsg);
+		addAuditEntry(
+			"planning_meeting_failed",
+			`Planning meeting failed: ${errMsg.slice(0, 200)}`,
+			{ error: errMsg, executeAfter },
+			{ squad_id: squadId, agent_id: lead.id, task_id: taskRecord.id },
+		);
+		addAgentEvent(
+			taskRecord.id,
+			"status",
+			`Planning meeting failed: ${errMsg}`,
+			{
+				error: errMsg,
+				executeAfter,
+			},
+		);
+		throw err;
+	} finally {
+		updateAgentStatus(lead.id, "idle");
+	}
 }

--- a/src/copilot/orchestrator.ts
+++ b/src/copilot/orchestrator.ts
@@ -9,13 +9,17 @@ import { getMcpServersForSession } from "../mcp/registry.js";
 import { resetClient } from "./client.js";
 import { addAuditEntry } from "../store/audit-log.js";
 import {
-  buildAttachmentSummary,
-  buildAttachmentPathSummary,
-  saveAttachmentsToDisk,
-  type MessageAttachment,
-  toCopilotBlobAttachments,
+	buildAttachmentSummary,
+	buildAttachmentPathSummary,
+	saveAttachmentsToDisk,
+	type MessageAttachment,
+	toCopilotBlobAttachments,
 } from "../chat/attachments.js";
 import { attachTokenTracker } from "./token-tracker.js";
+import {
+	sendAndWaitWithoutDuplicateToolCallIds,
+	truncateDuplicateToolCalls,
+} from "./tool-call-id-guard.js";
 
 let orchestratorSession: CopilotSession | undefined;
 let sessionCreatePromise: Promise<CopilotSession> | undefined;
@@ -23,207 +27,219 @@ let healthCheckInterval: ReturnType<typeof setInterval> | undefined;
 let activeMessageAttachments: MessageAttachment[] = [];
 
 interface OrchestratorOptions {
-  selfEdit: boolean;
+	selfEdit: boolean;
 }
 
 type MessageCallback = (text: string, done: boolean) => void;
 
 interface QueuedMessage {
-  prompt: string;
-  source: string;
-  callback: MessageCallback;
-  attachments: MessageAttachment[];
+	prompt: string;
+	source: string;
+	callback: MessageCallback;
+	attachments: MessageAttachment[];
 }
 
 const messageQueue: QueuedMessage[] = [];
 let processing = false;
 
 export async function initOrchestrator(
-  client: CopilotClient,
-  opts: OrchestratorOptions
+	client: CopilotClient,
+	opts: OrchestratorOptions,
 ): Promise<void> {
-  await ensureOrchestratorSession(client, opts);
-  startHealthCheck(client, opts);
+	await ensureOrchestratorSession(client, opts);
+	startHealthCheck(client, opts);
 }
 
 async function ensureOrchestratorSession(
-  client: CopilotClient,
-  opts: OrchestratorOptions
+	client: CopilotClient,
+	opts: OrchestratorOptions,
 ): Promise<CopilotSession> {
-  if (orchestratorSession) return orchestratorSession;
-  if (sessionCreatePromise) return sessionCreatePromise;
+	if (orchestratorSession) return orchestratorSession;
+	if (sessionCreatePromise) return sessionCreatePromise;
 
-  sessionCreatePromise = createOrResumeSession(client, opts);
-  try {
-    orchestratorSession = await sessionCreatePromise;
-    return orchestratorSession;
-  } finally {
-    sessionCreatePromise = undefined;
-  }
+	sessionCreatePromise = createOrResumeSession(client, opts);
+	try {
+		orchestratorSession = await sessionCreatePromise;
+		return orchestratorSession;
+	} finally {
+		sessionCreatePromise = undefined;
+	}
 }
 
 async function createOrResumeSession(
-  client: CopilotClient,
-  opts: OrchestratorOptions
+	client: CopilotClient,
+	opts: OrchestratorOptions,
 ): Promise<CopilotSession> {
-  const config = loadConfig();
-  const db = getDb();
-  const tools = createTools();
-  const skillDirs = await loadSkillDirectories();
-  const systemMessage = buildSystemMessage(opts.selfEdit);
+	const config = loadConfig();
+	const db = getDb();
+	const tools = createTools();
+	const skillDirs = await loadSkillDirectories();
+	const systemMessage = buildSystemMessage(opts.selfEdit);
 
-  const savedId = db
-    .prepare("SELECT value FROM session_state WHERE key = 'orchestrator_session_id'")
-    .get() as { value: string } | undefined;
+	const savedId = db
+		.prepare(
+			"SELECT value FROM session_state WHERE key = 'orchestrator_session_id'",
+		)
+		.get() as { value: string } | undefined;
 
-  const sessionConfig = {
-    model: config.defaultModel,
-    streaming: true,
-    workingDirectory: process.cwd(),
-    systemMessage: { content: systemMessage },
-    tools,
-    skillDirectories: skillDirs,
-    mcpServers: getMcpServersForSession(),
-    onPermissionRequest: approveAll,
-    infiniteSessions: {
-      enabled: true,
-      backgroundCompactionThreshold: 0.8,
-      bufferExhaustionThreshold: 0.95,
-    },
-  };
+	const sessionConfig = {
+		model: config.defaultModel,
+		streaming: true,
+		workingDirectory: process.cwd(),
+		systemMessage: { content: systemMessage },
+		tools,
+		skillDirectories: skillDirs,
+		mcpServers: getMcpServersForSession(),
+		onPermissionRequest: approveAll,
+		infiniteSessions: {
+			enabled: true,
+			backgroundCompactionThreshold: 0.8,
+			bufferExhaustionThreshold: 0.95,
+		},
+	};
 
-  let session: CopilotSession;
-  if (savedId?.value) {
-    try {
-      session = await client.resumeSession(savedId.value, sessionConfig);
-    } catch {
-      session = await client.createSession(sessionConfig);
-    }
-  } else {
-    session = await client.createSession(sessionConfig);
-  }
+	let session: CopilotSession;
+	if (savedId?.value) {
+		try {
+			session = await client.resumeSession(savedId.value, sessionConfig);
+		} catch {
+			session = await client.createSession(sessionConfig);
+		}
+	} else {
+		session = await client.createSession(sessionConfig);
+	}
 
-  // Persist session ID
-  db.prepare(
-    "INSERT OR REPLACE INTO session_state (key, value) VALUES ('orchestrator_session_id', ?)"
-  ).run(session.sessionId);
+	await truncateDuplicateToolCalls(session, "orchestrator-session-init");
 
-  return session;
+	// Persist session ID
+	db.prepare(
+		"INSERT OR REPLACE INTO session_state (key, value) VALUES ('orchestrator_session_id', ?)",
+	).run(session.sessionId);
+
+	return session;
 }
 
-function startHealthCheck(client: CopilotClient, opts: OrchestratorOptions): void {
-  healthCheckInterval = setInterval(async () => {
-    try {
-      await client.ping();
-    } catch {
-      console.warn("[io] Health check failed, resetting client...");
-      orchestratorSession = undefined;
-      const newClient = await resetClient();
-      await ensureOrchestratorSession(newClient, opts);
-    }
-  }, 30_000);
-  healthCheckInterval.unref();
+function startHealthCheck(
+	client: CopilotClient,
+	opts: OrchestratorOptions,
+): void {
+	healthCheckInterval = setInterval(async () => {
+		try {
+			await client.ping();
+		} catch {
+			console.warn("[io] Health check failed, resetting client...");
+			orchestratorSession = undefined;
+			const newClient = await resetClient();
+			await ensureOrchestratorSession(newClient, opts);
+		}
+	}, 30_000);
+	healthCheckInterval.unref();
 }
 
 export async function sendToOrchestrator(
-  prompt: string,
-  source: string,
-  callback: MessageCallback,
-  attachments: MessageAttachment[] = []
+	prompt: string,
+	source: string,
+	callback: MessageCallback,
+	attachments: MessageAttachment[] = [],
 ): Promise<void> {
-  addAuditEntry(
-    "message_received",
-    `Message from ${source}: ${prompt.slice(0, 200)}`,
-    {
-      source,
-      prompt: prompt.slice(0, 1000),
-      attachments: attachments.map((attachment) => ({
-        name: attachment.name,
-        mimeType: attachment.mimeType,
-        size: attachment.size,
-      })),
-    }
-  );
-  messageQueue.push({ prompt, source, callback, attachments });
-  if (!processing) processQueue();
+	addAuditEntry(
+		"message_received",
+		`Message from ${source}: ${prompt.slice(0, 200)}`,
+		{
+			source,
+			prompt: prompt.slice(0, 1000),
+			attachments: attachments.map((attachment) => ({
+				name: attachment.name,
+				mimeType: attachment.mimeType,
+				size: attachment.size,
+			})),
+		},
+	);
+	messageQueue.push({ prompt, source, callback, attachments });
+	if (!processing) processQueue();
 }
 
 async function processQueue(): Promise<void> {
-  if (processing) return;
-  processing = true;
+	if (processing) return;
+	processing = true;
 
-  while (messageQueue.length > 0) {
-    const msg = messageQueue.shift()!;
-    try {
-      await executeOnSession(msg);
-    } catch (err) {
-      const errMsg = err instanceof Error ? err.message : "Unknown error";
-      msg.callback(`Error: ${errMsg}`, true);
-    }
-  }
+	while (messageQueue.length > 0) {
+		const msg = messageQueue.shift()!;
+		try {
+			await executeOnSession(msg);
+		} catch (err) {
+			const errMsg = err instanceof Error ? err.message : "Unknown error";
+			msg.callback(`Error: ${errMsg}`, true);
+		}
+	}
 
-  processing = false;
+	processing = false;
 }
 
 async function executeOnSession(msg: QueuedMessage): Promise<void> {
-  if (!orchestratorSession) {
-    msg.callback("Error: Orchestrator session not initialized.", true);
-    return;
-  }
+	if (!orchestratorSession) {
+		msg.callback("Error: Orchestrator session not initialized.", true);
+		return;
+	}
 
-  activeMessageAttachments = msg.attachments;
+	activeMessageAttachments = msg.attachments;
 
-  const flushTokens = attachTokenTracker(orchestratorSession, {
-    agentId: "orchestrator",
-  });
+	const flushTokens = attachTokenTracker(orchestratorSession, {
+		agentId: "orchestrator",
+	});
 
-  try {
-    // Save attachments to disk so orchestrator/squads can access them via filesystem tools
-    const savedAttachments = saveAttachmentsToDisk(msg.attachments);
-    const pathSummary = buildAttachmentPathSummary(savedAttachments);
+	try {
+		// Save attachments to disk so orchestrator/squads can access them via filesystem tools
+		const savedAttachments = saveAttachmentsToDisk(msg.attachments);
+		const pathSummary = buildAttachmentPathSummary(savedAttachments);
 
-    const taggedPrompt = `[via ${msg.source}] ${msg.prompt}${pathSummary || buildAttachmentSummary(msg.attachments)}`;
-    let accumulated = "";
+		const taggedPrompt = `[via ${msg.source}] ${msg.prompt}${pathSummary || buildAttachmentSummary(msg.attachments)}`;
+		let accumulated = "";
 
-    const unsubscribe = orchestratorSession.on("assistant.message_delta", (event: any) => {
-      const delta = event.data?.deltaContent ?? "";
-      accumulated += delta;
-      msg.callback(accumulated, false);
-    });
+		const unsubscribe = orchestratorSession.on(
+			"assistant.message_delta",
+			(event: any) => {
+				const delta = event.data?.deltaContent ?? "";
+				accumulated += delta;
+				msg.callback(accumulated, false);
+			},
+		);
 
-    try {
-      const response = await orchestratorSession.sendAndWait(
-        {
-          prompt: taggedPrompt,
-          attachments: toCopilotBlobAttachments(msg.attachments),
-        },
-        7_200_000 // 2 hours — watchdog handles stale detection
-      );
-      const finalContent = response?.data?.content ?? accumulated;
-      msg.callback(finalContent, true);
-    } finally {
-      activeMessageAttachments = [];
-      unsubscribe();
-    }
-  } finally {
-    flushTokens();
-  }
+		try {
+			const response = await sendAndWaitWithoutDuplicateToolCallIds(
+				orchestratorSession,
+				{
+					prompt: taggedPrompt,
+					attachments: toCopilotBlobAttachments(msg.attachments),
+				},
+				7_200_000, // 2 hours — watchdog handles stale detection
+				"orchestrator-send",
+			);
+			const finalContent = response?.data?.content ?? accumulated;
+			msg.callback(finalContent, true);
+		} finally {
+			activeMessageAttachments = [];
+			unsubscribe();
+		}
+	} finally {
+		flushTokens();
+	}
 }
 
 export function feedAgentResult(
-  taskId: string,
-  agentName: string,
-  result: string,
-  callback: MessageCallback
+	taskId: string,
+	agentName: string,
+	result: string,
+	callback: MessageCallback,
 ): void {
-  const prompt = `[Agent task completed] @${agentName} finished task ${taskId}:\n\n${result}`;
-  sendToOrchestrator(prompt, "background", callback);
+	const prompt = `[Agent task completed] @${agentName} finished task ${taskId}:\n\n${result}`;
+	sendToOrchestrator(prompt, "background", callback);
 }
 
 export function getOrchestratorSession(): CopilotSession | undefined {
-  return orchestratorSession;
+	return orchestratorSession;
 }
 
 export function getActiveMessageAttachments(): MessageAttachment[] {
-  return activeMessageAttachments;
+	return activeMessageAttachments;
 }

--- a/src/copilot/scribe.ts
+++ b/src/copilot/scribe.ts
@@ -9,6 +9,7 @@ import { getMcpServersForSession } from "../mcp/registry.js";
 import { logWarn } from "../logging.js";
 import { addAuditEntry } from "../store/audit-log.js";
 import { PATHS } from "../paths.js";
+import { sendAndWaitWithoutDuplicateToolCallIds } from "./tool-call-id-guard.js";
 
 /**
  * Run the Scribe — a background agent that merges decisions from the inbox
@@ -24,7 +25,8 @@ export async function runScribe(options: {
 	agentName: string;
 	taskId: string;
 }): Promise<void> {
-	const { squadId, squadSlug, workDir, taskSummary, agentName, taskId } = options;
+	const { squadId, squadSlug, workDir, taskSummary, agentName, taskId } =
+		options;
 
 	// Ensure decisions structure exists (supports pre-existing squads)
 	ensureDecisionsStructure(squadSlug);
@@ -80,7 +82,12 @@ export async function runScribe(options: {
 
 If the inbox is empty and there's nothing to log, you may skip steps 1-3 and just write the session log.`;
 
-			await session.sendAndWait({ prompt }, 120_000);
+			await sendAndWaitWithoutDuplicateToolCallIds(
+				session,
+				{ prompt },
+				120_000,
+				"scribe-run",
+			);
 		} finally {
 			await session.disconnect();
 		}

--- a/src/copilot/specialist-runner.ts
+++ b/src/copilot/specialist-runner.ts
@@ -11,30 +11,31 @@ import { addAuditEntry } from "../store/audit-log.js";
 import { updateAgentStatus, type Agent } from "../store/squads.js";
 import { touchInstanceActivity } from "../store/instances.js";
 import type { Squad } from "../store/squads.js";
+import { sendAndWaitWithoutDuplicateToolCallIds } from "./tool-call-id-guard.js";
 
 export interface SpecialistTaskRequest {
-  agent: Agent;
-  squad: Squad;
-  squadSlug: string;
-  squadId: string;
-  task: string;
-  workDir: string;
-  instanceId?: string;
-  parentTaskId: string;
+	agent: Agent;
+	squad: Squad;
+	squadSlug: string;
+	squadId: string;
+	task: string;
+	workDir: string;
+	instanceId?: string;
+	parentTaskId: string;
 }
 
 export interface SpecialistTaskResult {
-  agentName: string;
-  role: string;
-  success: boolean;
-  result: string;
+	agentName: string;
+	role: string;
+	success: boolean;
+	result: string;
 }
 
 /**
  * Build the system message for a specialist agent session.
  */
 function buildSpecialistSystemMessage(agent: Agent, squad: Squad): string {
-  return `# Squad Specialist: ${agent.character_name}
+	return `# Squad Specialist: ${agent.character_name}
 
 ## 🚨 Security Rule
 NEVER expose secrets (API keys, tokens, passwords, connection strings, private config) in any public-facing content (PRs, issues, commits, logs, wiki, feed). Use \`<REDACTED>\` as placeholder. Violation = hard failure.
@@ -77,165 +78,207 @@ ${agent.persona ? `## Personality:\n${agent.persona}` : ""}
  * Run a specialist agent session independently.
  * Creates a full Copilot SDK session with tools, executes the task, returns the result.
  */
-export async function runSpecialistSession(request: SpecialistTaskRequest): Promise<SpecialistTaskResult> {
-  const { agent, squad, squadSlug, squadId, task, workDir, instanceId, parentTaskId } = request;
+export async function runSpecialistSession(
+	request: SpecialistTaskRequest,
+): Promise<SpecialistTaskResult> {
+	const {
+		agent,
+		squad,
+		squadSlug,
+		squadId,
+		task,
+		workDir,
+		instanceId,
+		parentTaskId,
+	} = request;
 
-  // Select model based on task complexity
-  const tier = classifyComplexity(task);
-  const model = await selectModel(tier);
+	// Select model based on task complexity
+	const tier = classifyComplexity(task);
+	const model = await selectModel(tier);
 
-  const systemMessage = buildSpecialistSystemMessage(agent, squad);
+	const systemMessage = buildSpecialistSystemMessage(agent, squad);
 
-  // Update agent status
-  updateAgentStatus(agent.id, "working");
+	// Update agent status
+	updateAgentStatus(agent.id, "working");
 
-  // Touch instance activity
-  if (instanceId) {
-    touchInstanceActivity(instanceId);
-  }
+	// Touch instance activity
+	if (instanceId) {
+		touchInstanceActivity(instanceId);
+	}
 
-  // Audit: specialist task started
-  addAuditEntry(
-    "specialist_task_started",
-    `Specialist task delegated to ${agent.character_name} (${agent.role_title})`,
-    { task: task.slice(0, 500), model, parentTaskId },
-    { squad_id: squadId, agent_id: agent.id }
-  );
+	// Audit: specialist task started
+	addAuditEntry(
+		"specialist_task_started",
+		`Specialist task delegated to ${agent.character_name} (${agent.role_title})`,
+		{ task: task.slice(0, 500), model, parentTaskId },
+		{ squad_id: squadId, agent_id: agent.id },
+	);
 
-  addAgentEvent(parentTaskId, "status", `Sub-task delegated to specialist ${agent.character_name} (${agent.role_title})`, {
-    agent: agent.character_name,
-    role: agent.role_title,
-    task: task.slice(0, 300),
-  });
+	addAgentEvent(
+		parentTaskId,
+		"status",
+		`Sub-task delegated to specialist ${agent.character_name} (${agent.role_title})`,
+		{
+			agent: agent.character_name,
+			role: agent.role_title,
+			task: task.slice(0, 300),
+		},
+	);
 
-  const client = await getClient();
+	const client = await getClient();
 
-  try {
-    // Load squad-scoped tools, skills, and MCP servers
-    const squadTools = createSquadTools(squadSlug, squadId, workDir);
-    const skillDirs = [...await loadSkillDirectories(), ...loadSquadSkillDirectories(squadSlug)];
-    const mcpServers = getMcpServersForSession();
+	try {
+		// Load squad-scoped tools, skills, and MCP servers
+		const squadTools = createSquadTools(squadSlug, squadId, workDir);
+		const skillDirs = [
+			...(await loadSkillDirectories()),
+			...loadSquadSkillDirectories(squadSlug),
+		];
+		const mcpServers = getMcpServersForSession();
 
-    const session = await client.createSession({
-      model,
-      streaming: true,
-      workingDirectory: workDir,
-      systemMessage: { content: systemMessage },
-      tools: squadTools,
-      skillDirectories: skillDirs,
-      mcpServers,
-      onPermissionRequest: approveAll,
-    });
+		const session = await client.createSession({
+			model,
+			streaming: true,
+			workingDirectory: workDir,
+			systemMessage: { content: systemMessage },
+			tools: squadTools,
+			skillDirectories: skillDirs,
+			mcpServers,
+			onPermissionRequest: approveAll,
+		});
 
-    const flushTokens = attachTokenTracker(session, {
-      squadId,
-      agentId: agent.id,
-      taskId: parentTaskId,
-    });
+		const flushTokens = attachTokenTracker(session, {
+			squadId,
+			agentId: agent.id,
+			taskId: parentTaskId,
+		});
 
-    // Subscribe to granular events for timeline
-    const unsubCapture = captureSessionEvents(session, {
-      taskId: parentTaskId,
-      agentName: agent.character_name,
-      agentRole: agent.role_title,
-      model,
-    });
+		// Subscribe to granular events for timeline
+		const unsubCapture = captureSessionEvents(session, {
+			taskId: parentTaskId,
+			agentName: agent.character_name,
+			agentRole: agent.role_title,
+			model,
+		});
 
-    // Stream deltas and broadcast via SSE
-    let accumulatedMessage = "";
-    const { broadcast } = await import("../api/server.js");
-    const unsubscribeDelta = session.on("assistant.message_delta", (event: any) => {
-      const delta = event.data?.deltaContent ?? "";
-      if (delta) {
-        accumulatedMessage += delta;
-        broadcast("agent_event", {
-          taskId: parentTaskId,
-          agentName: agent.character_name,
-          type: "specialist_delta",
-          summary: accumulatedMessage,
-          payload: { delta, accumulated: accumulatedMessage },
-        });
-      }
-    });
+		// Stream deltas and broadcast via SSE
+		let accumulatedMessage = "";
+		const { broadcast } = await import("../api/server.js");
+		const unsubscribeDelta = session.on(
+			"assistant.message_delta",
+			(event: any) => {
+				const delta = event.data?.deltaContent ?? "";
+				if (delta) {
+					accumulatedMessage += delta;
+					broadcast("agent_event", {
+						taskId: parentTaskId,
+						agentName: agent.character_name,
+						type: "specialist_delta",
+						summary: accumulatedMessage,
+						payload: { delta, accumulated: accumulatedMessage },
+					});
+				}
+			},
+		);
 
-    let result: string;
-    try {
-      const response = await session.sendAndWait(
-        { prompt: `You have been assigned the following sub-task by your team lead:\n\n${task}\n\nExecute this task fully. When done, provide a clear summary of what was accomplished.` },
-        7_200_000 // 2 hours — watchdog handles stale detection
-      );
-      result = response?.data?.content ?? "Task completed (no response content).";
-    } finally {
-      unsubCapture();
-      unsubscribeDelta();
-      flushTokens();
-      await session.disconnect();
-    }
+		let result: string;
+		try {
+			const response = await sendAndWaitWithoutDuplicateToolCallIds(
+				session,
+				{
+					prompt: `You have been assigned the following sub-task by your team lead:\n\n${task}\n\nExecute this task fully. When done, provide a clear summary of what was accomplished.`,
+				},
+				7_200_000, // 2 hours — watchdog handles stale detection
+				"specialist-send",
+			);
+			result =
+				response?.data?.content ?? "Task completed (no response content).";
+		} finally {
+			unsubCapture();
+			unsubscribeDelta();
+			flushTokens();
+			await session.disconnect();
+		}
 
-    // Record completion
-    addAgentEvent(parentTaskId, "status", `Specialist ${agent.character_name} completed sub-task`, {
-      agent: agent.character_name,
-      role: agent.role_title,
-      result: result.slice(0, 500),
-    });
+		// Record completion
+		addAgentEvent(
+			parentTaskId,
+			"status",
+			`Specialist ${agent.character_name} completed sub-task`,
+			{
+				agent: agent.character_name,
+				role: agent.role_title,
+				result: result.slice(0, 500),
+			},
+		);
 
-    addAuditEntry(
-      "specialist_task_completed",
-      `Specialist ${agent.character_name} completed task`,
-      { result: result.slice(0, 500) },
-      { squad_id: squadId, agent_id: agent.id }
-    );
+		addAuditEntry(
+			"specialist_task_completed",
+			`Specialist ${agent.character_name} completed task`,
+			{ result: result.slice(0, 500) },
+			{ squad_id: squadId, agent_id: agent.id },
+		);
 
-    updateAgentStatus(agent.id, "idle");
+		updateAgentStatus(agent.id, "idle");
 
-    return {
-      agentName: agent.character_name,
-      role: agent.role_title,
-      success: true,
-      result: result.length > 1500 ? result.slice(0, 1500) + "\n\n[...truncated]" : result,
-    };
-  } catch (err) {
-    const errMsg = err instanceof Error ? err.message : "Unknown error";
+		return {
+			agentName: agent.character_name,
+			role: agent.role_title,
+			success: true,
+			result:
+				result.length > 1500
+					? result.slice(0, 1500) + "\n\n[...truncated]"
+					: result,
+		};
+	} catch (err) {
+		const errMsg = err instanceof Error ? err.message : "Unknown error";
 
-    addAgentEvent(parentTaskId, "status", `Specialist ${agent.character_name} failed: ${errMsg}`, {
-      agent: agent.character_name,
-      error: errMsg,
-    });
+		addAgentEvent(
+			parentTaskId,
+			"status",
+			`Specialist ${agent.character_name} failed: ${errMsg}`,
+			{
+				agent: agent.character_name,
+				error: errMsg,
+			},
+		);
 
-    addAuditEntry(
-      "specialist_task_failed",
-      `Specialist ${agent.character_name} failed: ${errMsg.slice(0, 200)}`,
-      { error: errMsg },
-      { squad_id: squadId, agent_id: agent.id }
-    );
+		addAuditEntry(
+			"specialist_task_failed",
+			`Specialist ${agent.character_name} failed: ${errMsg.slice(0, 200)}`,
+			{ error: errMsg },
+			{ squad_id: squadId, agent_id: agent.id },
+		);
 
-    updateAgentStatus(agent.id, "idle");
+		updateAgentStatus(agent.id, "idle");
 
-    return {
-      agentName: agent.character_name,
-      role: agent.role_title,
-      success: false,
-      result: `Error: ${errMsg}`,
-    };
-  }
+		return {
+			agentName: agent.character_name,
+			role: agent.role_title,
+			success: false,
+			result: `Error: ${errMsg}`,
+		};
+	}
 }
 
 /**
  * Run multiple specialist sessions in parallel.
  * Returns results in the same order as the input requests.
  */
-export async function runSpecialistsParallel(requests: SpecialistTaskRequest[]): Promise<SpecialistTaskResult[]> {
-  const results = await Promise.allSettled(requests.map(runSpecialistSession));
+export async function runSpecialistsParallel(
+	requests: SpecialistTaskRequest[],
+): Promise<SpecialistTaskResult[]> {
+	const results = await Promise.allSettled(requests.map(runSpecialistSession));
 
-  return results.map((r, i) => {
-    if (r.status === "fulfilled") {
-      return r.value;
-    }
-    return {
-      agentName: requests[i].agent.character_name,
-      role: requests[i].agent.role_title,
-      success: false,
-      result: `Session error: ${r.reason instanceof Error ? r.reason.message : "Unknown error"}`,
-    };
-  });
+	return results.map((r, i) => {
+		if (r.status === "fulfilled") {
+			return r.value;
+		}
+		return {
+			agentName: requests[i].agent.character_name,
+			role: requests[i].agent.role_title,
+			success: false,
+			result: `Session error: ${r.reason instanceof Error ? r.reason.message : "Unknown error"}`,
+		};
+	});
 }

--- a/src/copilot/tool-call-id-guard.test.ts
+++ b/src/copilot/tool-call-id-guard.test.ts
@@ -1,0 +1,120 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+	sendAndWaitWithoutDuplicateToolCallIds,
+	truncateDuplicateToolCalls,
+} from "./tool-call-id-guard.js";
+
+type StubEvent = {
+	id: string;
+	type: string;
+	data?: { toolCallId?: string };
+};
+
+function createSessionStub(events: StubEvent[]) {
+	const calls = {
+		truncate: [] as string[],
+		sendAndWait: [] as { prompt: string }[],
+	};
+
+	const session = {
+		sessionId: "session-1",
+		async getMessages() {
+			return events as any;
+		},
+		rpc: {
+			history: {
+				async truncate({ eventId }: { eventId: string }) {
+					calls.truncate.push(eventId);
+					return { eventsRemoved: 3 };
+				},
+			},
+		},
+		async sendAndWait(options: { prompt: string }) {
+			calls.sendAndWait.push(options);
+			return { data: { content: "ok" }, type: "assistant.message" } as any;
+		},
+	};
+
+	return { session: session as any, calls };
+}
+
+test("truncateDuplicateToolCalls truncates at first duplicate external tool event", async () => {
+	const { session, calls } = createSessionStub([
+		{
+			id: "e1",
+			type: "external_tool.requested",
+			data: { toolCallId: "fc_call_1" },
+		},
+		{ id: "e2", type: "assistant.message" },
+		{
+			id: "e3",
+			type: "external_tool.requested",
+			data: { toolCallId: "fc_call_1" },
+		},
+	]);
+
+	const truncated = await truncateDuplicateToolCalls(session, "test");
+
+	assert.equal(truncated, true);
+	assert.deepEqual(calls.truncate, ["e3"]);
+});
+
+test("truncateDuplicateToolCalls does nothing when no duplicate exists", async () => {
+	const { session, calls } = createSessionStub([
+		{
+			id: "e1",
+			type: "external_tool.requested",
+			data: { toolCallId: "fc_call_1" },
+		},
+		{
+			id: "e2",
+			type: "external_tool.requested",
+			data: { toolCallId: "fc_call_2" },
+		},
+	]);
+
+	const truncated = await truncateDuplicateToolCalls(session, "test");
+
+	assert.equal(truncated, false);
+	assert.deepEqual(calls.truncate, []);
+});
+
+test("sendAndWaitWithoutDuplicateToolCallIds retries once after duplicate-id API error", async () => {
+	const events: StubEvent[] = [
+		{
+			id: "e1",
+			type: "external_tool.requested",
+			data: { toolCallId: "fc_call_1" },
+		},
+		{
+			id: "e2",
+			type: "external_tool.requested",
+			data: { toolCallId: "fc_call_1" },
+		},
+	];
+	const { session, calls } = createSessionStub(events);
+
+	let attempts = 0;
+	session.sendAndWait = async (options: { prompt: string }) => {
+		calls.sendAndWait.push(options);
+		attempts += 1;
+		if (attempts === 1) {
+			throw new Error(
+				"CAPIError: 400 Duplicate item found with id fc_call_1. Remove duplicate items from your input and try again.",
+			);
+		}
+		return { data: { content: "recovered" }, type: "assistant.message" };
+	};
+
+	const result = await sendAndWaitWithoutDuplicateToolCallIds(
+		session,
+		{ prompt: "hello" },
+		1000,
+		"test",
+	);
+
+	assert.equal(result?.data?.content, "recovered");
+	assert.equal(calls.sendAndWait.length, 2);
+	assert.deepEqual(calls.truncate, ["e2", "e2"]);
+});

--- a/src/copilot/tool-call-id-guard.ts
+++ b/src/copilot/tool-call-id-guard.ts
@@ -1,0 +1,103 @@
+import type { CopilotSession } from "@github/copilot-sdk";
+import { logWarn } from "../logging.js";
+
+const DUPLICATE_TOOL_CALL_ID_PATTERN =
+	/Duplicate item found with id (fc_call_[\w-]+)/i;
+
+type SendOptions = Parameters<CopilotSession["sendAndWait"]>[0];
+type SendResult = Awaited<ReturnType<CopilotSession["sendAndWait"]>>;
+
+interface DuplicateToolCallEvent {
+	eventId: string;
+	toolCallId: string;
+}
+
+function getErrorMessage(err: unknown): string {
+	if (err instanceof Error) return err.message;
+	if (typeof err === "string") return err;
+	return "";
+}
+
+function findDuplicateExternalToolCallEvent(
+	events: Awaited<ReturnType<CopilotSession["getMessages"]>>,
+): DuplicateToolCallEvent | undefined {
+	const seen = new Set<string>();
+
+	for (const event of events) {
+		if (event.type !== "external_tool.requested") continue;
+		const toolCallId = event.data?.toolCallId;
+		if (!toolCallId) continue;
+		if (seen.has(toolCallId)) {
+			return {
+				eventId: event.id,
+				toolCallId,
+			};
+		}
+		seen.add(toolCallId);
+	}
+
+	return undefined;
+}
+
+function getDuplicateToolCallIdFromError(err: unknown): string | undefined {
+	const message = getErrorMessage(err);
+	const match = DUPLICATE_TOOL_CALL_ID_PATTERN.exec(message);
+	return match?.[1];
+}
+
+export async function truncateDuplicateToolCalls(
+	session: CopilotSession,
+	context: string,
+): Promise<boolean> {
+	const events = await session.getMessages();
+	const duplicate = findDuplicateExternalToolCallEvent(events);
+	if (!duplicate) return false;
+
+	const result = await session.rpc.history.truncate({
+		eventId: duplicate.eventId,
+	});
+	logWarn(
+		"Detected duplicate tool call ID in session history; truncated tail",
+		{
+			context,
+			sessionId: session.sessionId,
+			toolCallId: duplicate.toolCallId,
+			eventId: duplicate.eventId,
+			eventsRemoved: result.eventsRemoved,
+		},
+	);
+	return true;
+}
+
+export async function sendAndWaitWithoutDuplicateToolCallIds(
+	session: CopilotSession,
+	options: SendOptions,
+	timeout: number,
+	context: string,
+): Promise<SendResult> {
+	await truncateDuplicateToolCalls(session, `${context}:preflight`);
+
+	try {
+		return await session.sendAndWait(options, timeout);
+	} catch (err) {
+		const duplicateToolCallId = getDuplicateToolCallIdFromError(err);
+		if (!duplicateToolCallId) throw err;
+
+		logWarn(
+			"Model API rejected duplicate tool call ID; attempting session-history repair",
+			{
+				context,
+				sessionId: session.sessionId,
+				toolCallId: duplicateToolCallId,
+			},
+		);
+
+		const didTruncate = await truncateDuplicateToolCalls(
+			session,
+			`${context}:retry`,
+		);
+		if (!didTruncate) throw err;
+
+		return session.sendAndWait(options, timeout);
+	}
+}


### PR DESCRIPTION
## Summary
Fix intermittent model API failures caused by duplicate  tool call IDs in outbound Copilot session payloads.

## Root cause
Long-lived/resumed Copilot sessions could contain duplicated  events with the same . We were calling  directly on those sessions, so the SDK replay path could emit duplicate function-call items to the model API, triggering:



## Fix
- Added  with a shared guard that:
  - scans session history for duplicate external tool call IDs,
  - truncates history at the first duplicate event before send,
  - retries once when the API explicitly returns a duplicate  error.
- Wired the guard into all Copilot  paths:
  - 
  - 
  - 
  - 
  - 
- Added regression tests in  for duplicate detection/truncation and recovery retry behavior.

## Validation
- 
> @michaeljolley/heyio@0.0.1 build
> tsc
- 
> @michaeljolley/heyio@0.0.1 test
> node --import tsx --test 'src/**/*.test.ts' 'web/src/**/*.test.ts'

✔ validateMessageAttachments accepts valid payload (1.908331ms)
✔ validateMessageAttachments enforces per-file size limit (0.421849ms)
✔ validateMessageAttachments enforces total size limit (0.368273ms)
✔ toCopilotBlobAttachments maps attachment content (1.314826ms)
✔ buildAttachmentSummary includes attachment metadata (0.372057ms)
✔ getCopilotClientOptions forwards configured github token from config (5.167331ms)
✔ buildSquadScopedPrompt includes squad context (1.950295ms)
✔ isGitHubRepoPath accepts GitHub-style owner/repo paths (2.745865ms)
✔ discoverSkills filters unsupported skills.sh sources (55.134458ms)
✔ discoverSkills uses remote frontmatter descriptions from SKILL.md content (16.37102ms)
✔ listSkills handles CRLF line endings in frontmatter (25.780392ms)
✔ listSkills handles LF line endings in frontmatter (20.318924ms)
✔ listSkills extracts description from frontmatter, not body (8.587988ms)
✔ listSkills falls back to body description when frontmatter has none (8.441649ms)
✔ listSkills preserves quoted frontmatter descriptions (14.304833ms)
✔ listSkills preserves block-scalar frontmatter descriptions (24.162044ms)
[io] ⚠️  Config file not found at /tmp/io-token-tracker-sExst5/.io/config.json — using defaults. Run "io setup" or create the file manually.
✔ attachTokenTracker records token usage from Copilot usage events (29.789963ms)
✔ attachTokenTracker accumulates multiple usage events across models (8.082508ms)
[io] Detected duplicate tool call ID in session history; truncated tail {
  context: 'test',
  sessionId: 'session-1',
  toolCallId: 'fc_call_1',
  eventId: 'e3',
  eventsRemoved: 3
}
[io] Detected duplicate tool call ID in session history; truncated tail {
  context: 'test:preflight',
  sessionId: 'session-1',
  toolCallId: 'fc_call_1',
  eventId: 'e2',
  eventsRemoved: 3
}
[io] Model API rejected duplicate tool call ID; attempting session-history repair { context: 'test', sessionId: 'session-1', toolCallId: 'fc_call_1' }
[io] Detected duplicate tool call ID in session history; truncated tail {
  context: 'test:retry',
  sessionId: 'session-1',
  toolCallId: 'fc_call_1',
  eventId: 'e2',
  eventsRemoved: 3
}
✔ truncateDuplicateToolCalls truncates at first duplicate external tool event (4.310839ms)
✔ truncateDuplicateToolCalls does nothing when no duplicate exists (0.314489ms)
✔ sendAndWaitWithoutDuplicateToolCallIds retries once after duplicate-id API error (1.620112ms)
✔ saveMessage persists attachments (15.510626ms)
✔ createSchedule requires a squad_id (1.865722ms)
✔ a squad can have multiple schedules (14.291512ms)
✔ updateSchedule persists prompt changes and toggles enabled state (3.119368ms)
✔ pickSquadColor picks from unused colors first (2.054508ms)
✔ createSquad assigns unique colors while palette has unused entries (13.2772ms)
✔ createSquad still assigns a palette color after palette is exhausted (9.841963ms)
✔ MarkdownRenderer renders core markdown features (118.269187ms)
✔ MarkdownRenderer sanitizes XSS payloads (6.50556ms)
✔ MarkdownRenderer adds target=_blank and rel=noopener noreferrer to external links (3.390361ms)
✔ MarkdownRenderer handles http links as external (2.87819ms)
ℹ tests 32
ℹ suites 0
ℹ pass 32
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 4160.460302
