### PR TITLE
fix: remove infiniteSessions from ephemeral agent sessions

### DIFF
--- a/src/copilot/agents.ts
+++ b/src/copilot/agents.ts
@@ -43,6 +43,12 @@ const execAsync = promisify(exec);
 // Registry of active agent sessions keyed by task ID
 const activeSessions = new Map<string, CopilotSession>();
 
+/** Detect the "Duplicate item found" API error that indicates corrupted session history. */
+function isDuplicateItemError(err: unknown): boolean {
+	if (!(err instanceof Error)) return false;
+	return err.message.includes("Duplicate item found with id");
+}
+
 /**
  * Resolve the working directory for a squad agent session.
  * Priority: instance worktree → cloned repo → process.cwd()
@@ -272,11 +278,6 @@ ${lead.persona ? `## Personality:\n${lead.persona}` : ""}
 			skillDirectories: skillDirs,
 			mcpServers,
 			onPermissionRequest: approveAll,
-			infiniteSessions: {
-				enabled: true,
-				backgroundCompactionThreshold: 0.6,
-				bufferExhaustionThreshold: 0.95,
-			},
 		});
 
 		// Register session so it can be stopped externally
@@ -340,13 +341,50 @@ ${lead.persona ? `## Personality:\n${lead.persona}` : ""}
 				const savedAttachments = saveAttachmentsToDisk(attachments);
 				const attachmentPathInfo = buildAttachmentPathSummary(savedAttachments);
 
-				const response = await session.sendAndWait(
-					{
-						prompt: `Task delegated to you:\n\n${task}${attachmentPathInfo}`,
-						attachments: toCopilotBlobAttachments(attachments),
-					},
-					7_200_000, // 2 hours — watchdog handles stale detection
-				);
+				let response: any;
+				try {
+					response = await session.sendAndWait(
+						{
+							prompt: `Task delegated to you:\n\n${task}${attachmentPathInfo}`,
+							attachments: toCopilotBlobAttachments(attachments),
+						},
+						7_200_000, // 2 hours — watchdog handles stale detection
+					);
+				} catch (sendErr) {
+					if (!isDuplicateItemError(sendErr)) throw sendErr;
+
+					// Session history is corrupted — disconnect and retry with a fresh session
+					logWarn("Duplicate item error detected, retrying with fresh session", {
+						taskId: taskRecord.id,
+					});
+					await session.disconnect();
+					activeSessions.delete(taskRecord.id);
+					unsubCapture();
+					flushTokens();
+
+					const retrySession = await client.createSession({
+						model,
+						streaming: true,
+						workingDirectory: workDir,
+						systemMessage: { content: systemMessage },
+						tools: [...squadTools, ...leadTools],
+						skillDirectories: skillDirs,
+						mcpServers,
+						onPermissionRequest: approveAll,
+					});
+					activeSessions.set(taskRecord.id, retrySession);
+
+					response = await retrySession.sendAndWait(
+						{
+							prompt: `Task delegated to you:\n\n${task}${attachmentPathInfo}`,
+							attachments: toCopilotBlobAttachments(attachments),
+						},
+						7_200_000,
+					);
+					await retrySession.disconnect();
+					activeSessions.delete(taskRecord.id);
+				}
+
 				result =
 					response?.data?.content ?? "Task completed (no response content).";
 
@@ -364,7 +402,7 @@ ${lead.persona ? `## Personality:\n${lead.persona}` : ""}
 			activeSessions.delete(taskRecord.id);
 			unsubCapture();
 			flushTokens();
-			await session.disconnect();
+				try { await session.disconnect(); } catch { /* may already be disconnected after retry */ }
 		}
 	} catch (err) {
 		const errMsg = err instanceof Error ? err.message : "Unknown error";

--- a/src/copilot/ceremonies.ts
+++ b/src/copilot/ceremonies.ts
@@ -189,11 +189,6 @@ export async function squadMeeting(
       skillDirectories,
       mcpServers,
       onPermissionRequest: approveAll,
-      infiniteSessions: {
-        enabled: true,
-        backgroundCompactionThreshold: 0.6,
-        bufferExhaustionThreshold: 0.95,
-      },
     });
 
     const flushTokens = attachTokenTracker(session, {


### PR DESCRIPTION
The infiniteSessions background compaction in the Copilot SDK is corrupting conversation history by duplicating fc_call_* entries, causing 400 errors on all squad agent tasks.

- Remove infiniteSessions from lead agent and ceremony sessions (ephemeral single-task sessions don't need infinite context)
- Add retry logic that detects the duplicate item error, creates a fresh session, and retries once
- Orchestrator retains infiniteSessions (long-lived, works fine)