### PR TITLE
feat(ui): increase font sizes by 25% across dashboard

### DIFF
--- a/web/src/components/AppHeader.tsx
+++ b/web/src/components/AppHeader.tsx
@@ -16,7 +16,7 @@ export function AppHeader() {
     <div className="h-[52px] flex-shrink-0 flex items-center justify-end px-4 border-b border-white/[0.06] bg-[var(--base-black)]">
       {/* <div className="flex items-center gap-2">
         <StatusDot status="connected" />
-        <span className="text-[11px] font-mono text-green-400">connected</span>
+        <span className="text-[14px] font-mono text-green-400">connected</span>
       </div> */}
       <div className="flex items-center gap-1.5">
         <div className="relative">
@@ -27,7 +27,7 @@ export function AppHeader() {
             <Bell className="w-3.5 h-3.5" />
             {feedCount > 0 && (
               <span
-                className="absolute top-1 right-1 w-3.5 h-3.5 rounded-full text-[8px] font-mono text-white flex items-center justify-center leading-none"
+                className="absolute top-1 right-1 w-3.5 h-3.5 rounded-full text-[10px] font-mono text-white flex items-center justify-center leading-none"
                 style={{ background: "linear-gradient(135deg, #45A29E, #F75F57)" }}
               >
                 {feedCount}
@@ -39,16 +39,16 @@ export function AppHeader() {
               <div className="fixed inset-0 z-40" onClick={() => setFlyout(false)} />
               <div className="absolute right-0 top-full mt-1.5 w-72 bg-[#1e1e1e] border border-white/[0.08] rounded-2xl shadow-2xl z-50 overflow-hidden">
                 <div className="px-4 py-2.5 border-b border-white/[0.06] flex items-center justify-between">
-                  <p className="text-[11px] font-mono text-zinc-500">Recent Activity</p>
+                  <p className="text-[14px] font-mono text-zinc-500">Recent Activity</p>
                 </div>
-                <div className="px-4 py-6 text-center text-[11px] font-mono text-zinc-700">No new activity</div>
+                <div className="px-4 py-6 text-center text-[14px] font-mono text-zinc-700">No new activity</div>
                 <div className="px-4 py-2 text-center border-t border-white/[0.04]">
                   <button
                     onClick={() => {
                       setFlyout(false);
                       navigate("/feed");
                     }}
-                    className="text-[11px] cursor-pointer font-mono text-[#66FCF1] hover:text-[#D789F3] transition-colors flex items-center gap-1 mx-auto"
+                    className="text-[14px] cursor-pointer font-mono text-[#66FCF1] hover:text-[#D789F3] transition-colors flex items-center gap-1 mx-auto"
                   >
                     View all <ArrowRight className="w-3 h-3" />
                   </button>
@@ -62,7 +62,7 @@ export function AppHeader() {
           className="w-6 h-6 rounded-lg flex items-center justify-center border border-[#66FCF1]/20"
           style={{ background: "rgba(102,252,241,0.12)" }}
         >
-          <span className="text-[10px] font-mono text-[#66FCF1]">{email?.[0]?.toUpperCase() ?? "A"}</span>
+          <span className="text-[13px] font-mono text-[#66FCF1]">{email?.[0]?.toUpperCase() ?? "A"}</span>
         </div>
         <button
           onClick={logout}

--- a/web/src/components/AppSidebar.tsx
+++ b/web/src/components/AppSidebar.tsx
@@ -46,7 +46,7 @@ function NavBtn({
     <button
       onClick={onClick}
       title={collapsed ? item.label : undefined}
-      className={`w-full flex items-center cursor-pointer gap-2.5 px-2 py-2 rounded-xl text-[11px] font-mono transition-colors ${active ? "text-[#66FCF1]" : "text-zinc-600 "} ${collapsed ? "justify-center" : ""} hover:text-zinc-200 hover:bg-white/[0.04]`}
+      className={`w-full flex items-center cursor-pointer gap-2.5 px-2 py-2 rounded-xl text-[14px] font-mono transition-colors ${active ? "text-[#66FCF1]" : "text-zinc-600 "} ${collapsed ? "justify-center" : ""} hover:text-zinc-200 hover:bg-white/[0.04]`}
       style={active ? { background: "rgba(102,252,241,0.1)" } : undefined}
     >
       <Icon className="w-3.5 h-3.5 flex-shrink-0" />
@@ -121,7 +121,7 @@ export function AppSidebar() {
             target="_blank"
             rel="noopener noreferrer"
             title="GitHub"
-            className={`flex items-center gap-2.5 px-2 py-2 rounded-xl text-[11px] font-mono text-zinc-600 hover:text-zinc-300 hover:bg-white/[0.04] transition-colors ${collapsed ? "justify-center" : ""}`}
+            className={`flex items-center gap-2.5 px-2 py-2 rounded-xl text-[14px] font-mono text-zinc-600 hover:text-zinc-300 hover:bg-white/[0.04] transition-colors ${collapsed ? "justify-center" : ""}`}
           >
             <svg className="w-3.5 h-3.5 flex-shrink-0" viewBox="0 0 24 24" fill="currentColor">
               <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
@@ -131,7 +131,7 @@ export function AppSidebar() {
           <button
             onClick={() => setCollapsed(!collapsed)}
             title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-            className={`w-full flex items-center gap-2.5 px-2 py-2 rounded-xl text-[11px] font-mono text-zinc-600 hover:text-zinc-300 hover:bg-white/[0.04] transition-colors cursor-pointer ${collapsed ? "justify-center" : ""}`}
+            className={`w-full flex items-center gap-2.5 px-2 py-2 rounded-xl text-[14px] font-mono text-zinc-600 hover:text-zinc-300 hover:bg-white/[0.04] transition-colors cursor-pointer ${collapsed ? "justify-center" : ""}`}
           >
             {collapsed ? (
               <ChevronRight className="w-3.5 h-3.5 flex-shrink-0" />

--- a/web/src/components/ChatOverlay.tsx
+++ b/web/src/components/ChatOverlay.tsx
@@ -110,10 +110,10 @@ export function ChatOverlay() {
                   <FileText className="w-3 h-3 text-zinc-500" />
                 </div>
                 <div className="flex-1 min-w-0">
-                  <p className="text-[10px] font-mono text-zinc-300 truncate leading-tight">
+                  <p className="text-[13px] font-mono text-zinc-300 truncate leading-tight">
                     {pendingAttachments[0].name}
                   </p>
-                  <p className="text-[9px] font-mono text-zinc-600 leading-tight">
+                  <p className="text-[11px] font-mono text-zinc-600 leading-tight">
                     {formatAttachmentSize(pendingAttachments[0].size)}
                   </p>
                 </div>

--- a/web/src/components/ui/Buttons.tsx
+++ b/web/src/components/ui/Buttons.tsx
@@ -12,7 +12,7 @@ export function PrimaryBtn({
   return (
     <button
       onClick={onClick}
-      className={`flex items-center gap-1.5 font-mono text-[11px] rounded-lg active:opacity-80 cursor-pointer primary-btn ${className}`}
+      className={`flex items-center gap-1.5 font-mono text-[14px] rounded-lg active:opacity-80 cursor-pointer primary-btn ${className}`}
     >
       {children}
     </button>
@@ -31,7 +31,7 @@ export function SecondaryBtn({
   return (
     <button
       onClick={onClick}
-      className={`flex items-center cursor-pointer gap-1.5 px-2.5 py-1 rounded-lg font-mono text-[11px] text-zinc-400 bg-[#252525] hover:bg-[#2e2e2e] hover:text-zinc-100 transition-colors ${className}`}
+      className={`flex items-center cursor-pointer gap-1.5 px-2.5 py-1 rounded-lg font-mono text-[14px] text-zinc-400 bg-[#252525] hover:bg-[#2e2e2e] hover:text-zinc-100 transition-colors ${className}`}
     >
       {children}
     </button>
@@ -50,7 +50,7 @@ export function DangerBtn({
   return (
     <button
       onClick={onClick}
-      className={`flex items-center cursor-pointer gap-1.5 px-2.5 py-1 rounded-lg font-mono text-[11px] text-zinc-400 bg-[#252525] hover:bg-red-500/10 hover:text-red-400 transition-colors ${className}`}
+      className={`flex items-center cursor-pointer gap-1.5 px-2.5 py-1 rounded-lg font-mono text-[14px] text-zinc-400 bg-[#252525] hover:bg-red-500/10 hover:text-red-400 transition-colors ${className}`}
     >
       {children}
     </button>
@@ -69,7 +69,7 @@ export function WarnBtn({
   return (
     <button
       onClick={onClick}
-      className={`flex items-center cursor-pointer gap-1.5 px-2.5 py-1 rounded-lg font-mono text-[11px] text-zinc-400 bg-[#252525] hover:bg-amber-500/10 hover:text-amber-400 transition-colors ${className}`}
+      className={`flex items-center cursor-pointer gap-1.5 px-2.5 py-1 rounded-lg font-mono text-[14px] text-zinc-400 bg-[#252525] hover:bg-amber-500/10 hover:text-amber-400 transition-colors ${className}`}
     >
       {children}
     </button>

--- a/web/src/components/ui/MessageBubble.tsx
+++ b/web/src/components/ui/MessageBubble.tsx
@@ -25,7 +25,7 @@ export function MessageBubble({ msg }: { msg: ChatMessage }) {
         className={`rounded-xl px-3 py-2 text-xs leading-relaxed border ${msg.role === "user" ? "text-[#1F2833]  border-[#66FCF1]/30  rounded-tr-sm" : "bg-[#282828] border-white/[0.06] text-zinc-200 rounded-tl-sm"}`}
         style={msg.role === "user" ? { background: "var(--base-dark-teal)", color: "var(--base-teal)" } : undefined}
       >
-        <MarkdownRenderer content={msg.content} className="max-w-none text-[11px] leading-relaxed text-inherit" />
+        <MarkdownRenderer content={msg.content} className="max-w-none text-[14px] leading-relaxed text-inherit" />
       </div>
     </div>
   );

--- a/web/src/components/ui/StatusChip.tsx
+++ b/web/src/components/ui/StatusChip.tsx
@@ -33,7 +33,7 @@ export function Chip({ children, variant = "muted" }: { children: ReactNode; var
     muted: "bg-white/5 text-zinc-400 border-white/10",
   }[variant];
   return (
-    <span className={`inline-flex items-center px-2 py-px rounded-full text-[10px] font-mono border ${cls}`}>
+    <span className={`inline-flex items-center px-2 py-px rounded-full text-[13px] font-mono border ${cls}`}>
       {children}
     </span>
   );
@@ -63,7 +63,7 @@ export function SquadChip({ name, color: colorProp }: { name: string; color?: st
   if (color) {
     return (
       <span
-        className="inline-flex items-center px-1.5 py-px rounded text-[10px] font-mono border"
+        className="inline-flex items-center px-1.5 py-px rounded text-[13px] font-mono border"
         style={{ background: `${color}15`, color, borderColor: `${color}30` }}
       >
         {name}

--- a/web/src/components/ui/UserIndicator.tsx
+++ b/web/src/components/ui/UserIndicator.tsx
@@ -3,7 +3,7 @@ import { IoMark } from "../IoMark";
 export function UserIndicator({ role }: { role: "user" | "assistant" }) {
   return (
     <div
-      className={`flex-shrink-0 w-6 h-6 rounded-lg flex items-center justify-center text-[10px] font-mono mt-0.5 ${role === "user" ? "border border-[#66FCF1]/30 text-[#66FCF1]" : "bg-[#282828] border border-white/[0.07] text-zinc-500"}`}
+      className={`flex-shrink-0 w-6 h-6 rounded-lg flex items-center justify-center text-[13px] font-mono mt-0.5 ${role === "user" ? "border border-[#66FCF1]/30 text-[#66FCF1]" : "bg-[#282828] border border-white/[0.07] text-zinc-500"}`}
       style={role === "user" ? { background: "rgba(69,162,158,0.12)" } : undefined}
     >
       {role === "user" ? "U" : <IoMark height={12} />}

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -27,7 +27,7 @@
   --base-accent2: oklch(68.135% 0.18797 26.281);
 
 
-  --font-size: 16px;
+  --font-size: 20px;
   --background: var(--base-black);
   --foreground: var(--base-gray);
   --card: var(--base-blue);
@@ -218,7 +218,7 @@
 }
 .prose-io code {
   font-family: "JetBrains Mono", monospace;
-  font-size: 0.82em;
+  font-size: 1.025em;
   background: var(--base-blue);
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 4px;
@@ -238,7 +238,7 @@
   border: none;
   padding: 0;
   color: var(--base-gray);
-  font-size: 0.85em;
+  font-size: 1.063em;
 }
 .prose-io blockquote {
   border-left: 2px solid var(--base-teal);
@@ -260,7 +260,7 @@
   width: 100%;
   border-collapse: collapse;
   margin: 0.8em 0;
-  font-size: 0.85em;
+  font-size: 1.063em;
 }
 .prose-io th {
   text-align: left;

--- a/web/src/views/ChatView.tsx
+++ b/web/src/views/ChatView.tsx
@@ -90,7 +90,7 @@ export default function ChatView() {
 
       {/* Input area */}
       <div className="border-t border-white/[0.06] p-4 flex-shrink-0">
-        {composerError && <div className="text-[11px] font-mono text-red-400 mb-2">{composerError}</div>}
+        {composerError && <div className="text-[14px] font-mono text-red-400 mb-2">{composerError}</div>}
 
         {pendingAttachments.length > 0 && (
           <div className="flex flex-wrap gap-2 mb-2">
@@ -99,8 +99,8 @@ export default function ChatView() {
                 key={`${att.name}:${att.size}:${att.mimeType}`}
                 className="flex items-center gap-2 bg-[#252525] border border-white/[0.08] rounded-xl px-3 py-1.5"
               >
-                <span className="text-[10px] font-mono text-zinc-400 truncate max-w-[120px]">{att.name}</span>
-                <span className="text-[9px] font-mono text-zinc-600">{formatAttachmentSize(att.size)}</span>
+                <span className="text-[13px] font-mono text-zinc-400 truncate max-w-[120px]">{att.name}</span>
+                <span className="text-[11px] font-mono text-zinc-600">{formatAttachmentSize(att.size)}</span>
                 <button
                   onClick={() => setPendingAttachments((p) => p.filter((_, idx) => idx !== i))}
                   className="text-zinc-600 hover:text-zinc-300 cursor-pointer"
@@ -144,7 +144,7 @@ export default function ChatView() {
               {isStreaming ? (
                 <button
                   onClick={stopStreaming}
-                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-zinc-800 hover:bg-zinc-700 text-[11px] font-mono text-zinc-300 transition-colors"
+                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-zinc-800 hover:bg-zinc-700 text-[14px] font-mono text-zinc-300 transition-colors"
                 >
                   <Square className="w-3 h-3" /> Stop
                 </button>
@@ -161,7 +161,7 @@ export default function ChatView() {
             </div>
           </div>
         </div>
-        <p className="text-center text-[11px] text-zinc-800 font-mono mt-2">
+        <p className="text-center text-[14px] text-zinc-800 font-mono mt-2">
           IO may make mistakes. Verify important outputs.
         </p>
       </div>

--- a/web/src/views/FeedView.tsx
+++ b/web/src/views/FeedView.tsx
@@ -167,7 +167,7 @@ export default function FeedView() {
           <div className="px-5 pt-5 pb-4 border-b border-white/[0.06] space-y-4">
             <div className="flex items-center justify-between gap-3">
               <div>
-                <p className="text-[11px] font-mono uppercase tracking-[0.28em] text-zinc-500">Feed</p>
+                <p className="text-[14px] font-mono uppercase tracking-[0.28em] text-zinc-500">Feed</p>
                 <h1 className="text-3xl text-zinc-100 leading-none" style={{ fontFamily: "'Bebas Neue', sans-serif" }}>
                   Inbox
                 </h1>
@@ -175,7 +175,7 @@ export default function FeedView() {
               <Chip variant={unreadCount > 0 ? "default" : "muted"}>{unreadCount} unread</Chip>
             </div>
 
-            <div className="flex gap-2 rounded-xl border border-white/[0.06] bg-black/10 p-1 font-mono text-[11px]">
+            <div className="flex gap-2 rounded-xl border border-white/[0.06] bg-black/10 p-1 font-mono text-[14px]">
               {(["all", "unread"] as const).map((tab) => (
                 <button
                   key={tab}
@@ -187,7 +187,7 @@ export default function FeedView() {
               ))}
             </div>
 
-            <div className="flex items-center justify-between rounded-xl border border-white/[0.06] bg-black/10 px-3 py-2 text-[11px] font-mono text-zinc-400">
+            <div className="flex items-center justify-between rounded-xl border border-white/[0.06] bg-black/10 px-3 py-2 text-[14px] font-mono text-zinc-400">
               <label className="flex items-center gap-2 cursor-pointer">
                 <input
                   type="checkbox"
@@ -222,7 +222,7 @@ export default function FeedView() {
 
           <div className="flex-1 min-h-0 overflow-y-auto p-2 space-y-2">
             {loading ? (
-              <div className="h-full flex items-center justify-center text-[11px] font-mono text-zinc-500">
+              <div className="h-full flex items-center justify-center text-[14px] font-mono text-zinc-500">
                 Loading inbox…
               </div>
             ) : items.length === 0 ? (
@@ -230,7 +230,7 @@ export default function FeedView() {
                 <IoMark height={26} />
                 <div>
                   <p className="text-zinc-200">No feed items</p>
-                  <p className="text-[11px] font-mono text-zinc-500">
+                  <p className="text-[14px] font-mono text-zinc-500">
                     {filter === "unread"
                       ? "Everything has been reviewed."
                       : "The daemon has not posted any updates yet."}
@@ -263,7 +263,7 @@ export default function FeedView() {
                             )}
                             <SquadChip name={item.source} />
                           </div>
-                          <span className="text-[11px] font-mono text-zinc-500 flex items-center gap-1 flex-shrink-0">
+                          <span className="text-[14px] font-mono text-zinc-500 flex items-center gap-1 flex-shrink-0">
                             <Clock3 className="h-3 w-3" />
                             {formatTimestamp(item.created_at)}
                           </span>
@@ -273,7 +273,7 @@ export default function FeedView() {
                         >
                           {item.title}
                         </p>
-                        <p className="mt-1 text-[11px] font-mono text-zinc-500 line-clamp-2">
+                        <p className="mt-1 text-[14px] font-mono text-zinc-500 line-clamp-2">
                           {previewText(item.content)}
                         </p>
                       </button>
@@ -294,7 +294,7 @@ export default function FeedView() {
                 </div>
                 <div>
                   <p className="text-zinc-100 text-lg">Bulk mode enabled</p>
-                  <p className="text-[11px] font-mono text-zinc-500 mt-2">
+                  <p className="text-[14px] font-mono text-zinc-500 mt-2">
                     {checkedIds.length} feed item{checkedIds.length === 1 ? "" : "s"} selected. Use the bulk controls to
                     mark everything read or delete in one pass.
                   </p>
@@ -307,7 +307,7 @@ export default function FeedView() {
                 <div className="min-w-0">
                   <div className="flex items-center gap-2 mb-3">
                     <SquadChip name={selectedItem.source} />
-                    <span className="text-[11px] font-mono text-zinc-500">
+                    <span className="text-[14px] font-mono text-zinc-500">
                       {formatTimestamp(selectedItem.created_at)}
                     </span>
                   </div>
@@ -333,7 +333,7 @@ export default function FeedView() {
                 </div>
                 <div>
                   <p className="text-zinc-100 text-lg">Select a message to read</p>
-                  <p className="text-[11px] font-mono text-zinc-500 mt-2">
+                  <p className="text-[14px] font-mono text-zinc-500 mt-2">
                     Choose any feed item from the left panel to open the full markdown update here.
                   </p>
                 </div>

--- a/web/src/views/LoginView.tsx
+++ b/web/src/views/LoginView.tsx
@@ -43,7 +43,7 @@ export default function LoginView() {
         <div className="flex flex-col items-center mb-8 gap-3">
           <IoMark height={52} />
           <div className="text-center">
-            <p className="text-[11px] font-mono text-zinc-600 tracking-widest uppercase mt-1">
+            <p className="text-[14px] font-mono text-zinc-600 tracking-widest uppercase mt-1">
               personal ai orchestrator
             </p>
           </div>
@@ -51,12 +51,12 @@ export default function LoginView() {
 
         <form onSubmit={handleSubmit} className="glass-card border border-white/[0.07] rounded-2xl p-6 space-y-4">
           {error && (
-            <div className="text-[11px] font-mono text-red-400 bg-red-500/10 border border-red-500/20 rounded-xl px-3 py-2">
+            <div className="text-[14px] font-mono text-red-400 bg-red-500/10 border border-red-500/20 rounded-xl px-3 py-2">
               {error}
             </div>
           )}
           <div className="space-y-1">
-            <label className="text-[11px] font-mono text-zinc-500 block">Email</label>
+            <label className="text-[14px] font-mono text-zinc-500 block">Email</label>
             <input
               type="email"
               value={email}
@@ -66,7 +66,7 @@ export default function LoginView() {
             />
           </div>
           <div className="space-y-1">
-            <label className="text-[11px] font-mono text-zinc-500 block">Password</label>
+            <label className="text-[14px] font-mono text-zinc-500 block">Password</label>
             <input
               type="password"
               value={password}

--- a/web/src/views/McpView.tsx
+++ b/web/src/views/McpView.tsx
@@ -34,8 +34,8 @@ interface ServerDraft {
 
 const GLASS_CARD = "glass-card border border-white/[0.07] rounded-2xl";
 const INPUT_CLASS =
-  "bg-[#181818] border border-white/[0.06] rounded-xl px-3 py-2 text-[11px] text-zinc-300 font-mono placeholder:text-zinc-700 focus:outline-none focus:border-[#66FCF1]/30";
-const SECTION_HEADER = "text-[10px] font-mono text-zinc-700 uppercase tracking-wider";
+  "bg-[#181818] border border-white/[0.06] rounded-xl px-3 py-2 text-[14px] text-zinc-300 font-mono placeholder:text-zinc-700 focus:outline-none focus:border-[#66FCF1]/30";
+const SECTION_HEADER = "text-[13px] font-mono text-zinc-700 uppercase tracking-wider";
 const MODAL_BACKDROP = {
   background: "rgba(0,0,0,0.55)",
   backdropFilter: "blur(4px)",
@@ -301,7 +301,7 @@ export default function McpView() {
           <h1 className="text-4xl leading-none text-white" style={{ fontFamily: "'Bebas Neue', sans-serif" }}>
             MCP Servers
           </h1>
-          <p className="mt-2 text-[11px] font-mono text-zinc-600">{servers.length} configured servers</p>
+          <p className="mt-2 text-[14px] font-mono text-zinc-600">{servers.length} configured servers</p>
         </div>
         <PrimaryBtn onClick={() => setShowModal(true)} className="px-3 py-1.5">
           <Plus className="h-3.5 w-3.5" />
@@ -310,16 +310,16 @@ export default function McpView() {
       </div>
 
       {error && (
-        <div className="rounded-2xl border border-red-500/15 bg-red-500/6 px-4 py-3 text-[11px] font-mono text-red-300">
+        <div className="rounded-2xl border border-red-500/15 bg-red-500/6 px-4 py-3 text-[14px] font-mono text-red-300">
           {error}
         </div>
       )}
 
       <div className="space-y-2">
         {loading ? (
-          <div className={`${GLASS_CARD} px-4 py-5 text-[11px] font-mono text-zinc-600`}>Loading MCP servers…</div>
+          <div className={`${GLASS_CARD} px-4 py-5 text-[14px] font-mono text-zinc-600`}>Loading MCP servers…</div>
         ) : servers.length === 0 ? (
-          <div className={`${GLASS_CARD} px-4 py-5 text-[11px] font-mono text-zinc-700`}>
+          <div className={`${GLASS_CARD} px-4 py-5 text-[14px] font-mono text-zinc-700`}>
             No MCP servers configured.
           </div>
         ) : (
@@ -343,12 +343,12 @@ export default function McpView() {
                       <div className="flex flex-wrap items-center gap-2">
                         <span className="truncate text-sm text-zinc-100">{server.name}</span>
                         <Chip variant={server.type === "http" ? "info" : "muted"}>{server.type}</Chip>
-                        <span className="flex items-center gap-1.5 text-[11px] font-mono text-zinc-500">
+                        <span className="flex items-center gap-1.5 text-[14px] font-mono text-zinc-500">
                           <StatusDot status={server.enabled ? "connected" : "disconnected"} />
                           {statusText}
                         </span>
                       </div>
-                      <div className="mt-1 truncate text-[11px] font-mono text-zinc-600">
+                      <div className="mt-1 truncate text-[14px] font-mono text-zinc-600">
                         {server.type === "stdio"
                           ? [server.command, ...(server.args ?? [])].filter(Boolean).join(" ") ||
                             "No command configured"
@@ -376,7 +376,7 @@ export default function McpView() {
                     <div className={SECTION_HEADER}>Tools</div>
                     <div className="mt-3 space-y-2">
                       {server.tools.length === 0 ? (
-                        <div className="rounded-xl border border-white/[0.05] bg-black/10 px-3 py-3 text-[11px] font-mono text-zinc-700">
+                        <div className="rounded-xl border border-white/[0.05] bg-black/10 px-3 py-3 text-[14px] font-mono text-zinc-700">
                           No tools reported by this server yet.
                         </div>
                       ) : (
@@ -386,8 +386,8 @@ export default function McpView() {
                             className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-white/[0.05] bg-black/10 px-3 py-3"
                           >
                             <div className="min-w-0 flex-1">
-                              <div className="truncate text-[11px] font-mono text-zinc-200">{tool.name}</div>
-                              <div className="mt-1 text-[10px] text-zinc-600">
+                              <div className="truncate text-[14px] font-mono text-zinc-200">{tool.name}</div>
+                              <div className="mt-1 text-[13px] text-zinc-600">
                                 {tool.description || "No description provided."}
                               </div>
                             </div>
@@ -417,7 +417,7 @@ export default function McpView() {
                 <h2 className="text-3xl leading-none text-white" style={{ fontFamily: "'Bebas Neue', sans-serif" }}>
                   Add Server
                 </h2>
-                <p className="mt-2 text-[11px] font-mono text-zinc-600">Connect a new MCP stdio or HTTP endpoint.</p>
+                <p className="mt-2 text-[14px] font-mono text-zinc-600">Connect a new MCP stdio or HTTP endpoint.</p>
               </div>
               <SecondaryBtn onClick={closeModal} className="px-3 py-1.5">
                 Close
@@ -444,7 +444,7 @@ export default function McpView() {
                       <button
                         key={type}
                         onClick={() => setDraft((current) => ({ ...current, type }))}
-                        className={`rounded-xl border px-3 py-2 text-left text-[11px] font-mono transition-colors ${
+                        className={`rounded-xl border px-3 py-2 text-left text-[14px] font-mono transition-colors ${
                           active
                             ? "border-[#66FCF1]/30 text-[#66FCF1]"
                             : "border-white/[0.06] text-zinc-500 hover:text-zinc-300 hover:bg-white/[0.03]"

--- a/web/src/views/SchedulesView.tsx
+++ b/web/src/views/SchedulesView.tsx
@@ -39,8 +39,8 @@ interface ScheduleDraft {
 
 const GLASS_CARD = "glass-card border border-white/[0.07] rounded-2xl";
 const INPUT_CLASS =
-  "bg-[#181818] border border-white/[0.06] rounded-xl px-3 py-2 text-[11px] text-zinc-300 font-mono placeholder:text-zinc-700 focus:outline-none focus:border-[#66FCF1]/30";
-const SECTION_HEADER = "text-[10px] font-mono text-zinc-700 uppercase tracking-wider";
+  "bg-[#181818] border border-white/[0.06] rounded-xl px-3 py-2 text-[14px] text-zinc-300 font-mono placeholder:text-zinc-700 focus:outline-none focus:border-[#66FCF1]/30";
+const SECTION_HEADER = "text-[13px] font-mono text-zinc-700 uppercase tracking-wider";
 const MODAL_BACKDROP = {
   background: "rgba(0,0,0,0.55)",
   backdropFilter: "blur(4px)",
@@ -420,7 +420,7 @@ export default function SchedulesView() {
             <button
               key={value}
               onClick={() => setTab(value)}
-              className={`cursor-pointer px-2 pb-2 text-[11px] border-b font-mono uppercase tracking-[0.18em] transition-colors ${!active ? "hover:text-zinc-300" : ""}`}
+              className={`cursor-pointer px-2 pb-2 text-[14px] border-b font-mono uppercase tracking-[0.18em] transition-colors ${!active ? "hover:text-zinc-300" : ""}`}
               style={{
                 borderColor: active ? "#66FCF1" : "transparent",
                 color: active ? "#66FCF1" : undefined,
@@ -433,13 +433,13 @@ export default function SchedulesView() {
       </div>
 
       {error && (
-        <div className="rounded-2xl border border-red-500/15 bg-red-500/6 px-4 py-3 text-[11px] font-mono text-red-300">
+        <div className="rounded-2xl border border-red-500/15 bg-red-500/6 px-4 py-3 text-[14px] font-mono text-red-300">
           {error}
         </div>
       )}
 
       <div className={`${GLASS_CARD} overflow-hidden`}>
-        <table className="w-full text-[11px] font-mono">
+        <table className="w-full text-[14px] font-mono">
           <thead>
             <tr className="border-b border-white/[0.06]" style={{ background: "rgba(20,20,20,0.6)" }}>
               <th className="text-left px-4 py-2.5 text-white font-medium">Schedule</th>
@@ -525,7 +525,7 @@ export default function SchedulesView() {
                 <h2 className="text-3xl leading-none text-white" style={{ fontFamily: "'Bebas Neue', sans-serif" }}>
                   {editingId ? "Edit Schedule" : "New Schedule"}
                 </h2>
-                <p className="mt-2 text-[11px] font-mono text-zinc-600">
+                <p className="mt-2 text-[14px] font-mono text-zinc-600">
                   Configure cadence, label, and prompt payload.
                 </p>
               </div>
@@ -542,7 +542,7 @@ export default function SchedulesView() {
                         <button
                           key={value}
                           onClick={() => setDraft((current) => ({ ...current, type: value }))}
-                          className={`rounded-xl border px-3 py-2 text-left text-[11px] font-mono transition-colors cursor-pointer ${
+                          className={`rounded-xl border px-3 py-2 text-left text-[14px] font-mono transition-colors cursor-pointer ${
                             active
                               ? "border-[#66FCF1]/30 text-[#66FCF1]"
                               : "border-white/[0.06] text-zinc-500 hover:text-zinc-300 hover:bg-white/[0.03]"

--- a/web/src/views/SettingsView.tsx
+++ b/web/src/views/SettingsView.tsx
@@ -28,9 +28,9 @@ interface SettingsForm {
 const tabs: SettingsTab[] = ["General", "Telegram", "Auth", "Advanced"];
 const MASK = "••••••••";
 const inputClass =
-  "bg-[#181818] border border-white/[0.06] rounded-xl px-3 py-2 text-[11px] text-zinc-300 font-mono placeholder:text-zinc-700 focus:outline-none focus:border-[#66FCF1]/30";
+  "bg-[#181818] border border-white/[0.06] rounded-xl px-3 py-2 text-[14px] text-zinc-300 font-mono placeholder:text-zinc-700 focus:outline-none focus:border-[#66FCF1]/30";
 const tabClass =
-  "cursor-pointer px-2 pb-2 text-[11px] border-b font-mono uppercase tracking-[0.18em] transition-colors";
+  "cursor-pointer px-2 pb-2 text-[14px] border-b font-mono uppercase tracking-[0.18em] transition-colors";
 
 const emptySettings: SettingsForm = {
   defaultModel: "",
@@ -155,7 +155,7 @@ function buildPayload(settings: SettingsForm) {
 function FormRow({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="flex flex-col gap-2 border-b border-white/[0.04] py-4 first:pt-0 last:border-b-0 last:pb-0 md:flex-row md:items-center">
-      <div className="w-40 text-[11px] font-mono text-zinc-500">{label}</div>
+      <div className="w-40 text-[14px] font-mono text-zinc-500">{label}</div>
       <div className="flex-1 flex justify-end">{children}</div>
     </div>
   );
@@ -276,7 +276,7 @@ export default function SettingsView() {
   };
 
   if (loading) {
-    return <div className="p-6 text-[11px] font-mono text-zinc-500">Loading settings…</div>;
+    return <div className="p-6 text-[14px] font-mono text-zinc-500">Loading settings…</div>;
   }
 
   return (
@@ -286,7 +286,7 @@ export default function SettingsView() {
           <h1 className="text-3xl leading-none text-zinc-100" style={{ fontFamily: "'Bebas Neue', sans-serif" }}>
             Settings
           </h1>
-          <p className="mt-2 text-[11px] font-mono text-zinc-500">
+          <p className="mt-2 text-[14px] font-mono text-zinc-500">
             Control auth, notifications, models, and runtime behavior.
           </p>
         </div>
@@ -425,7 +425,7 @@ export default function SettingsView() {
         </div>
 
         <div className="border-t border-white/[0.06] px-5 py-4 flex items-center justify-between gap-3">
-          <p className="text-[11px] font-mono text-zinc-600">
+          <p className="text-[14px] font-mono text-zinc-600">
             {dirty ? "Unsaved changes" : `Secrets remain masked as ${MASK}`}
           </p>
           <div className="flex items-center gap-2">

--- a/web/src/views/SkillsView.tsx
+++ b/web/src/views/SkillsView.tsx
@@ -35,7 +35,7 @@ interface SelectedSkill {
   slug: string;
 }
 
-const SECTION_HEADER = "text-[10px] font-mono text-zinc-700 uppercase tracking-wider";
+const SECTION_HEADER = "text-[13px] font-mono text-zinc-700 uppercase tracking-wider";
 
 function skillKey(source: SkillSource, slug: string): string {
   return `${source}:${slug}`;
@@ -347,7 +347,7 @@ export default function SkillsView() {
                 value={search}
                 onChange={(event) => setSearch(event.target.value)}
                 placeholder="Search skills..."
-                className={`w-full pl-9 bg-[#181818] border border-white/[0.06] rounded-xl px-3 py-2 text-[11px] text-zinc-300 font-mono placeholder:text-zinc-700 focus:outline-none focus:border-[#66FCF1]/30`}
+                className={`w-full pl-9 bg-[#181818] border border-white/[0.06] rounded-xl px-3 py-2 text-[14px] text-zinc-300 font-mono placeholder:text-zinc-700 focus:outline-none focus:border-[#66FCF1]/30`}
               />
             </div>
 
@@ -364,7 +364,7 @@ export default function SkillsView() {
                   <button
                     key={tabKey}
                     onClick={() => setSource(tabKey)}
-                    className={`w-full text-left cursor-pointer px-2.5 py-1.5 rounded-lg text-[11px] font-mono transition-colors ${
+                    className={`w-full text-left cursor-pointer px-2.5 py-1.5 rounded-lg text-[14px] font-mono transition-colors ${
                       active ? "text-[#66FCF1]" : "text-zinc-500 hover:text-zinc-300 hover:bg-white/[0.04]"
                     }`}
                     style={active ? { background: "rgba(102,252,241,0.10)" } : undefined}
@@ -378,15 +378,15 @@ export default function SkillsView() {
 
           <div className="min-h-0 flex-1 overflow-y-auto">
             {pageError && (
-              <div className="border-b border-red-500/15 bg-red-500/6 px-3 py-2 text-[11px] font-mono text-red-300">
+              <div className="border-b border-red-500/15 bg-red-500/6 px-3 py-2 text-[14px] font-mono text-red-300">
                 {pageError}
               </div>
             )}
 
             {(loadingInstalled || loadingRemote) && visibleSkills.length === 0 ? (
-              <div className="px-4 py-5 text-[11px] font-mono text-zinc-600">Loading skills…</div>
+              <div className="px-4 py-5 text-[14px] font-mono text-zinc-600">Loading skills…</div>
             ) : visibleSkills.length === 0 ? (
-              <div className="px-4 py-5 text-[11px] font-mono text-zinc-700">No skills found.</div>
+              <div className="px-4 py-5 text-[14px] font-mono text-zinc-700">No skills found.</div>
             ) : (
               visibleSkills.map((skill) => {
                 const active = selected?.source === source && selected.slug === skill.slug;
@@ -402,9 +402,9 @@ export default function SkillsView() {
                     }`}
                     style={active ? { background: "var(--base-dark-teal)" } : undefined}
                   >
-                    <div className="truncate text-[11px] font-mono text-zinc-200">{skill.name || skill.slug}</div>
+                    <div className="truncate text-[14px] font-mono text-zinc-200">{skill.name || skill.slug}</div>
                     <div
-                      className="mt-1 text-[10px] leading-relaxed text-zinc-600 line-clamp-2"
+                      className="mt-1 text-[13px] leading-relaxed text-zinc-600 line-clamp-2"
                       style={active ? { color: "var(--base-gray)" } : undefined}
                     >
                       {skill.description
@@ -414,7 +414,7 @@ export default function SkillsView() {
                         : "No description"}
                     </div>
                     <div
-                      className="mt-2 truncate text-[9px] font-mono text-zinc-700"
+                      className="mt-2 truncate text-[11px] font-mono text-zinc-700"
                       style={active ? { color: "var(--base-gray)" } : undefined}
                     >
                       {getListMeta(skill)}
@@ -500,9 +500,9 @@ export default function SkillsView() {
 
               <div className="min-h-0 flex-1 overflow-y-auto p-6 space-y-6">
                 {selectedDetail?.loading ? (
-                  <div className="text-[11px] font-mono text-zinc-600">Loading skill detail…</div>
+                  <div className="text-[14px] font-mono text-zinc-600">Loading skill detail…</div>
                 ) : selectedDetail?.error ? (
-                  <div className="rounded-2xl border border-red-500/15 bg-red-500/6 px-4 py-3 text-[11px] font-mono text-red-300">
+                  <div className="rounded-2xl border border-red-500/15 bg-red-500/6 px-4 py-3 text-[14px] font-mono text-red-300">
                     {selectedDetail.error}
                   </div>
                 ) : editMode ? (
@@ -511,7 +511,7 @@ export default function SkillsView() {
                     <textarea
                       value={editContent}
                       onChange={(event) => setEditContent(event.target.value)}
-                      className="min-h-[440px] w-full resize-y rounded-2xl border border-white/[0.06] bg-[#181818] px-4 py-3 font-mono text-[11px] text-zinc-300 placeholder:text-zinc-700 focus:border-[#66FCF1]/30 focus:outline-none"
+                      className="min-h-[440px] w-full resize-y rounded-2xl border border-white/[0.06] bg-[#181818] px-4 py-3 font-mono text-[14px] text-zinc-300 placeholder:text-zinc-700 focus:border-[#66FCF1]/30 focus:outline-none"
                     />
                     <div className="flex flex-wrap gap-2">
                       <PrimaryBtn onClick={() => void saveEditedContent()} className="px-3 py-1.5">
@@ -534,7 +534,7 @@ export default function SkillsView() {
                           v !== "" &&
                           !(Array.isArray(v) && v.length === 0),
                       ).length === 0 ? (
-                        <div className="mt-4 text-[11px] font-mono text-zinc-700">No front matter metadata found.</div>
+                        <div className="mt-4 text-[14px] font-mono text-zinc-700">No front matter metadata found.</div>
                       ) : (
                         <div className="mt-4 space-y-0">
                           {Object.entries(selectedFrontmatter)
@@ -550,8 +550,8 @@ export default function SkillsView() {
                                 key={key}
                                 className="grid grid-cols-[200px_1fr] gap-2 border-b border-white/[0.04] py-3 first:pt-0 last:border-b-0 last:pb-0"
                               >
-                                <span className="text-[11px] font-mono text-zinc-500">{frontmatterLabel(key)}</span>
-                                <span className="text-[11px] font-mono text-zinc-300 break-words min-w-0 text-left">
+                                <span className="text-[14px] font-mono text-zinc-500">{frontmatterLabel(key)}</span>
+                                <span className="text-[14px] font-mono text-zinc-300 break-words min-w-0 text-left">
                                   {frontmatterValue(value)}
                                 </span>
                               </div>
@@ -565,7 +565,7 @@ export default function SkillsView() {
                       {selectedBody ? (
                         <MarkdownRenderer content={selectedBody} className="mt-4" />
                       ) : (
-                        <div className="mt-4 text-[11px] font-mono text-zinc-700">This skill has no markdown body.</div>
+                        <div className="mt-4 text-[14px] font-mono text-zinc-700">This skill has no markdown body.</div>
                       )}
                     </div>
                   </>

--- a/web/src/views/SquadDetailView.tsx
+++ b/web/src/views/SquadDetailView.tsx
@@ -429,11 +429,11 @@ export default function SquadDetailView() {
   };
 
   if (loading) {
-    return <div className="p-6 text-[11px] font-mono text-zinc-500">Loading squad…</div>;
+    return <div className="p-6 text-[14px] font-mono text-zinc-500">Loading squad…</div>;
   }
 
   if (!squad) {
-    return <div className="p-6 text-[11px] font-mono text-zinc-500">Squad not found.</div>;
+    return <div className="p-6 text-[14px] font-mono text-zinc-500">Squad not found.</div>;
   }
 
   const tabs: TabKey[] = ["agents", "instances", "schedules", "history"];
@@ -460,7 +460,7 @@ export default function SquadDetailView() {
               setActivityEvents([]);
               setSelectedAgents(new Set());
             }}
-            className="flex items-center gap-1.5 text-[11px] text-zinc-600 hover:text-zinc-300 font-mono transition-colors cursor-pointer"
+            className="flex items-center gap-1.5 text-[14px] text-zinc-600 hover:text-zinc-300 font-mono transition-colors cursor-pointer"
           >
             <ChevronLeft className="w-3.5 h-3.5" /> Back to {squad.name}
           </button>
@@ -474,11 +474,11 @@ export default function SquadDetailView() {
                 {selectedHistoryItem?.title || "Objective"}
               </h2>
               <div className="flex items-center gap-3 mt-1">
-                <span className="text-[11px] text-zinc-600 font-mono">
+                <span className="text-[14px] text-zinc-600 font-mono">
                   {formatTimestamp(selectedHistoryItem?.timestamp)}
                 </span>
                 {selectedHistoryItem?.duration && (
-                  <span className="text-[11px] text-zinc-700 font-mono flex items-center gap-1">
+                  <span className="text-[14px] text-zinc-700 font-mono flex items-center gap-1">
                     <Clock className="w-3 h-3" />
                     {selectedHistoryItem.duration}
                   </span>
@@ -509,7 +509,7 @@ export default function SquadDetailView() {
                     }}
                   >
                     <Bot className="w-3 h-3" style={{ color: isActive ? color : "#71717a" }} />
-                    <span className="text-[11px] font-mono" style={{ color: isActive ? color : "#71717a" }}>
+                    <span className="text-[14px] font-mono" style={{ color: isActive ? color : "#71717a" }}>
                       {name}
                     </span>
                   </button>
@@ -518,7 +518,7 @@ export default function SquadDetailView() {
               {selectedAgents.size > 0 && (
                 <button
                   onClick={() => setSelectedAgents(new Set())}
-                  className="flex items-center gap-1 px-2.5 py-1.5 rounded-xl border border-white/[0.1] text-[11px] font-mono text-zinc-400 hover:text-zinc-200 transition-colors cursor-pointer"
+                  className="flex items-center gap-1 px-2.5 py-1.5 rounded-xl border border-white/[0.1] text-[14px] font-mono text-zinc-400 hover:text-zinc-200 transition-colors cursor-pointer"
                 >
                   Show all
                 </button>
@@ -528,9 +528,9 @@ export default function SquadDetailView() {
 
           {/* Unified timeline */}
           {activityLoading ? (
-            <p className="text-[11px] font-mono text-zinc-500 py-10 text-center">Loading activity…</p>
+            <p className="text-[14px] font-mono text-zinc-500 py-10 text-center">Loading activity…</p>
           ) : filteredTimelineEvents.length === 0 ? (
-            <p className="text-[11px] font-mono text-zinc-500 py-10 text-center">No events recorded for this task.</p>
+            <p className="text-[14px] font-mono text-zinc-500 py-10 text-center">No events recorded for this task.</p>
           ) : (
             <div className="relative pl-10">
               <div className="absolute left-[15px] top-0 bottom-0 w-px bg-white/[0.06]" />
@@ -557,18 +557,18 @@ export default function SquadDetailView() {
                           <div className="flex items-center gap-2 flex-wrap">
                             <div className="flex items-center gap-1">
                               <Bot className="w-3 h-3" style={{ color }} />
-                              <span className="text-[10px] font-mono" style={{ color }}>
+                              <span className="text-[13px] font-mono" style={{ color }}>
                                 {name}
                               </span>
                               {event.model && (
-                                <span className="text-[9px] font-mono text-zinc-600 bg-white/[0.04] px-1.5 py-0.5 rounded">
+                                <span className="text-[11px] font-mono text-zinc-600 bg-white/[0.04] px-1.5 py-0.5 rounded">
                                   {event.model}
                                 </span>
                               )}
                             </div>
-                            <span className="text-zinc-700 text-[10px]">·</span>
+                            <span className="text-zinc-700 text-[13px]">·</span>
                             <div className="flex min-w-0 max-w-full items-center gap-1.5 overflow-x-auto whitespace-nowrap">
-                              <span className="text-[10px] font-mono uppercase tracking-wider text-zinc-500 whitespace-nowrap">
+                              <span className="text-[13px] font-mono uppercase tracking-wider text-zinc-500 whitespace-nowrap">
                                 {meta.label}
                               </span>
                               {isCode &&
@@ -576,12 +576,12 @@ export default function SquadDetailView() {
                                   const { toolName, success } = parseToolEventPayload(event);
                                   return (
                                     <>
-                                      <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-mono bg-white/[0.06] text-zinc-300 border border-white/[0.08] whitespace-nowrap">
+                                      <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[13px] font-mono bg-white/[0.06] text-zinc-300 border border-white/[0.08] whitespace-nowrap">
                                         {toolName}
                                       </span>
                                       {success !== undefined && (
                                         <span
-                                          className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-mono whitespace-nowrap ${
+                                          className={`inline-flex items-center px-2 py-0.5 rounded-full text-[13px] font-mono whitespace-nowrap ${
                                             success
                                               ? "bg-green-500/10 text-green-400 border border-green-500/20"
                                               : "bg-red-500/10 text-red-400 border border-red-500/20"
@@ -595,7 +595,7 @@ export default function SquadDetailView() {
                                 })()}
                             </div>
                           </div>
-                          <span className="text-[10px] font-mono text-zinc-700 flex-shrink-0 ml-2">
+                          <span className="text-[13px] font-mono text-zinc-700 flex-shrink-0 ml-2">
                             {formatTimestamp(event.created_at)}
                           </span>
                         </div>
@@ -605,7 +605,7 @@ export default function SquadDetailView() {
                             return (
                               <div className="mt-1">
                                 {body && (
-                                  <pre className="mt-2 text-[11px] font-mono text-zinc-400 whitespace-pre-wrap leading-relaxed overflow-x-auto rounded-lg p-2 bg-black/20">
+                                  <pre className="mt-2 text-[14px] font-mono text-zinc-400 whitespace-pre-wrap leading-relaxed overflow-x-auto rounded-lg p-2 bg-black/20">
                                     {body}
                                   </pre>
                                 )}
@@ -615,7 +615,7 @@ export default function SquadDetailView() {
                         ) : (
                           <MarkdownRenderer
                             content={event.summary || event.payload || ""}
-                            className="text-[12px] [&_pre]:text-[10px]"
+                            className="text-[15px] [&_pre]:text-[13px]"
                           />
                         )}
                       </div>
@@ -647,7 +647,7 @@ export default function SquadDetailView() {
               >
                 {squad.name} <Chip variant={statusToVariant(overallStatus)}>{overallStatus}</Chip>
               </h1>
-              <div className="flex flex-col flex-wrap items-start gap-2 text-[11px] font-mono">
+              <div className="flex flex-col flex-wrap items-start gap-2 text-[14px] font-mono">
                 <p className="muted">{squad.universe}</p>
                 <p>
                   {squad.repo_url && (
@@ -669,7 +669,7 @@ export default function SquadDetailView() {
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 min-w-0 xl:min-w-[360px]">
               <div className="rounded-2xl border border-white/[0.06] bg-black/10 px-4 py-3">
                 <p
-                  className="text-[11px] font-mono uppercase tracking-wide text-zinc-500"
+                  className="text-[14px] font-mono uppercase tracking-wide text-zinc-500"
                   style={{ color: squad.color || "#66FCF1" }}
                 >
                   Agents
@@ -678,7 +678,7 @@ export default function SquadDetailView() {
               </div>
               <div className="rounded-2xl border border-white/[0.06] bg-black/10 px-4 py-3">
                 <p
-                  className="text-[11px] font-mono uppercase tracking-wide text-zinc-500"
+                  className="text-[14px] font-mono uppercase tracking-wide text-zinc-500"
                   style={{ color: squad.color || "#66FCF1" }}
                 >
                   Instances
@@ -687,7 +687,7 @@ export default function SquadDetailView() {
               </div>
               <div className="rounded-2xl border border-white/[0.06] bg-black/10 px-4 py-3">
                 <p
-                  className="text-[11px] font-mono uppercase tracking-wide text-zinc-500"
+                  className="text-[14px] font-mono uppercase tracking-wide text-zinc-500"
                   style={{ color: squad.color || "#66FCF1" }}
                 >
                   Tasks
@@ -703,7 +703,7 @@ export default function SquadDetailView() {
             <button
               key={tab}
               onClick={() => setActiveTab(tab)}
-              className={`cursor-pointer px-2 pb-2 text-[11px] border-b font-mono uppercase tracking-[0.18em] transition-color ${activeTab !== tab ? "hover:text-zinc-300" : ""}`}
+              className={`cursor-pointer px-2 pb-2 text-[14px] border-b font-mono uppercase tracking-[0.18em] transition-color ${activeTab !== tab ? "hover:text-zinc-300" : ""}`}
               style={{
                 borderColor: activeTab === tab ? squad.color : "transparent",
                 color: activeTab === tab ? squad.color : "var(--base-gray)",
@@ -747,18 +747,18 @@ export default function SquadDetailView() {
                             <div className="flex items-center gap-1 flex-wrap">
                               <h3 className="text-sm truncate">{agent.character_name}</h3>
                             </div>
-                            <p className="text-[9px] font-mono uppercase tracking-[0.18em] text-zinc-500">
+                            <p className="text-[11px] font-mono uppercase tracking-[0.18em] text-zinc-500">
                               {agent.role_title?.trim() || "Agent"}
                             </p>
                           </div>
                         </div>
 
-                        <div className="flex items-center gap-1 text-[10px] font-mono text-zinc-500 flex-shrink-0">
+                        <div className="flex items-center gap-1 text-[13px] font-mono text-zinc-500 flex-shrink-0">
                           <Chip variant={statusToVariant(status)}>{agent.status || "idle"}</Chip>
                         </div>
                       </div>
                       <div className="min-w-0 flex">
-                        <p className="mt-1 text-[11px] text-zinc-400 line-clamp-2">
+                        <p className="mt-1 text-[14px] text-zinc-400 line-clamp-2">
                           {currentTask?.description ?? "No active task assigned."}
                         </p>
                       </div>
@@ -793,7 +793,7 @@ export default function SquadDetailView() {
             {instances.length === 0 ? (
               <div className="glass-card border border-white/[0.07] rounded-2xl p-10 text-center col-span-full">
                 <p className="text-zinc-100 mt-4">No active instances</p>
-                <p className="text-[11px] font-mono text-zinc-500 mt-2">
+                <p className="text-[14px] font-mono text-zinc-500 mt-2">
                   Ask IO to spin up an instance to see it here.
                 </p>
               </div>
@@ -802,7 +802,7 @@ export default function SquadDetailView() {
                 const task = currentTaskByInstance[instance.id];
                 return (
                   <div key={instance.id} className="glass-card border border-white/[0.07] rounded-2xl p-4 space-y-4">
-                    <div className="grid grid-cols-2 gap-3 text-[11px] font-mono">
+                    <div className="grid grid-cols-2 gap-3 text-[14px] font-mono">
                       <div>
                         <p className="text-zinc-500 uppercase tracking-wide">ID</p>
                         <p className="text-zinc-200 mt-1 break-all">{instance.id}</p>
@@ -851,7 +851,7 @@ export default function SquadDetailView() {
             {schedules.length === 0 ? (
               <div className="glass-card border border-white/[0.07] rounded-2xl p-10 text-center col-span-full">
                 <p className="text-zinc-100 mt-4">No schedules configured</p>
-                <p className="text-[11px] font-mono text-zinc-500 mt-2">
+                <p className="text-[14px] font-mono text-zinc-500 mt-2">
                   Scheduled automations for this squad will appear here.
                 </p>
               </div>
@@ -866,20 +866,20 @@ export default function SquadDetailView() {
                       <Chip variant={schedule.enabled ? "success" : "muted"}>
                         {schedule.enabled ? "enabled" : "paused"}
                       </Chip>
-                      <span className="text-[11px] font-mono text-zinc-500">{schedule.cron}</span>
+                      <span className="text-[14px] font-mono text-zinc-500">{schedule.cron}</span>
                     </div>
                     <div>
-                      <p className="text-[11px] font-mono uppercase tracking-wide text-zinc-500">Agenda</p>
+                      <p className="text-[14px] font-mono uppercase tracking-wide text-zinc-500">Agenda</p>
                       <p className="text-zinc-200 mt-1">{schedule.agenda || "No agenda supplied."}</p>
                     </div>
                     <div>
-                      <p className="text-[11px] font-mono uppercase tracking-wide text-zinc-500">Prompt</p>
+                      <p className="text-[14px] font-mono uppercase tracking-wide text-zinc-500">Prompt</p>
                       <p className="text-zinc-400 mt-1 whitespace-pre-wrap">
                         {schedule.prompt || "No prompt configured."}
                       </p>
                     </div>
                   </div>
-                  <div className="flex items-center gap-3 text-[11px] font-mono text-zinc-500">
+                  <div className="flex items-center gap-3 text-[14px] font-mono text-zinc-500">
                     <span>Last run {formatTimestamp(schedule.last_run)}</span>
                     <Toggle checked={Boolean(schedule.enabled)} onChange={() => void toggleSchedule(schedule)} />
                   </div>
@@ -894,7 +894,7 @@ export default function SquadDetailView() {
             {historyItems.length === 0 ? (
               <div className="glass-card border border-white/[0.07] rounded-2xl p-10 text-center col-span-full">
                 <p className="text-zinc-100 mt-4">No objectives yet</p>
-                <p className="text-[11px] font-mono text-zinc-500 mt-2">
+                <p className="text-[14px] font-mono text-zinc-500 mt-2">
                   Delegated work and completed objectives will appear here.
                 </p>
               </div>
@@ -907,14 +907,14 @@ export default function SquadDetailView() {
                 >
                   <div className="flex-shrink-0">{activityStatus(item.status)}</div>
                   <div className="flex-1 min-w-0">
-                    <p className="text-[12px] text-zinc-200 truncate">{item.title}</p>
+                    <p className="text-[15px] text-zinc-200 truncate">{item.title}</p>
                     <div className="flex items-center gap-3 mt-1">
-                      <span className="text-[10px] text-zinc-700 font-mono">{formatTimestamp(item.timestamp)}</span>
-                      <span className="text-[10px] text-zinc-700 font-mono flex items-center gap-1">
+                      <span className="text-[13px] text-zinc-700 font-mono">{formatTimestamp(item.timestamp)}</span>
+                      <span className="text-[13px] text-zinc-700 font-mono flex items-center gap-1">
                         <Clock className="w-2.5 h-2.5" />
                         {item.duration}
                       </span>
-                      <span className="text-[10px] text-zinc-700 font-mono flex items-center gap-1">
+                      <span className="text-[13px] text-zinc-700 font-mono flex items-center gap-1">
                         <Bot className="w-2.5 h-2.5" />
                         {item.agentCount} agent{item.agentCount !== 1 ? "s" : ""}
                       </span>

--- a/web/src/views/SquadsView.tsx
+++ b/web/src/views/SquadsView.tsx
@@ -163,14 +163,14 @@ export default function SquadsView() {
             <h1 className="text-3xl text-zinc-100 leading-none" style={{ fontFamily: "'Bebas Neue', sans-serif" }}>
               Squads
             </h1>
-            <p className="mt-2 text-[11px] font-mono text-zinc-500">
+            <p className="mt-2 text-[14px] font-mono text-zinc-500">
               {data.squads.length} squad{data.squads.length === 1 ? "" : "s"} loaded.
             </p>
           </div>
         </header>
 
         {loading ? (
-          <div className="glass-card border border-white/[0.07] rounded-2xl p-10 text-center text-[11px] font-mono text-zinc-500">
+          <div className="glass-card border border-white/[0.07] rounded-2xl p-10 text-center text-[14px] font-mono text-zinc-500">
             Loading squads…
           </div>
         ) : data.squads.length === 0 ? (
@@ -179,7 +179,7 @@ export default function SquadsView() {
               <IoMark height={28} />
             </div>
             <p className="text-zinc-100 text-lg">No existing squads</p>
-            <p className="text-[11px] font-mono text-zinc-500 mt-2">
+            <p className="text-[14px] font-mono text-zinc-500 mt-2">
               Ask IO to create a squad to see them listed here.
             </p>
           </div>
@@ -222,14 +222,14 @@ export default function SquadsView() {
                       >
                         {squad.name}
                       </h2>
-                      <p className="text-[11px] font-mono uppercase tracking-[0.18em] text-zinc-500">
+                      <p className="text-[14px] font-mono uppercase tracking-[0.18em] text-zinc-500">
                         {squad.universe}
                       </p>
                     </div>
                     <Chip variant={statusToVariant(status)}>{status}</Chip>
                   </div>
 
-                  <div className="mt-1 flex justify-between text-[11px] font-mono text-zinc-400">
+                  <div className="mt-1 flex justify-between text-[14px] font-mono text-zinc-400">
                     <div className="flex items-center gap-2 text-zinc-200">
                       <Users className="h-3.5 w-3.5" style={{ color }} /> {squadAgents.length} agents
                     </div>
@@ -239,7 +239,7 @@ export default function SquadsView() {
                     </div>
                   </div>
 
-                  <div className="text-[11px] font-mono">
+                  <div className="text-[14px] font-mono">
                     {squad.repo_url ? (
                       <a
                         href={squad.repo_url}
@@ -258,7 +258,7 @@ export default function SquadsView() {
                   </div>
 
                   <div className="mt-4 pt-4 border-t border-white/[0.06]">
-                    <p className="text-[11px] font-mono uppercase tracking-[0.18em] text-zinc-500 mb-3">
+                    <p className="text-[14px] font-mono uppercase tracking-[0.18em] text-zinc-500 mb-3">
                       Recent Objectives
                     </p>
                     <div className="space-y-2">
@@ -268,10 +268,10 @@ export default function SquadsView() {
                           return (
                             <div key={task.id} className="flex items-center gap-2.5 text-sm text-zinc-200">
                               <ActivityIcon status={taskStatus} />
-                              <span className="truncate flex-1 text-[11px] font-mono">
+                              <span className="truncate flex-1 text-[14px] font-mono">
                                 {snippetDescription(task.description)}
                               </span>
-                              <span className="inline-flex items-center gap-1 text-[10px] font-mono text-zinc-500 shrink-0">
+                              <span className="inline-flex items-center gap-1 text-[13px] font-mono text-zinc-500 shrink-0">
                                 <StatusDot status={taskStatus} />
                                 {task.status}
                               </span>
@@ -279,7 +279,7 @@ export default function SquadsView() {
                           );
                         })
                       ) : (
-                        <p className="text-[11px] font-mono text-zinc-600">No objectives yet.</p>
+                        <p className="text-[14px] font-mono text-zinc-600">No objectives yet.</p>
                       )}
                     </div>
                   </div>

--- a/web/src/views/UsageView.tsx
+++ b/web/src/views/UsageView.tsx
@@ -118,7 +118,7 @@ const tooltipStyle = {
   border: "1px solid rgba(255,255,255,0.08)",
   color: "rgb(228 228 231)",
   borderRadius: "12px",
-  fontSize: "11px",
+  fontSize: "14px",
 };
 
 export default function UsageView() {
@@ -208,7 +208,7 @@ export default function UsageView() {
   const formatNumber = (value: number) => value.toLocaleString();
 
   if (loading) {
-    return <div className="p-6 text-[11px] font-mono text-zinc-500">Loading usage…</div>;
+    return <div className="p-6 text-[14px] font-mono text-zinc-500">Loading usage…</div>;
   }
 
   return (
@@ -218,7 +218,7 @@ export default function UsageView() {
           <h1 className="text-4xl leading-none text-white" style={{ fontFamily: "'Bebas Neue', sans-serif" }}>
             Usage
           </h1>
-          <p className="mt-2 text-[11px] font-mono text-zinc-600">Track tokens and activity by squad.</p>
+          <p className="mt-2 text-[14px] font-mono text-zinc-600">Track tokens and activity by squad.</p>
         </div>
         <div className="glass-card border border-white/[0.07] rounded-2xl px-4 py-3 flex items-center gap-3">
           <CalendarDays className="h-4 w-4 text-[#66FCF1]" />
@@ -227,32 +227,32 @@ export default function UsageView() {
             value={range.from}
             max={range.to}
             onChange={(event) => setRange((current) => ({ ...current, from: event.target.value }))}
-            className="bg-[#181818] border border-white/[0.06] rounded-xl px-3 py-2 text-[11px] text-zinc-300 font-mono focus:outline-none focus:border-[#66FCF1]/30"
+            className="bg-[#181818] border border-white/[0.06] rounded-xl px-3 py-2 text-[14px] text-zinc-300 font-mono focus:outline-none focus:border-[#66FCF1]/30"
           />
-          <span className="text-[11px] font-mono text-zinc-600">to</span>
+          <span className="text-[14px] font-mono text-zinc-600">to</span>
           <input
             type="date"
             value={range.to}
             min={range.from}
             onChange={(event) => setRange((current) => ({ ...current, to: event.target.value }))}
-            className="bg-[#181818] border border-white/[0.06] rounded-xl px-3 py-2 text-[11px] text-zinc-300 font-mono focus:outline-none focus:border-[#66FCF1]/30"
+            className="bg-[#181818] border border-white/[0.06] rounded-xl px-3 py-2 text-[14px] text-zinc-300 font-mono focus:outline-none focus:border-[#66FCF1]/30"
           />
         </div>
       </div>
 
       <div className="grid gap-4 md:grid-cols-2">
         <div className="glass-card border border-white/[0.07] rounded-2xl p-5">
-          <p className="text-[10px] font-mono uppercase tracking-[0.24em] text-zinc-600">Total tokens</p>
+          <p className="text-[13px] font-mono uppercase tracking-[0.24em] text-zinc-600">Total tokens</p>
           <p className="mt-3 text-3xl text-white">{formatNumber(totals.totalTokens)}</p>
-          <p className="mt-2 text-[11px] font-mono text-zinc-500">
+          <p className="mt-2 text-[14px] font-mono text-zinc-500">
             In {formatNumber(totals.totalInputTokens)} / Out {formatNumber(totals.totalOutputTokens)}
           </p>
         </div>
 
         <div className="glass-card border border-white/[0.07] rounded-2xl p-5">
-          <p className="text-[10px] font-mono uppercase tracking-[0.24em] text-zinc-600">Total calls</p>
+          <p className="text-[13px] font-mono uppercase tracking-[0.24em] text-zinc-600">Total calls</p>
           <p className="mt-3 text-3xl text-white">{formatNumber(totals.totalCalls)}</p>
-          <p className="mt-2 text-[11px] font-mono text-zinc-500">Counted API usage records</p>
+          <p className="mt-2 text-[14px] font-mono text-zinc-500">Counted API usage records</p>
         </div>
       </div>
 
@@ -260,13 +260,13 @@ export default function UsageView() {
         <div className="glass-card border border-white/[0.07] rounded-2xl p-5 h-[320px]">
           <div className="mb-4">
             <h2 className="text-sm text-white">Daily usage</h2>
-            <p className="text-[11px] font-mono text-zinc-600">Input vs output tokens</p>
+            <p className="text-[14px] font-mono text-zinc-600">Input vs output tokens</p>
           </div>
           <ResponsiveContainer width="100%" height="82%">
             <BarChart data={daily}>
               <CartesianGrid stroke="rgba(255,255,255,0.05)" vertical={false} />
-              <XAxis dataKey="date" stroke="#71717a" fontSize={10} tickLine={false} axisLine={false} />
-              <YAxis stroke="#71717a" fontSize={10} tickLine={false} axisLine={false} tickFormatter={formatNumber} />
+              <XAxis dataKey="date" stroke="#71717a" fontSize={13} tickLine={false} axisLine={false} />
+              <YAxis stroke="#71717a" fontSize={13} tickLine={false} axisLine={false} tickFormatter={formatNumber} />
               <Tooltip
                 contentStyle={tooltipStyle}
                 labelStyle={{ color: "#e4e4e7" }}
@@ -282,11 +282,11 @@ export default function UsageView() {
       <div className="glass-card border border-white/[0.07] rounded-2xl overflow-hidden">
         <div className="border-b border-white/[0.06] px-5 py-4">
           <h2 className="text-sm text-white">Squad breakdown</h2>
-          <p className="mt-1 text-[11px] font-mono text-zinc-600">Expand a squad to inspect individual agents.</p>
+          <p className="mt-1 text-[14px] font-mono text-zinc-600">Expand a squad to inspect individual agents.</p>
         </div>
 
         <div className="overflow-x-auto">
-          <table className="w-full text-[11px] font-mono">
+          <table className="w-full text-[14px] font-mono">
             <thead className="bg-white/[0.02] text-zinc-500">
               <tr>
                 <th className="px-5 py-3 text-left font-medium">Name</th>

--- a/web/src/views/WikiView.tsx
+++ b/web/src/views/WikiView.tsx
@@ -20,7 +20,7 @@ interface TreeNode {
   children?: TreeNode[];
 }
 
-const treeItemClass = "px-3 py-1.5 text-[11px] font-mono hover:bg-white/[0.04] rounded-lg cursor-pointer";
+const treeItemClass = "px-3 py-1.5 text-[14px] font-mono hover:bg-white/[0.04] rounded-lg cursor-pointer";
 
 function encodePath(path: string) {
   return path
@@ -131,7 +131,7 @@ function Breadcrumbs({ path }: { path: string }) {
   const parts = path.split("/").filter(Boolean);
 
   return (
-    <div className="flex items-center gap-1.5 overflow-x-auto whitespace-nowrap text-[11px] font-mono text-zinc-500">
+    <div className="flex items-center gap-1.5 overflow-x-auto whitespace-nowrap text-[14px] font-mono text-zinc-500">
       {parts.map((part, index) => (
         <div key={parts.slice(0, index + 1).join("/")} className="flex items-center gap-1.5">
           {index > 0 && <span className="text-zinc-700">/</span>}
@@ -419,7 +419,7 @@ export default function WikiView() {
   };
 
   if (loading) {
-    return <div className="p-6 text-[11px] font-mono text-zinc-500">Loading wiki…</div>;
+    return <div className="p-6 text-[14px] font-mono text-zinc-500">Loading wiki…</div>;
   }
 
   return (
@@ -431,7 +431,7 @@ export default function WikiView() {
             value={search}
             onChange={(event) => setSearch(event.target.value)}
             placeholder="Search wiki"
-            className={`bg-[#181818] border border-white/[0.06] rounded-xl px-3 py-2 text-[11px] text-zinc-300 font-mono placeholder:text-zinc-700 focus:outline-none focus:border-[#66FCF1]/30 w-full pl-9`}
+            className={`bg-[#181818] border border-white/[0.06] rounded-xl px-3 py-2 text-[14px] text-zinc-300 font-mono placeholder:text-zinc-700 focus:outline-none focus:border-[#66FCF1]/30 w-full pl-9`}
           />
         </div>
 
@@ -453,7 +453,7 @@ export default function WikiView() {
                 value={newPagePath}
                 onChange={(event) => setNewPagePath(event.target.value)}
                 placeholder="notes/roadmap.md"
-                className={`bg-[#181818] border border-white/[0.06] rounded-xl px-3 py-2 text-[11px] text-zinc-300 font-mono placeholder:text-zinc-700 focus:outline-none focus:border-[#66FCF1]/30 w-full pl-9 w-full`}
+                className={`bg-[#181818] border border-white/[0.06] rounded-xl px-3 py-2 text-[14px] text-zinc-300 font-mono placeholder:text-zinc-700 focus:outline-none focus:border-[#66FCF1]/30 w-full pl-9 w-full`}
               />
               <div className="flex items-center gap-2">
                 <PrimaryBtn
@@ -483,7 +483,7 @@ export default function WikiView() {
                 onDeleteFolder={(path) => void deleteFolder(path)}
               />
             ) : (
-              <div className="px-3 py-6 text-center text-[11px] font-mono text-zinc-600">No pages found</div>
+              <div className="px-3 py-6 text-center text-[14px] font-mono text-zinc-600">No pages found</div>
             )}
           </div>
         </div>
@@ -495,7 +495,7 @@ export default function WikiView() {
             {selectedPath ? (
               <Breadcrumbs path={selectedPath} />
             ) : (
-              <p className="text-[11px] font-mono uppercase tracking-[0.24em] text-zinc-600">Wiki</p>
+              <p className="text-[14px] font-mono uppercase tracking-[0.24em] text-zinc-600">Wiki</p>
             )}
           </div>
           <div className="flex items-center gap-2">
@@ -554,14 +554,14 @@ export default function WikiView() {
                 <textarea
                   value={draft}
                   onChange={(event) => setDraft(event.target.value)}
-                  className="h-full w-full resize-none rounded-2xl border border-white/[0.06] bg-[#121212] px-4 py-3 text-[12px] leading-6 text-zinc-300 font-mono focus:outline-none focus:border-[#66FCF1]/30"
+                  className="h-full w-full resize-none rounded-2xl border border-white/[0.06] bg-[#121212] px-4 py-3 text-[15px] leading-6 text-zinc-300 font-mono focus:outline-none focus:border-[#66FCF1]/30"
                   spellCheck={false}
                 />
               </div>
             ) : (
               <div className="h-full overflow-y-auto px-6 py-5">
                 {busy ? (
-                  <div className="text-[11px] font-mono text-zinc-500">Loading page…</div>
+                  <div className="text-[14px] font-mono text-zinc-500">Loading page…</div>
                 ) : (
                   <MarkdownRenderer content={content} />
                 )}
@@ -575,7 +575,7 @@ export default function WikiView() {
               <h2 className="text-lg text-white" style={{ fontFamily: "'Bebas Neue', sans-serif" }}>
                 Select a page
               </h2>
-              <p className="mt-2 max-w-md text-[11px] font-mono text-zinc-600">
+              <p className="mt-2 max-w-md text-[14px] font-mono text-zinc-600">
                 Browse the file tree on the left, search for a page, or create a new markdown document.
               </p>
             </div>


### PR DESCRIPTION
Summary:\n- Updated global root font-size (web/src/style.css: --font-size 16px → 20px) to scale rem-based text (Tailwind classes).\n- Ran a codemod to update explicit font-size occurrences under web/src (text-[Npx], inline fontSize props, numeric fontSize values).\n\nInvestigation report:\n- Found global root size at web/src/style.css: --font-size: 16px (used by html { font-size: var(--font-size) }).\n- Tailwind config not present in repo; Tailwind utilities rely on rems.\n- Many components use Tailwind arbitrary pixel classes (e.g., text-[11px]) and inline fontSize props which do not scale with root font size.\n- Files touched: web/src/style.css and multiple components under web/src (see commits).\n\nRounding rules applied:\n- px values: multiplied by 1.25 and rounded (Math.round).\n- rem/em: multiplied by 1.25 and preserved up to 3 decimals.\n\nHow to verify locally:\n1. npm ci --prefix web --include=dev\n2. npm run test --prefix web\n3. npm run build --prefix web\n4. Start the app and visually inspect main pages (Chat, Usage, Wiki, Skills, Settings) for layout regressions.\n\nDecision inbox note: decisions/inbox/increase-font-sizes.md