### PR TITLE
chore: remove decisions.md pre-read instruction

### DIFF
--- a/src/copilot/agents.ts
+++ b/src/copilot/agents.ts
@@ -225,8 +225,6 @@ Failure to follow squad wiki rules is a CRITICAL FAILURE.
 
 ## 📝 Decision Logging (Team Memory)
 
-Your squad has a shared decision log at \`decisions.md\`. **Before starting work**, read it with \`wiki_read\` to see what the team already knows — prior architectural decisions, conventions discovered, patterns established.
-
 **During work**, when you or your specialists make significant decisions (architectural choices, discovered conventions, tool/library selections, patterns to follow), log them by writing a brief note to the decisions inbox:
 - Use \`wiki_write\` to create \`decisions/inbox/{topic}.md\`
 - Keep entries concise: what was decided, why, and by whom

--- a/src/copilot/specialist-runner.ts
+++ b/src/copilot/specialist-runner.ts
@@ -54,8 +54,6 @@ You are an independent specialist — you execute implementation work within you
 ## Squad Wiki = Your Source of Truth
 Your squad wiki contains workflow rules set by the project owner. Read it (use \`wiki_read\`) and follow those rules exactly — branching, PR process, review format, merge criteria. If your task involves reviewing a PR, follow the wiki's review process precisely.
 
-**Before starting work**, read \`decisions.md\` to see what the team already knows about this codebase — prior decisions, discovered conventions, established patterns. This saves you from re-discovering what the team has already learned.
-
 ## Workflow Rules:
 - Always use the gh CLI for GitHub interactions
 - Use \`--comment\` with "LGTM" for approvals (not \`--approve\`)


### PR DESCRIPTION
## Rationale

Every specialist/agent invocation currently includes an instruction to read `decisions.md` before starting work. This wastes tokens on every task — especially for small/focused tasks where the read is pure overhead.

## Changes

- `src/copilot/specialist-runner.ts`: removed the "Before starting work, read decisions.md..." paragraph from the specialist system prompt.
- `src/copilot/agents.ts`: removed the equivalent sentence from the team-lead system prompt.

## Preserved

The **Decision Logging** sections (writing to `decisions/inbox/`) are intentionally kept. Agents still log new decisions for the Scribe to merge — we just don't force every agent to re-read the log on every task.

Draft for team-lead review.