### PR TITLE
fix: standardize view scrolling so all pages scroll independently

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -35,7 +35,7 @@ export function App() {
             <div className="orb orb-gray" />
           </div>
           {/* Allow inner route content to scroll vertically when content exceeds the viewport. */}
-          <div className="relative flex-1 overflow-auto flex flex-col min-h-0" style={{ zIndex: 1 }}>
+          <div className="relative flex-1 overflow-hidden flex flex-col min-h-0" style={{ zIndex: 1 }}>
             <AppRoutes />
           </div>
         </main>

--- a/web/src/views/McpView.tsx
+++ b/web/src/views/McpView.tsx
@@ -295,7 +295,7 @@ export default function McpView() {
   };
 
   return (
-    <div className="p-6 max-w-5xl mx-auto space-y-4">
+    <div className="flex-1 min-h-0 overflow-y-auto p-6 max-w-5xl mx-auto space-y-4">
       <div className="flex flex-wrap items-end justify-between gap-4">
         <div>
           <h1 className="text-4xl leading-none text-white" style={{ fontFamily: "'Bebas Neue', sans-serif" }}>

--- a/web/src/views/SchedulesView.tsx
+++ b/web/src/views/SchedulesView.tsx
@@ -395,7 +395,7 @@ export default function SchedulesView() {
   };
 
   return (
-    <div className="p-6 w-full space-y-4">
+    <div className="flex-1 min-h-0 overflow-y-auto p-6 w-full space-y-4">
       <div className="flex flex-wrap items-end justify-between gap-4">
         <div>
           <h1 className="text-3xl leading-none text-zinc-100" style={{ fontFamily: "'Bebas Neue', sans-serif" }}>

--- a/web/src/views/SettingsView.tsx
+++ b/web/src/views/SettingsView.tsx
@@ -280,7 +280,7 @@ export default function SettingsView() {
   }
 
   return (
-    <div className="mx-auto flex h-full w-full max-w-5xl flex-col gap-6 p-6 text-zinc-200">
+    <div className="mx-auto flex flex-1 min-h-0 overflow-y-auto w-full max-w-5xl flex-col gap-6 p-6 text-zinc-200">
       <div className="flex items-end justify-between gap-4">
         <div>
           <h1 className="text-3xl leading-none text-zinc-100" style={{ fontFamily: "'Bebas Neue', sans-serif" }}>

--- a/web/src/views/SkillsView.tsx
+++ b/web/src/views/SkillsView.tsx
@@ -337,7 +337,7 @@ export default function SkillsView() {
   };
 
   return (
-    <div className="h-full">
+    <div className="flex-1 min-h-0">
       <div className="grid h-full min-h-0 grid-cols-[16rem_minmax(0,1fr)]">
         <aside className={`min-h-0 overflow-hidden flex flex-col border-r border-white/[0.06]`}>
           <div className="border-b border-white/[0.06] p-3">

--- a/web/src/views/UsageView.tsx
+++ b/web/src/views/UsageView.tsx
@@ -211,7 +211,7 @@ export default function UsageView() {
   }
 
   return (
-    <div className="mx-auto flex h-full w-full max-w-6xl flex-col gap-6 overflow-y-auto p-6 text-zinc-200 min-h-0">
+    <div className="mx-auto flex flex-1 w-full max-w-6xl flex-col gap-6 overflow-y-auto p-6 text-zinc-200 min-h-0">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <div>
           <h1 className="text-4xl leading-none text-white" style={{ fontFamily: "'Bebas Neue', sans-serif" }}>

--- a/web/src/views/WikiView.tsx
+++ b/web/src/views/WikiView.tsx
@@ -423,7 +423,7 @@ export default function WikiView() {
   }
 
   return (
-    <div className="flex h-full min-h-0  text-zinc-200">
+    <div className="flex flex-1 min-h-0  text-zinc-200">
       <aside className="w-64 border-r border-white/[0.06]  p-3 flex flex-col gap-3">
         <div className="relative">
           <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-zinc-700" />


### PR DESCRIPTION
Each view now owns its own scroll instead of relying on the App.tsx wrapper. Changed wrapper from overflow-auto to overflow-hidden and ensured every view (except ChatView with its pinned input) uses flex-1 min-h-0 overflow-y-auto or internal panel-level scrolling.