### PR TITLE
Fix: Usage view vertical scrolling (v2)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,12 +29,13 @@ export function App() {
       {showChrome && <AppSidebar />}
       <div className="flex-1 flex flex-col overflow-hidden min-w-0">
         {showChrome && <AppHeader />}
-        <main className="flex-1 overflow-hidden flex flex-col min-h-0 ] relative bg-[var(--base-darker-gray)]">
+        <main className="flex-1 overflow-hidden flex flex-col min-h-0 relative bg-[var(--base-darker-gray)]">
           <div className="absolute inset-0 overflow-hidden pointer-events-none" style={{ zIndex: 0 }}>
             <div className="orb orb-pink" />
             <div className="orb orb-gray" />
           </div>
-          <div className="relative flex-1 overflow-hidden flex flex-col min-h-0" style={{ zIndex: 1 }}>
+          {/* Allow inner route content to scroll vertically when content exceeds the viewport. */}
+          <div className="relative flex-1 overflow-auto flex flex-col min-h-0" style={{ zIndex: 1 }}>
             <AppRoutes />
           </div>
         </main>


### PR DESCRIPTION
Root cause: The inner app container had overflow:hidden which prevented route content from scrolling. The Usage view uses an overflow-y-auto container; because ancestors were set to overflow:hidden the bottom of the squad breakdown table could not be reached.\n\nWhat I changed: Updated web/src/App.tsx to set the inner route container to 'overflow-auto' (was 'overflow-hidden') and removed a stray bracket in the main className. Added an inline comment explaining the change. This is a minimal, local fix that allows the Usage view to scroll without altering the sidebar/header chrome behavior.\n\nTesting performed:\n- Pulled latest main and created branch dev/mjolley/squad/fix-usage-scroll-v2\n- Modified web/src/App.tsx to allow vertical scrolling of route content\n- Smoke-tested the Usage view and verified the squad breakdown table bottom is reachable when content exceeds viewport height (manual visual verification).\n- Spot-checked Home and Team views to ensure scrolling unchanged.\n- Attempted to run web build/typecheck; the repo's web TypeScript checks surfaced unrelated existing test/type errors in the local environment. These are pre-existing and outside the scope of this minimal layout fix.\n\nNotes: If reviewers prefer an alternate approach (e.g., removing overflow-hidden from a different parent), I can update the PR accordingly.,cwd:}]