### PR TITLE
feat(usage): format numbers with commas on Usage view

### DIFF
--- a/web/src/lib/formatNumber.test.ts
+++ b/web/src/lib/formatNumber.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { formatNumber } from "./formatNumber";
+
+test("formatNumber formats numbers with commas", () => {
+  assert.equal(formatNumber(1234567), "1,234,567");
+  assert.equal(formatNumber("1234567"), "1,234,567");
+  assert.equal(formatNumber("1,234,567"), "1,234,567");
+  assert.equal(formatNumber(null), "0");
+  assert.equal(formatNumber(undefined), "0");
+  assert.equal(formatNumber("not-a-number"), "0");
+});

--- a/web/src/lib/formatNumber.ts
+++ b/web/src/lib/formatNumber.ts
@@ -1,0 +1,8 @@
+export function formatNumber(value: number | string | null | undefined): string {
+  if (value === null || value === undefined) return "0";
+
+  const num = typeof value === "number" ? value : Number(String(value).replace(/,/g, ""));
+  if (!Number.isFinite(num)) return "0";
+
+  return num.toLocaleString();
+}

--- a/web/src/views/UsageView.tsx
+++ b/web/src/views/UsageView.tsx
@@ -3,9 +3,9 @@ import { useEffect, useMemo, useState } from "react";
 import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { toast } from "sonner";
 import { SquadChip } from "@/components/ui";
+import { formatNumber } from "@/lib/formatNumber";
 import { uuid } from "@/lib/uuid";
 import { useAuthStore } from "@/stores/auth";
-import { formatNumber } from "@/lib/formatNumber";
 
 interface UsageSummary {
   totalTokens: number;

--- a/web/src/views/UsageView.tsx
+++ b/web/src/views/UsageView.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { SquadChip } from "@/components/ui";
 import { uuid } from "@/lib/uuid";
 import { useAuthStore } from "@/stores/auth";
+import { formatNumber } from "@/lib/formatNumber";
 
 interface UsageSummary {
   totalTokens: number;
@@ -204,8 +205,6 @@ export default function UsageView() {
       totalOutputTokens: summary?.totalOutputTokens ?? 0,
     };
   }, [daily, squads, summary]);
-
-  const formatNumber = (value: number) => value.toLocaleString();
 
   if (loading) {
     return <div className="p-6 text-[11px] font-mono text-zinc-500">Loading usage…</div>;

--- a/web/src/views/UsageView.tsx
+++ b/web/src/views/UsageView.tsx
@@ -270,6 +270,7 @@ export default function UsageView() {
                 contentStyle={tooltipStyle}
                 labelStyle={{ color: "#e4e4e7" }}
                 cursor={{ fill: "rgba(255,255,255,0.04)" }}
+                formatter={(value) => formatNumber(value as number | string | null | undefined)}
               />
               <Bar dataKey="inputTokens" name="Input Tokens" fill="#66FCF1" radius={[6, 6, 0, 0]} />
               <Bar dataKey="outputTokens" name="Output Tokens" fill="#45A29E" radius={[6, 6, 0, 0]} />


### PR DESCRIPTION
This PR formats numeric values on the Usage view with thousands separators. See tests. Requesting reviews from @michaeljolley (Hannibal) and @murdock (Murdock).