### PR TITLE
fix(usage): add from/to date range support and fix squad filtering

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -648,23 +648,31 @@ export async function startApiServer(config: Config): Promise<void> {
   // --- Token Usage ---
   app.get("/api/token-usage/summary", (req, res) => {
     const since = req.query.since as string | undefined;
-    res.json(getTokenUsageSummary({ since }));
+    const from = req.query.from as string | undefined;
+    const to = req.query.to as string | undefined;
+    res.json(getTokenUsageSummary({ since, from, to }));
   });
 
   app.get("/api/token-usage/by-squad", (req, res) => {
     const since = req.query.since as string | undefined;
-    res.json(getTokenUsageBySquad({ since }));
+    const from = req.query.from as string | undefined;
+    const to = req.query.to as string | undefined;
+    res.json(getTokenUsageBySquad({ since, from, to }));
   });
 
   app.get("/api/token-usage/by-agent", (req, res) => {
     const since = req.query.since as string | undefined;
-    const squadId = req.query.squad_id as string | undefined;
-    res.json(getTokenUsageByAgent({ since, squadId }));
+    const from = req.query.from as string | undefined;
+    const to = req.query.to as string | undefined;
+    const squadId = (req.query.squad_id ?? req.query.squad) as string | undefined;
+    res.json(getTokenUsageByAgent({ since, from, to, squadId }));
   });
 
   app.get("/api/token-usage/daily", (req, res) => {
-    const days = parseInt(req.query.days as string) || 30;
-    res.json(getDailyTokenUsage(days));
+    const days = parseInt(req.query.days as string) || undefined;
+    const from = req.query.from as string | undefined;
+    const to = req.query.to as string | undefined;
+    res.json(getDailyTokenUsage({ days, from, to }));
   });
 
   // --- Health (unauthenticated) ---

--- a/src/store/token-usage.ts
+++ b/src/store/token-usage.ts
@@ -35,6 +35,30 @@ export interface DailyTokenUsage {
   total_tokens: number;
 }
 
+interface DateRangeOpts {
+  since?: string;
+  from?: string;
+  to?: string;
+}
+
+function buildDateFilter(opts: DateRangeOpts | undefined, alias: string): { clause: string; params: string[] } {
+  if (!opts) return { clause: "", params: [] };
+  const conditions: string[] = [];
+  const params: string[] = [];
+  if (opts.from) {
+    conditions.push(`${alias}.created_at >= ?`);
+    params.push(`${opts.from}T00:00:00`);
+  } else if (opts.since) {
+    conditions.push(`${alias}.created_at >= ?`);
+    params.push(opts.since);
+  }
+  if (opts.to) {
+    conditions.push(`${alias}.created_at < date(?, '+1 day')`);
+    params.push(opts.to);
+  }
+  return { clause: conditions.length ? " AND " + conditions.join(" AND ") : "", params };
+}
+
 export function recordTokenUsage(params: {
   squadId?: string;
   agentId?: string;
@@ -60,25 +84,22 @@ export function recordTokenUsage(params: {
   return db.prepare("SELECT * FROM token_usage WHERE id = ?").get(id) as TokenUsageRecord;
 }
 
-export function getTokenUsageSummary(opts?: { since?: string }): TokenUsageSummary {
+export function getTokenUsageSummary(opts?: DateRangeOpts): TokenUsageSummary {
   const db = getDb();
-  let sql = `SELECT
+  const { clause, params } = buildDateFilter(opts, "token_usage");
+  const sql = `SELECT
     COUNT(*) as total_records,
     COALESCE(SUM(input_tokens), 0) as total_input_tokens,
     COALESCE(SUM(output_tokens), 0) as total_output_tokens,
     COALESCE(SUM(input_tokens + output_tokens), 0) as total_tokens
-  FROM token_usage WHERE 1=1`;
-  const params: string[] = [];
-  if (opts?.since) {
-    sql += " AND created_at >= ?";
-    params.push(opts.since);
-  }
+  FROM token_usage WHERE 1=1${clause}`;
   return db.prepare(sql).get(...params) as TokenUsageSummary;
 }
 
-export function getTokenUsageBySquad(opts?: { since?: string }): TokenUsageByGroup[] {
+export function getTokenUsageBySquad(opts?: DateRangeOpts): TokenUsageByGroup[] {
   const db = getDb();
-  let sql = `SELECT
+  const { clause, params } = buildDateFilter(opts, "t");
+  const sql = `SELECT
     s.id,
     s.name,
     COALESCE(SUM(t.input_tokens), 0) as total_input_tokens,
@@ -86,18 +107,14 @@ export function getTokenUsageBySquad(opts?: { since?: string }): TokenUsageByGro
     COALESCE(SUM(t.input_tokens + t.output_tokens), 0) as total_tokens,
     COUNT(t.id) as record_count
   FROM squads s
-  LEFT JOIN token_usage t ON t.squad_id = s.id`;
-  const params: string[] = [];
-  if (opts?.since) {
-    sql += " AND t.created_at >= ?";
-    params.push(opts.since);
-  }
-  sql += " GROUP BY s.id ORDER BY total_tokens DESC";
+  LEFT JOIN token_usage t ON t.squad_id = s.id${clause}
+  GROUP BY s.id ORDER BY total_tokens DESC`;
   return db.prepare(sql).all(...params) as TokenUsageByGroup[];
 }
 
-export function getTokenUsageByAgent(opts?: { squadId?: string; since?: string }): TokenUsageByGroup[] {
+export function getTokenUsageByAgent(opts?: { squadId?: string } & DateRangeOpts): TokenUsageByGroup[] {
   const db = getDb();
+  const { clause: dateClause, params: dateParams } = buildDateFilter(opts, "t");
   let sql = `SELECT
     a.id,
     a.character_name as name,
@@ -106,36 +123,46 @@ export function getTokenUsageByAgent(opts?: { squadId?: string; since?: string }
     COALESCE(SUM(t.input_tokens + t.output_tokens), 0) as total_tokens,
     COUNT(t.id) as record_count
   FROM agents a
-  LEFT JOIN token_usage t ON t.agent_id = a.id`;
-  const params: string[] = [];
-  const conditions: string[] = [];
+  LEFT JOIN token_usage t ON t.agent_id = a.id${dateClause}`;
+  const params: string[] = [...dateParams];
   if (opts?.squadId) {
-    conditions.push("a.squad_id = ?");
+    sql += " WHERE a.squad_id = ?";
     params.push(opts.squadId);
-  }
-  if (opts?.since) {
-    conditions.push("(t.created_at >= ? OR t.created_at IS NULL)");
-    params.push(opts.since);
-  }
-  if (conditions.length > 0) {
-    sql += " WHERE " + conditions.join(" AND ");
   }
   sql += " GROUP BY a.id ORDER BY total_tokens DESC";
   return db.prepare(sql).all(...params) as TokenUsageByGroup[];
 }
 
-export function getDailyTokenUsage(days = 30): DailyTokenUsage[] {
+export function getDailyTokenUsage(opts?: { days?: number } & DateRangeOpts): DailyTokenUsage[] {
   const db = getDb();
+  const params: (string | number)[] = [];
+  let whereClause: string;
+  if (opts?.from || opts?.to) {
+    const conditions: string[] = [];
+    if (opts.from) {
+      conditions.push("created_at >= ?");
+      params.push(`${opts.from}T00:00:00`);
+    }
+    if (opts.to) {
+      conditions.push("created_at < date(?, '+1 day')");
+      params.push(opts.to);
+    }
+    whereClause = "WHERE " + conditions.join(" AND ");
+  } else {
+    const days = opts?.days ?? 30;
+    whereClause = "WHERE created_at >= date('now', '-' || ? || ' days')";
+    params.push(days);
+  }
   const sql = `SELECT
     date(created_at) as date,
     COALESCE(SUM(input_tokens), 0) as total_input_tokens,
     COALESCE(SUM(output_tokens), 0) as total_output_tokens,
     COALESCE(SUM(input_tokens + output_tokens), 0) as total_tokens
   FROM token_usage
-  WHERE created_at >= date('now', '-' || ? || ' days')
+  ${whereClause}
   GROUP BY date(created_at)
   ORDER BY date ASC`;
-  return db.prepare(sql).all(days) as DailyTokenUsage[];
+  return db.prepare(sql).all(...params) as DailyTokenUsage[];
 }
 
 export function getTokenUsageForTask(taskId: string): TokenUsageRecord[] {

--- a/web/src/views/UsageView.tsx
+++ b/web/src/views/UsageView.tsx
@@ -44,37 +44,19 @@ function getDefaultRange() {
   return { from: formatDateInput(from), to: formatDateInput(to) };
 }
 
-function daysBetween(from: string, to: string) {
-  const start = new Date(`${from}T00:00:00`);
-  const end = new Date(`${to}T00:00:00`);
-  const diff = Math.round((end.getTime() - start.getTime()) / 86400000);
-  return Math.max(diff + 1, 1);
-}
-
-async function authJson<T>(paths: string[]): Promise<T> {
+async function authJson<T>(path: string): Promise<T> {
   const token = useAuthStore.getState().token;
-
-  for (let index = 0; index < paths.length; index += 1) {
-    const res = await fetch(paths[index], {
-      headers: {
-        "Content-Type": "application/json",
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-    });
-
-    if (res.ok) {
-      return (await res.json()) as T;
-    }
-
-    if (res.status === 404 && index < paths.length - 1) {
-      continue;
-    }
-
+  const res = await fetch(path, {
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+  if (!res.ok) {
     const message = await res.text();
     throw new Error(message || `Request failed: ${res.status}`);
   }
-
-  throw new Error("Request failed");
+  return (await res.json()) as T;
 }
 
 function toNumber(value: unknown) {
@@ -134,21 +116,12 @@ export default function UsageView() {
   const queryParts = useMemo(() => {
     const from = range.from;
     const to = range.to;
-    const days = daysBetween(from, to);
     return {
-      summary: [
-        `/api/token-usage/summary?from=${from}&to=${to}`,
-        `/api/token-usage/summary?since=${from}T00:00:00.000Z`,
-      ],
-      squads: [
-        `/api/token-usage/by-squad?from=${from}&to=${to}`,
-        `/api/token-usage/by-squad?since=${from}T00:00:00.000Z`,
-      ],
-      daily: [`/api/token-usage/daily?from=${from}&to=${to}`, `/api/token-usage/daily?days=${days}`],
-      agentPaths: (squadId: string) => [
-        `/api/token-usage/by-agent?squad=${encodeURIComponent(squadId)}&from=${from}&to=${to}`,
-        `/api/token-usage/by-agent?squad_id=${encodeURIComponent(squadId)}&since=${from}T00:00:00.000Z`,
-      ],
+      summary: `/api/token-usage/summary?from=${from}&to=${to}`,
+      squads: `/api/token-usage/by-squad?from=${from}&to=${to}`,
+      daily: `/api/token-usage/daily?from=${from}&to=${to}`,
+      agentPath: (squadId: string) =>
+        `/api/token-usage/by-agent?squad_id=${encodeURIComponent(squadId)}&from=${from}&to=${to}`,
     };
   }, [range.from, range.to]);
 
@@ -182,7 +155,7 @@ export default function UsageView() {
     if (isOpen || agentsBySquad[squad.id]) return;
 
     try {
-      const response = await authJson<Record<string, unknown>[]>(queryParts.agentPaths(squad.id));
+      const response = await authJson<Record<string, unknown>[]>(queryParts.agentPath(squad.id));
       setAgentsBySquad((current) => ({
         ...current,
         [squad.id]: Array.isArray(response) ? response.map(normalizeGroup) : [],


### PR DESCRIPTION
The usage view was showing inaccurate data due to two backend bugs:

1. Backend ignored from/to query params - only supported 'since'. The frontend sent ?from=X&to=Y which returned 200 with all-time unfiltered data (unknown params silently ignored).

2. Agent endpoint only read 'squad_id' but frontend sent 'squad' param. Returned all agents across all squads, causing duplication in the squad breakdown table.

Fix:
- Add from/to date range support to all token-usage store functions
- API endpoints now read from, to, since, and squad/squad_id
- Frontend simplified to use single URL per endpoint (no fallback array)
- Removed unused daysBetween utility