### PR TITLE
fix: standardize view scrolling so all pages scroll independently

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -35,7 +35,7 @@ export function App() {
             <div className="orb orb-gray" />
           </div>
           {/* Allow inner route content to scroll vertically when content exceeds the viewport. */}
-          <div className="relative flex-1 overflow-hidden flex flex-col min-h-0" style={{ zIndex: 1 }}>
+          <div className="relative flex-1 overflow-y-auto min-h-0" style={{ zIndex: 1 }}>
             <AppRoutes />
           </div>
         </main>

--- a/web/src/views/ChatView.tsx
+++ b/web/src/views/ChatView.tsx
@@ -73,7 +73,7 @@ export default function ChatView() {
   return (
     <div
       ref={viewRef}
-      className="flex flex-col flex-1 min-h-0"
+      className="flex flex-col h-full min-h-0"
       onDragOver={(e) => {
         e.preventDefault();
         setIsDragging(true);

--- a/web/src/views/FeedView.tsx
+++ b/web/src/views/FeedView.tsx
@@ -161,7 +161,7 @@ export default function FeedView() {
   };
 
   return (
-    <div className="flex flex-1 min-h-0 p-5">
+    <div className="flex h-full min-h-0 p-5">
       <div className="flex flex-1 min-h-0 gap-5">
         <aside className="glass-card border border-white/[0.07] rounded-2xl w-72 min-h-0 flex flex-col overflow-hidden">
           <div className="px-5 pt-5 pb-4 border-b border-white/[0.06] space-y-4">

--- a/web/src/views/SettingsView.tsx
+++ b/web/src/views/SettingsView.tsx
@@ -280,7 +280,7 @@ export default function SettingsView() {
   }
 
   return (
-    <div className="mx-auto flex flex-1 min-h-0 overflow-y-auto w-full max-w-5xl flex-col gap-6 p-6 text-zinc-200">
+    <div className="mx-auto w-full max-w-5xl flex flex-col gap-6 p-6 text-zinc-200">
       <div className="flex items-end justify-between gap-4">
         <div>
           <h1 className="text-3xl leading-none text-zinc-100" style={{ fontFamily: "'Bebas Neue', sans-serif" }}>
@@ -292,7 +292,7 @@ export default function SettingsView() {
         </div>
       </div>
 
-      <div className="glass-card border border-white/[0.07] rounded-2xl overflow-hidden flex-1 min-h-0 flex flex-col w-full lg:w-1/2">
+      <div className="glass-card border border-white/[0.07] rounded-2xl overflow-hidden w-full lg:w-1/2">
         <div className="px-5 pt-4">
           <div className="flex flex-wrap gap-4 border-b border-white/[0.06]">
             {tabs.map((tab) => (
@@ -312,7 +312,7 @@ export default function SettingsView() {
           </div>
         </div>
 
-        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5">
+        <div className="px-5 py-5">
           {activeTab === "General" ? (
             <div className="space-y-1">
               <FormRow label="Default model">

--- a/web/src/views/SkillsView.tsx
+++ b/web/src/views/SkillsView.tsx
@@ -337,7 +337,7 @@ export default function SkillsView() {
   };
 
   return (
-    <div className="flex-1 min-h-0">
+    <div className="h-full min-h-0">
       <div className="grid h-full min-h-0 grid-cols-[16rem_minmax(0,1fr)]">
         <aside className={`min-h-0 overflow-hidden flex flex-col border-r border-white/[0.06]`}>
           <div className="border-b border-white/[0.06] p-3">

--- a/web/src/views/SquadDetailView.tsx
+++ b/web/src/views/SquadDetailView.tsx
@@ -452,7 +452,7 @@ export default function SquadDetailView() {
     };
 
     return (
-      <div className="flex-1 min-h-0 overflow-y-auto p-5">
+      <div className="p-5">
         <div className="max-w-5xl mx-auto space-y-5">
           <button
             onClick={() => {
@@ -631,7 +631,7 @@ export default function SquadDetailView() {
   }
 
   return (
-    <div className="flex-1 min-h-0 overflow-y-auto p-5">
+    <div className="p-5">
       <div className="max-w-7xl mx-auto space-y-5">
         <SecondaryBtn onClick={() => navigate("/squads")} className="px-3 py-2">
           <ArrowLeft className="h-3.5 w-3.5" />

--- a/web/src/views/SquadsView.tsx
+++ b/web/src/views/SquadsView.tsx
@@ -156,7 +156,7 @@ export default function SquadsView() {
   }, [data.agents]);
 
   return (
-    <div className="flex-1 min-h-0 overflow-y-auto p-5">
+    <div className="p-5">
       <div className="max-w-7xl mx-auto space-y-5">
         <header className="p-5 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
           <div>

--- a/web/src/views/UsageView.tsx
+++ b/web/src/views/UsageView.tsx
@@ -211,7 +211,7 @@ export default function UsageView() {
   }
 
   return (
-    <div className="mx-auto flex flex-1 w-full max-w-6xl flex-col gap-6 overflow-y-auto p-6 text-zinc-200 min-h-0">
+    <div className="mx-auto w-full max-w-6xl flex flex-col gap-6 p-6 text-zinc-200">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <div>
           <h1 className="text-4xl leading-none text-white" style={{ fontFamily: "'Bebas Neue', sans-serif" }}>


### PR DESCRIPTION
Make the App.tsx content wrapper a simple scroll container (overflow-y-auto) instead of a flex column with overflow-hidden. Content-sized views (Usage, Schedules, MCP, Settings, Squads, SquadDetail) flow naturally and the wrapper scrolls for them. Panel-layout views (Chat, Skills, Wiki, Feed) use h-full to fill the viewport and handle internal scrolling.